### PR TITLE
fix: force fusion style on windows

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake -L
+use flake

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QCommandLineParser>
+#include <QStyleFactory>
 
 // Local
 #include "configs/settings_base.h"
@@ -87,6 +88,8 @@ int main(int argc, char* argv[]) {
     }
     else {
         QApplication a(argc, argv);
+        QApplication::setStyle(QStyleFactory::create("fusion"));
+
         QApplication::setApplicationName("slicer2");
         QApplication::setOrganizationName("ornl");
         QApplication::setApplicationVersion(BOOST_PP_STRINGIZE(SLICER2_VERSION));


### PR DESCRIPTION
Forces the use of the "fusion" style on all platforms. Mainly to fix weirdness with Windows 11 native widgets being too small in Qt6.