### PR TITLE
fix(slicing): fix settings mesh alignment for angled slicing

### DIFF
--- a/include/cross_section/cross_section.h
+++ b/include/cross_section/cross_section.h
@@ -6,18 +6,23 @@
 #include "geometry/polygon_list.h"
 
 namespace ORNL {
+
 class CrossSectionSegment;
 
 //! \brief provides access to functions that cross section meshes
 namespace CrossSection {
-//! \brief Computes the cross-section for a mesh and a plane.
-//! \todo Although the external interface to cross section has been simplified, the internals still need some cleanup.
-//! \param QSharedPointer<Mesh> pointer to the mesh to be cross-sectioned
-//! \param Plane* the plane used to generate a cross-section
-//! \param Point* layers must be shifted before rotated, used to return the shift amount to the layer
-//! \param QVector3D* the average normal for the cross-section given the faces that are intersected
-PolygonList doCrossSection(QSharedPointer<MeshBase> mesh, Plane& slicing_plane, Point& shift, QVector3D& averageNormal,
-                           QSharedPointer<SettingsBase> sb);
+
+//! @brief Computes the cross-section for a mesh and a plane.
+//! @param mesh the mesh to cross-section
+//! @param slicing_plane the plane to cross-section with
+//! @param shift the shift applied to the mesh before cross-sectioning (modified by function)
+//! @param average_normal the average normal of all cross-sectioned faces (output)
+//! @param sb the settings to use for cross-sectioning
+//! @param preserve_input_shift if true, the incoming shift is used (not recomputed) so multiple meshes share the same
+//! flattening transform when slicing with an angled plane.
+//! @return the resulting cross-section polygons
+PolygonList doCrossSection(QSharedPointer<MeshBase> mesh, Plane& slicing_plane, Point& shift, QVector3D& average_normal,
+                           QSharedPointer<SettingsBase> sb, bool preserve_input_shift = false);
 
 //! \brief finds the center of the slicing plane within the bounding box
 //! \param mesh the mesh
@@ -31,5 +36,7 @@ Point findSlicingPlaneMidPoint(QSharedPointer<MeshBase> mesh, Plane& slicing_pla
 //! \param slicing_plane the plane
 //! \return the intersection point
 Point findIntersection(Point& vertex0, Point& vertex1, Plane& slicing_plane);
+
 } // namespace CrossSection
+
 } // namespace ORNL

--- a/include/slicing/buffered_slicer.h
+++ b/include/slicing/buffered_slicer.h
@@ -8,9 +8,8 @@
 namespace ORNL {
 //! \class BufferedSlicer
 //! \brief Provides a stateful cross-sectional slicer that can buffer. This class performs and tracks cross-sectioning
-//! for
-//!        a certain number of future and past slices. Depending on the future buffer size, when processNextSlice() is
-//!        called, it actually computes the Nth next slice, however returns whatever the front of the buffer is.
+//! for a certain number of future and past slices. Depending on the future buffer size, when processNextSlice() is
+//! called, it actually computes the Nth next slice, however returns whatever the front of the buffer is.
 //! \note when the previous or future buffers cannot be filled with valid slices, they are instead filled with nullptr
 class BufferedSlicer {
   public:
@@ -73,9 +72,10 @@ class BufferedSlicer {
     //! \return a cross-section (SliceMeta) object
     QSharedPointer<BufferedSlicer::SliceMeta> processSingleSlice();
 
-    //! \brief computes cross-sections for settings parts and extracts their geometry
+    //! \brief computes cross-sections for settings parts and extracts their geometry, aligned to a base shift
     //! \param settings_polygons a vector to fill with settings polygons
-    void computeSettingsPolygons(QVector<SettingsPolygon>& settings_polygons);
+    //! \param base_shift the shift used by the primary mesh cross-section so settings geometry aligns in 2D space
+    void computeSettingsPolygons(QVector<SettingsPolygon>& settings_polygons, const Point& base_shift);
 
     //! \brief the mesh this slicer is slicing
     QSharedPointer<MeshBase> m_mesh;

--- a/include/step/layer/regions/skeleton.h
+++ b/include/step/layer/regions/skeleton.h
@@ -55,7 +55,7 @@ class Skeleton : public RegionBase {
     void incorporateLostGeometry();
 
     //! \brief Cleans input geometry using ClipperLib2's cleanPolygons function
-    void simplifyInputGeometry(const uint& layer_num);
+    void simplifyInputGeometry();
 
     //! \brief Cleans output geometry according to ClipperLib2's cleanPolygons function
     void simplifyOutputGeometry();
@@ -116,7 +116,7 @@ class Skeleton : public RegionBase {
      *      Additionally, you may find it easier to inspect the skeleton by reversing the contrast of the application.
      *      On the right-hand side of the application select the wrench icon and then select Reverse Contrast.
      */
-    void inspectSkeleton(const uint& layer_num);
+    void inspectSkeleton();
 
     /*!
      * \brief Used for internal inspection of m_skeleton_graph.
@@ -205,5 +205,8 @@ class Skeleton : public RegionBase {
 
     //! \brief Precomputed paths for wire feed at anchors
     QVector<Polyline> m_computed_anchor_lines;
+
+    //! @brief The current layer number being processed
+    uint m_layer_num;
 };
 } // namespace ORNL

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -5,11 +5,13 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
+
 PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& slicing_plane, Point& shift,
-                                         QVector3D& averageNormal, QSharedPointer<SettingsBase> sb) {
+                                         QVector3D& average_normal, QSharedPointer<SettingsBase> sb,
+                                         bool preserve_input_shift) {
     //! \brief Helper for doCrossSection(). Exists as lamda to simplfy external interface (i.e. not show helpers).
     // given a point, a rotation, and a shift_amount: does **negative** shift of point and then rotation
-    auto rotatePoint = [](Point point_to_rotate, QQuaternion rotation, Point& shift_amount) {
+    auto rotatePoint = [](Point point_to_rotate, const QQuaternion& rotation, const Point& shift_amount) {
         // shift to rotate around origin
         point_to_rotate = point_to_rotate - shift_amount;
 
@@ -20,6 +22,7 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
         // reapply translate to account for origin offset
         result.setX(result.x() + shift_amount.x());
         result.setY(result.y() + shift_amount.y());
+        result.setZ(result.z() + shift_amount.z()); // restore original z offset (needed for consistent inverse)
 
         return Point(result); // will un-rotate and un-shift later, just before gcode writing
     };
@@ -34,12 +37,21 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
     CrossSectionObject cs(sb);
     int num_intersections = 0;
     QVector3D normal_accumulator(0, 0, 0);
+    // Compute shift once (unless caller wants to preserve provided shift reference)
+    if (!preserve_input_shift) {
+        shift = findSlicingPlaneMidPoint(mesh, slicing_plane);
+    }
+
+    // Precompute rotation once
+    QQuaternion rotation = MathUtils::CreateQuaternion(slicing_plane.normal(), QVector3D(0, 0, 1));
+
     for (int m = 0, end = faces.size(); m < end; ++m) {
         const MeshFace& face = faces[m];
 
         // Skip ignored faces
-        if (face.ignore)
+        if (face.ignore) {
             continue;
+        }
 
         const MeshVertex& v0 = vertices[face.vertex_index[0]];
         const MeshVertex& v1 = vertices[face.vertex_index[1]];
@@ -148,11 +160,7 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
          * Polymer_slicer save shift and rotation amount to layer so that this is un-done before gcode writing
          */
 
-        // modify shift parameter so that it can be saved to layer outside of this function
-        shift = findSlicingPlaneMidPoint(mesh, slicing_plane);
-
-        // define rotation using the direction of the slicing plane
-        QQuaternion rotation = MathUtils::CreateQuaternion(slicing_plane.normal(), QVector3D(0, 0, 1));
+        // Rotate into 2D frame using precomputed shift & rotation
         segment.start = rotatePoint(segment.start, rotation, shift);
         segment.end = rotatePoint(segment.end, rotation, shift);
 
@@ -167,8 +175,8 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
 
     // Only set average normal if there was at least one intersection
     if (num_intersections > 0) {
-        averageNormal = normal_accumulator / static_cast<float>(num_intersections);
-        averageNormal.normalize();
+        average_normal = normal_accumulator / static_cast<float>(num_intersections);
+        average_normal.normalize();
     }
 
     return cs.makePolygons();

--- a/src/slicing/buffered_slicer.cpp
+++ b/src/slicing/buffered_slicer.cpp
@@ -124,7 +124,7 @@ QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processSingleSlice() {
         if (m_slicing_plane.evaluatePoint(m_mesh_max) < 0)
             return nullptr;
 
-        Point shift_amount = Point(0, 0, 0); // cross sectioning will add data
+        Point shift_amount = Point(0, 0, 0); // cross sectioning will add data (primary mesh)
         QVector3D average_normal;
 
         PolygonList geometry;
@@ -134,8 +134,8 @@ QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processSingleSlice() {
             auto result = m_mesh->intersect(m_slicing_plane);
             opt_polylines = result.first;
 
-            for (auto polygon : result.second) // Extract polygons
-            {
+            // Extract polygons
+            for (auto polygon : result.second) {
                 geometry += polygon;
             }
 
@@ -143,7 +143,7 @@ QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processSingleSlice() {
         }
         else {
             geometry = CrossSection::doCrossSection(m_mesh, m_slicing_plane, shift_amount, average_normal,
-                                                    layer_specific_settings);
+                                                    layer_specific_settings, false);
         }
 
         if (layer_specific_settings->setting<bool>(PS::SpecialModes::kEnableOversize) && geometry.size() > 0) {
@@ -152,20 +152,25 @@ QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processSingleSlice() {
 
         // Settings regions
         QVector<SettingsPolygon> settings_polygons;
-        computeSettingsPolygons(settings_polygons);
+        computeSettingsPolygons(settings_polygons, shift_amount);
 
         SingleExternalGridInfo single_grid;
 
         PolygonList settings_modified_geometry;
-        if (m_settings_remaining_build_mesh != nullptr)
-            settings_modified_geometry =
-                CrossSection::doCrossSection(m_settings_remaining_build_mesh, m_slicing_plane, shift_amount,
-                                             average_normal, layer_specific_settings);
+        if (m_settings_remaining_build_mesh != nullptr) {
+            Point aux_shift = shift_amount; // preserve base
+            QVector3D aux_normal;
+            settings_modified_geometry = CrossSection::doCrossSection(
+                m_settings_remaining_build_mesh, m_slicing_plane, aux_shift, aux_normal, layer_specific_settings, true);
+        }
 
         PolygonList settings_bounded_geometry;
-        if (m_settings_bounded_mesh != nullptr)
+        if (m_settings_bounded_mesh != nullptr) {
+            Point aux_shift = shift_amount;
+            QVector3D aux_normal;
             settings_bounded_geometry = CrossSection::doCrossSection(
-                m_settings_bounded_mesh, m_slicing_plane, shift_amount, average_normal, layer_specific_settings);
+                m_settings_bounded_mesh, m_slicing_plane, aux_shift, aux_normal, layer_specific_settings, true);
+        }
 
         SliceMeta meta = {
             m_slice_count,
@@ -190,18 +195,28 @@ QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processSingleSlice() {
     return slice_meta;
 }
 
-void BufferedSlicer::computeSettingsPolygons(QVector<SettingsPolygon>& settings_polygons) {
-    // Create settings polygons
+void BufferedSlicer::computeSettingsPolygons(QVector<SettingsPolygon>& settings_polygons, const Point& base_shift) {
     for (const auto& settings_part : m_settings_parts) {
-        // Add a settings polys for each island.
-        Point tmp_point;
+        Point part_shift = base_shift; // preserve base shift
         QVector3D tmp_vec;
-
-        PolygonList geometry = CrossSection::doCrossSection(settings_part->rootMesh(), m_slicing_plane, tmp_point,
-                                                            tmp_vec, settings_part->getSb());
-
-        auto settings = settings_part->getSb();
-        settings_polygons.push_back(SettingsPolygon(geometry, settings));
+        PolygonList geometry = CrossSection::doCrossSection(settings_part->rootMesh(), m_slicing_plane, part_shift,
+                                                            tmp_vec, settings_part->getSb(), true);
+        // If cross-section altered shift (it should not with preserve flag), translate to match base
+        if (part_shift != base_shift) {
+            Point delta = base_shift - part_shift;
+            for (Polygon& poly : geometry) {
+                for (Point& p : poly) {
+                    p = p + delta;
+                }
+            }
+        }
+        QVector<Polygon> geom_vec;
+        geom_vec.reserve(geometry.size());
+        for (const Polygon& poly : geometry) {
+            geom_vec.push_back(poly);
+        }
+        auto sb = settings_part->getSb();
+        settings_polygons.push_back(SettingsPolygon(geom_vec, sb));
     }
 }
 } // namespace ORNL

--- a/src/step/layer/regions/skeleton.cpp
+++ b/src/step/layer/regions/skeleton.cpp
@@ -55,6 +55,8 @@ QString Skeleton::writeGCode(QSharedPointer<WriterBase> writer) {
 }
 
 void Skeleton::compute(uint layer_num, QSharedPointer<SyncManager>& sync) {
+    m_layer_num = layer_num;
+
     m_paths.clear();
 
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kSkeletonNum));
@@ -62,7 +64,7 @@ void Skeleton::compute(uint layer_num, QSharedPointer<SyncManager>& sync) {
     incorporateLostGeometry();
 
     if (!m_geometry.isEmpty()) {
-        simplifyInputGeometry(layer_num);
+        simplifyInputGeometry();
 
         const SkeletonInput& input = static_cast<SkeletonInput>(m_sb->setting<int>(PS::Skeleton::kSkeletonInput));
         switch (input) {
@@ -89,7 +91,7 @@ void Skeleton::compute(uint layer_num, QSharedPointer<SyncManager>& sync) {
             }
         }
         else {
-            qDebug() << "\t\tNo permitted skeletons generated from geometry on layer " << layer_num;
+            qDebug() << "\t\tNo permitted skeletons generated from geometry on layer " << m_layer_num;
         }
     }
     else {
@@ -234,7 +236,7 @@ void Skeleton::incorporateLostGeometry() {
     }
 }
 
-void Skeleton::simplifyInputGeometry(const uint& layer_num) {
+void Skeleton::simplifyInputGeometry() {
     const Distance& cleaning_dist = m_sb->setting<Distance>(PS::Skeleton::kSkeletonInputCleaningDistance);
 
     //! Too large of a cleaning distance may decimate inner/outer polygons such that they
@@ -259,7 +261,7 @@ void Skeleton::simplifyInputGeometry(const uint& layer_num) {
         m_geometry = m_geometry.cleanPolygons(cleaning_dist);
     }
     else {
-        qDebug() << "Layer " << layer_num << " Skeleton input geometry cleaning distance too large.";
+        qDebug() << "Layer " << m_layer_num << " Skeleton input geometry cleaning distance too large.";
     }
 
     //! Chamfer long axis corner of triangles
@@ -578,14 +580,14 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
     m_computed_geometry.append(path);
 }
 
-void Skeleton::inspectSkeleton(const uint& layer_num) {
+void Skeleton::inspectSkeleton() {
     static QMutex lock;
     QMutexLocker locker(&lock);
 
 #define precision_qDebug() qDebug() << Qt::fixed << qSetRealNumberPrecision(1)
 
     //! Print input geometry
-    qDebug() << "Layer " << layer_num << "Input Geometry:";
+    qDebug() << "Layer " << m_layer_num << "Input Geometry:";
     for (Polygon& poly : m_geometry) {
         for (uint i = 0, max = poly.size() - 1; i < max; ++i) {
             precision_qDebug() << "polygon((" << poly[i].x() << "," << poly[i].y() << "),(" << poly[i + 1].x() << ","
@@ -596,7 +598,7 @@ void Skeleton::inspectSkeleton(const uint& layer_num) {
     }
 
     //! Print skeleton geometry
-    qDebug() << "Layer " << layer_num << "Skeleton Geometry";
+    qDebug() << "Layer " << m_layer_num << "Skeleton Geometry";
     for (Polyline& seg : m_computed_geometry) {
         for (uint i = 0, max = seg.size() - 1; i < max; ++i) {
             precision_qDebug() << "polygon((" << seg[i].x() << "," << seg[i].y() << "),(" << seg[i + 1].x() << ","
@@ -612,7 +614,7 @@ void Skeleton::inspectSkeletonGraph() {
 #define precision_qDebug() qDebug() << Qt::fixed << qSetRealNumberPrecision(1)
 
     //! Print input geometry
-    qDebug() << "Input Geometry";
+    qDebug() << "Layer " << m_layer_num << "Input Geometry:";
     for (Polygon& poly : m_geometry) {
         for (uint i = 0, max = poly.size() - 1; i < max; ++i) {
             precision_qDebug() << "polygon((" << poly[i].x() << "," << poly[i].y() << "),(" << poly[i + 1].x() << ","

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "major":  "1",
     "minor":  "3",
-    "patch":  "004",
+    "patch":  "005",
     "suffix": "BETA"
 }


### PR DESCRIPTION
This pull request introduces improvements to the cross-sectioning and skeleton region processing logic to ensure consistent alignment, simplify interfaces, and improve debug traceability. The main changes include updating the cross-section function to optionally preserve input shifts for mesh alignment, propagating this alignment through the buffered slicer and settings geometry, and refactoring skeleton region methods to use internal state for layer tracking and debugging.

### Cross-sectioning and mesh alignment improvements

* The `doCrossSection` function in `cross_section.h` and `cross_section.cpp` now accepts a `preserve_input_shift` parameter, allowing multiple meshes to share the same flattening transform when slicing with an angled plane. This ensures consistent alignment of settings and build geometry. [[1]](diffhunk://#diff-4c15e033c9bc48a6356ae023b535ec1e9dbf54df6d5cadcf945e96dd04556d79R9-R25) [[2]](diffhunk://#diff-a69dfeea5b88c388b3e2b6669cd07a6d9863d60c029b0f120b0534e604056dc4R8-R14) [[3]](diffhunk://#diff-a69dfeea5b88c388b3e2b6669cd07a6d9863d60c029b0f120b0534e604056dc4R40-R54) [[4]](diffhunk://#diff-a69dfeea5b88c388b3e2b6669cd07a6d9863d60c029b0f120b0534e604056dc4L151-R163)
* The `computeSettingsPolygons` method in `buffered_slicer.h` and `buffered_slicer.cpp` now takes a `base_shift` parameter, propagating the primary mesh's shift to settings geometry for proper alignment in 2D space. Geometry is translated if needed to match the base shift. [[1]](diffhunk://#diff-918f5480268f0341082b4d6d2fa4a78bf50ecf8bcd8d165081c3f864380326acL76-R78) [[2]](diffhunk://#diff-ba27b01f7561e0a37b7980fda84f1f3038052eb9f61f597edb5d340c7fb5e6cfL155-R173) [[3]](diffhunk://#diff-ba27b01f7561e0a37b7980fda84f1f3038052eb9f61f597edb5d340c7fb5e6cfL193-R219)

### Skeleton region refactoring and debug improvements

* The `Skeleton` region class now stores the current layer number internally (`m_layer_num`) and uses it for debugging and geometry cleaning, replacing previous method signatures that passed the layer number as a parameter. This change affects `simplifyInputGeometry`, `inspectSkeleton`, and related debug output. [[1]](diffhunk://#diff-e563e235e0f485bca52db14edac72f0f2cf9e24e5de5dfc70a004af2fd24fc42L58-R58) [[2]](diffhunk://#diff-e563e235e0f485bca52db14edac72f0f2cf9e24e5de5dfc70a004af2fd24fc42L119-R119) [[3]](diffhunk://#diff-e563e235e0f485bca52db14edac72f0f2cf9e24e5de5dfc70a004af2fd24fc42R208-R210) [[4]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24R58-R67) [[5]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L237-R239) [[6]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L262-R264) [[7]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L581-R590) [[8]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L599-R601) [[9]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L615-R617)
* Debug output for skeleton geometry cleaning and inspection now consistently reports the correct layer number via the internal state, improving traceability during development and troubleshooting. [[1]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L92-R94) [[2]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L262-R264) [[3]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L581-R590) [[4]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L599-R601) [[5]](diffhunk://#diff-5242b759c9b29eeded444e65b0f5c0a43f369b08b207df68e63ec7ec17c0bf24L615-R617)

### Minor interface and documentation updates

* Documentation comments and parameter lists have been updated in several header files for clarity and consistency, especially regarding the new alignment and shift-preservation features. [[1]](diffhunk://#diff-4c15e033c9bc48a6356ae023b535ec1e9dbf54df6d5cadcf945e96dd04556d79R9-R25) [[2]](diffhunk://#diff-918f5480268f0341082b4d6d2fa4a78bf50ecf8bcd8d165081c3f864380326acL11-R11)
* Minor code style and parameter passing improvements were made, such as using references and const correctness in lambda functions. [[1]](diffhunk://#diff-a69dfeea5b88c388b3e2b6669cd07a6d9863d60c029b0f120b0534e604056dc4R8-R14) [[2]](diffhunk://#diff-a69dfeea5b88c388b3e2b6669cd07a6d9863d60c029b0f120b0534e604056dc4R25)

These changes collectively improve the reliability and maintainability of cross-sectioning and region processing, especially when handling complex multi-mesh slicing scenarios.