### PR TITLE
Update Flake for New Libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,14 +41,22 @@ find_package(CGAL          REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(VTK           REQUIRED)
 find_package(TBB           REQUIRED)
-find_package(OpenMP        REQUIRED)
+
+find_package(OpenMP)
+
+if(OpenMP_CXX_FOUND)
+    message(STATUS "OpenMP Found")
+    list(APPEND optional_libs OpenMP::OpenMP_CXX)
+else()
+    message(WARNING "OpenMP NOT Found")
+endif()
 
 # Find Eigen
 add_definitions(-DEIGEN_NO_CUDA=1) # Eigen does not have CUDA support for MSVC yet
 find_package(Eigen3 3.3.0 REQUIRED NO_MODULE)
 include(CGAL_Eigen3_support)
 
-list(APPEND libs assimp::assimp Boost::system CGAL::CGAL Eigen3::Eigen nlohmann_json ${VTK_LIBRARIES} OpenMP::OpenMP_CXX)
+list(APPEND libs assimp::assimp Boost::system CGAL::CGAL Eigen3::Eigen nlohmann_json ${VTK_LIBRARIES} ${optional_libs})
 
 # Check if CGAL was configured with Eigen
 if(TARGET CGAL::Eigen3_support)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 include(contrib/vcpkg.cmake)
 
 # Define project name and base it on C++
-project(ornl_slicer_2 CXX)
+project(ornl_slicer_2 CXX C)
 
 option(CMAKE_VERBOSE_MAKEFILE "Verbose MAKE Files" ON)
 
@@ -41,7 +41,7 @@ find_package(CGAL          REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(VTK           REQUIRED)
 find_package(TBB           REQUIRED)
-find_package(OPENMP        REQUIRED)
+find_package(OpenMP        REQUIRED)
 
 # Find Eigen
 add_definitions(-DEIGEN_NO_CUDA=1) # Eigen does not have CUDA support for MSVC yet

--- a/contrib/qtxlsxwriter/CMakeLists.txt
+++ b/contrib/qtxlsxwriter/CMakeLists.txt
@@ -23,7 +23,11 @@ include_directories(
 	${Qt5Gui_INCLUDE_DIRS}
 	${Qt5Gui_PRIVATE_INCLUDE_DIRS} )
 
-add_library(QtXlsxWriter STATIC "${QtXlsxWriter_SOURCE_FILES}")
+if(WIN32)
+    add_library(QtXlsxWriter SHARED "${QtXlsxWriter_SOURCE_FILES}")
+else()
+    add_library(QtXlsxWriter STATIC "${QtXlsxWriter_SOURCE_FILES}")
+endif()
 
 # automatically add C++11 support with GCC
 if(NOT MSVC)

--- a/contrib/qtxlsxwriter/CMakeLists.txt
+++ b/contrib/qtxlsxwriter/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 file(
 	GLOB
-	QtXlsxWriter_SOURCE_FILES 
+	QtXlsxWriter_SOURCE_FILES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/xlsx/*.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/QtXlsxWriterTest_automoc.cpp
 )
@@ -19,11 +19,11 @@ file(
 find_package(Qt5 5.5 REQUIRED Core Gui Test)
 include_directories(
 	${CMAKE_CURRENT_SOURCE_DIR}/src/xlsx/
-	${Qt5Core_INCLUDE_DIRS} 
+	${Qt5Core_INCLUDE_DIRS}
 	${Qt5Gui_INCLUDE_DIRS}
 	${Qt5Gui_PRIVATE_INCLUDE_DIRS} )
 
-add_library(QtXlsxWriter SHARED "${QtXlsxWriter_SOURCE_FILES}")
+add_library(QtXlsxWriter STATIC "${QtXlsxWriter_SOURCE_FILES}")
 
 # automatically add C++11 support with GCC
 if(NOT MSVC)
@@ -70,7 +70,7 @@ INSTALL(TARGETS QtXlsxWriter
 
 INSTALL(FILES  ${CMAKE_CURRENT_BINARY_DIR}/QtXlsxWriterConfig.cmake DESTINATION lib/cmake/${PROJECT_NAME})
 
-SET(INCLUDE_FILES 
+SET(INCLUDE_FILES
   src/xlsx/xlsxabstractooxmlfile.h
   src/xlsx/xlsxabstractsheet.h
   src/xlsx/xlsxcell.h

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720028023,
-        "narHash": "sha256-xHhc9VmLrElpCxchkMB3cVz2BwXYvv73tk22g+e3clQ=",
+        "lastModified": 1723474834,
+        "narHash": "sha256-5c/e7l3fDwdWbQzadnIn2zY8L1V0dCFN2i5JDViyEuw=",
         "owner": "mdfbaam",
         "repo": "nixpkgs",
-        "rev": "9c8bbb60c1be295619daa1b9b97497bb3c61020e",
+        "rev": "c3da6d68fe68ed3146c067e7e6b807b236133e87",
         "type": "github"
       },
       "original": {
         "owner": "mdfbaam",
-        "ref": "pathcompiler-staging",
+        "ref": "slicer2",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
                         pkgs.hdf5
                         pkgs.vtk-qt5
                         pkgs.tbb
-
+                    ] ++ pkgs.lib.optionals (stdenv == llvm.stdenv) [
                         llvm.openmp
                     ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -186,4 +186,9 @@
             };
         };
     });
+
+    nixConfig = {
+        extra-substituters = [ "https://mdfbaam.cachix.org" ];
+        extra-trusted-public-keys = [ "mdfbaam.cachix.org-1:WCQinXaMJP7Ny4sMlKdisNUyhcO2MHnPoobUef5aTmQ=" ];
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
     description = "ORNL Slicer 2 - An advanced object slicer";
 
     inputs = {
-        nixpkgs.url = github:mdfbaam/nixpkgs/pathcompiler-staging;
+        nixpkgs.url = github:mdfbaam/nixpkgs/slicer2;
         utils.url = github:numtide/flake-utils;
     };
 
@@ -24,7 +24,7 @@
             ornl = {
                 slicer2 = stdenv.mkDerivation rec {
                     pname = "ornl-slicer2";
-                    version = "1.0-" + (builtins.substring 0 8 (if (self ? rev) then self.rev else "dirty"));
+                    version = "1.01-" + (builtins.substring 0 8 (if (self ? rev) then self.rev else "dirty"));
 
                     src = self;
 
@@ -39,6 +39,11 @@
                         pkgs.gmp
                         pkgs.nlohmann_json
                         pkgs.mpfr
+                        pkgs.hdf5
+                        pkgs.vtk-qt5
+                        pkgs.tbb
+
+                        llvm.openmp
                     ];
 
                     nativeBuildInputs = [
@@ -51,8 +56,8 @@
 
                     # Workaround for non-NixOS to find GPU drivers
                     # TODO: add more linux distro paths as they are found or query ldconfig
-                    qtWrapperArgs = [
-                        "--suffix LD_LIBRARY_PATH : /usr/lib/x86_64-linux-gnu"
+                    qtWrapperArgs = pkgs.lib.optionals stdenv.isLinux [
+                        "--suffix LD_FALLBACK_PATH : /usr/lib/x86_64-linux-gnu"
                     ];
 
                     # The current build system is a bit weird, so we have to do some manual copying.


### PR DESCRIPTION
Updates Nix flake to support new libraries introduced in #55.

There's some issue with the nix bundling relating to VTK, not a blocking issue since it can still be run directly on linux via Nix:
```
nix run github:ORNLSlicer/Slicer-2
```