### PR TITLE
feat/geometry-debugger

### DIFF
--- a/include/geometry/geometry_debug.h
+++ b/include/geometry/geometry_debug.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "geometry/point.h"
+#include "geometry/polygon.h"
+#include "geometry/polygon_list.h"
+#include "geometry/polyline.h"
+
+#include <QPair>
+#include <QString>
+
+namespace ORNL {
+namespace GeometryDebug {
+
+using EdgeList = QVector<QPair<Point, Point>>;
+
+/// @brief Print a single polyline via Qt's debug output as Desmos-compatible line segments.
+/// @details Each line segment is printed as a separate polygon in the format "polygon((x1,y1),(x2,y2))".
+/// @param polyline The polyline to print. Polylines with fewer than 2 points will not be printed.
+/// @param label An optional label to prepend to the output for identification purposes.
+void printDesmos(const Polyline& polyline, QString label = "");
+
+/// @brief Print a collection of polylines via Qt's debug output as Desmos-compatible line segments.
+/// @details Each polyline is printed as a separate polygon in the format "polygon((x1,y1),(x2,y2))".
+/// @param polylines The collection of polylines to print.
+/// @param label An optional label to prepend to the output for identification purposes.
+void printDesmos(const QVector<Polyline>& polylines, QString label = "");
+
+/// @brief Print grouped polyline geometry via Qt's debug output as Desmos-compatible line segments.
+/// @details Each group of polylines is printed as a separate polygon in the format "polygon((x1,y1),(x2,y2))".
+/// @param geometry The grouped polyline geometry to print.
+/// @param label An optional label to prepend to the output for identification purposes.
+void printDesmos(const QVector<QVector<Polyline>>& geometry, QString label = "");
+
+/// @brief Print a polygon via Qt's debug output as Desmos-compatible line segments.
+/// @details Each line segment of the polygon is printed as a separate polygon in the format "polygon((x1,y1),(x2,y2))".
+/// @param polygon The polygon to print.
+/// @param label An optional label to prepend to the output for identification purposes.
+void printDesmos(const Polygon& polygon, QString label = "");
+
+/// @brief Print a list of polygons via Qt's debug output as Desmos-compatible line segments.
+/// @details Each line segment of each polygon is printed as a separate polygon in the format
+/// "polygon((x1,y1),(x2,y2))".
+/// @param polygon_list The list of polygons to print.
+/// @param label An optional label to prepend to the output for identification purposes.
+void printDesmos(const PolygonList& polygon_list, QString label = "");
+
+/// @brief Print an edge list via Qt's debug output as Desmos-compatible line segments.
+/// @details Each edge is printed as a separate polygon in the format "polygon((x1,y1),(x2,y2))".
+/// @param edge_list The edge list to print.
+/// @param label An optional label to prepend to the output for identification purposes.
+void printDesmos(const EdgeList& edge_list, QString label = "");
+
+} // namespace GeometryDebug
+} // namespace ORNL

--- a/include/step/layer/regions/skeleton.h
+++ b/include/step/layer/regions/skeleton.h
@@ -79,50 +79,16 @@ class Skeleton : public RegionBase {
     //! m_computed_geometry
     void extractPath(QVector<SkeletonEdge> path);
 
-    /*!
-     * \brief Used for internal inspection of skeleton structure contained in m_computed_geometry.
-     * Due to the underlyting nature of Voronoi Diagrams, small skeleton segments may be generated
-     * that will not be visible in the UI. To properly inspect these segments and their source geometry,
-     * follow these instructions:
-     *
-     * 1.   Call inspectSkeleton() after cleanOutputGeometry() is called within compute().
-     *
-     * 2.   The ouput will appear as:
-     *
-     *      Input Geometry
-     *      polygon((x1,y1),(x2,y2))
-     *      ...
-     *      Skeleton Geometry
-     *      polygon((x1,y1),(x2,y2))
-     *      ...
-     *
-     *      Copy this entire output including the "Input Geometry" and "Skeleton Geometry" text.
-     *      It will help you later identify which a segment belongs to.
-     *
-     * 3.   Go to desmos.com/calculator
-     *
-     * 4.   On the left-hand side of the application you will see an area to input data.
-     *      Select the first input row and paste the output from inspectSkeleton() using ctrl + v.
-     *
-     * 5.   You will see that the input has been entered but not initialized.
-     *      To initialize the input, scroll all the way to the top input row and select it.
-     *      Now hold down the tab button until you have iterated through all input rows.
-     *      The input should now be initialized.
-     *
-     * 6.   The graph will be centered at (0,0) however the input will most likely be at a much grater scale.
-     *      Continue to zoom out until the input becomes visible. Once visible, you can then zoom in on the
-     *      skeleton structure to inspect it in detail.
-     *
-     *      Additionally, you may find it easier to inspect the skeleton by reversing the contrast of the application.
-     *      On the right-hand side of the application select the wrench icon and then select Reverse Contrast.
-     */
+    /// @brief Used for internal inspection of skeleton geometry. To be used after compute and before optimize.
+    /// @details Prints the input geometry and computed skeleton geometry to Qt's debug output in a Desmos-compatible
+    /// format. Each line segment is printed as a separate polygon in the format "polygon((x1,y1),(x2,y2))". Polylines
+    /// with fewer than 2 points will not be printed.
     void inspectSkeleton();
 
-    /*!
-     * \brief Used for internal inspection of m_skeleton_graph.
-     * To be used after generateSkeletonGraph is called and before skeleton extraction is complete.
-     * Follows same instructions listed above.
-     */
+    /// @brief Used for internal inspection of skeleton graph. To be used after generateSkeletonGraph and before
+    /// optimize.
+    /// @details Prints the input geometry and skeleton graph edges to Qt's debug output in a Desmos-compatible format.
+    /// Each edge is printed as a separate polygon in the format "polygon((x1,y1),(x2,y2))".
     void inspectSkeletonGraph();
 
     //! \brief Optimizes the region.

--- a/src/geometry/geometry_debug.cpp
+++ b/src/geometry/geometry_debug.cpp
@@ -1,0 +1,108 @@
+#include "geometry/geometry_debug.h"
+
+#include "geometry/point.h"
+
+#include <QDebug>
+#include <QMutex>
+#include <QMutexLocker>
+
+namespace {
+QMutex& desmosOutputMutex() {
+    static QMutex output_mutex;
+    return output_mutex;
+}
+
+void printDesmosSegment(const ORNL::Point& start, const ORNL::Point& end) {
+    qDebug().noquote().nospace() << Qt::fixed << qSetRealNumberPrecision(1) << "polygon((" << start.x() << ","
+                                 << start.y() << "),(" << end.x() << "," << end.y() << "))";
+}
+
+void printDesmosPolyline(const ORNL::Polyline& polyline) {
+    if (polyline.size() < 2) {
+        return;
+    }
+
+    for (int i = 0; i < polyline.size() - 1; ++i) {
+        printDesmosSegment(polyline[i], polyline[i + 1]);
+    }
+}
+
+void printDesmosPolygon(const ORNL::Polygon& polygon) {
+    if (polygon.size() < 2) {
+        return;
+    }
+
+    for (int i = 0; i < polygon.size() - 1; ++i) {
+        printDesmosSegment(polygon[i], polygon[i + 1]);
+    }
+    printDesmosSegment(polygon.last(), polygon.first());
+}
+
+void printDesmosEdgeList(const ORNL::GeometryDebug::EdgeList& edge_list) {
+    for (const QPair<ORNL::Point, ORNL::Point>& edge : edge_list) {
+        printDesmosSegment(edge.first, edge.second);
+    }
+}
+
+} // namespace
+
+namespace ORNL {
+namespace GeometryDebug {
+void printDesmos(const Polyline& polyline, QString label) {
+    QMutexLocker locker(&desmosOutputMutex());
+    if (!label.isEmpty()) {
+        qDebug() << label;
+    }
+    printDesmosPolyline(polyline);
+}
+
+void printDesmos(const QVector<Polyline>& polylines, QString label) {
+    QMutexLocker locker(&desmosOutputMutex());
+    if (!label.isEmpty()) {
+        qDebug() << label;
+    }
+    for (const Polyline& polyline : polylines) {
+        printDesmosPolyline(polyline);
+    }
+}
+
+void printDesmos(const QVector<QVector<Polyline>>& geometry, QString label) {
+    QMutexLocker locker(&desmosOutputMutex());
+    if (!label.isEmpty()) {
+        qDebug() << label;
+    }
+    for (const QVector<Polyline>& polyline_group : geometry) {
+        for (const Polyline& polyline : polyline_group) {
+            printDesmosPolyline(polyline);
+        }
+    }
+}
+
+void printDesmos(const Polygon& polygon, QString label) {
+    QMutexLocker locker(&desmosOutputMutex());
+    if (!label.isEmpty()) {
+        qDebug() << label;
+    }
+    printDesmosPolygon(polygon);
+}
+
+void printDesmos(const PolygonList& polygon_list, QString label) {
+    QMutexLocker locker(&desmosOutputMutex());
+    if (!label.isEmpty()) {
+        qDebug() << label;
+    }
+    for (const Polygon& polygon : polygon_list) {
+        printDesmosPolygon(polygon);
+    }
+}
+
+void printDesmos(const EdgeList& edge_list, QString label) {
+    QMutexLocker locker(&desmosOutputMutex());
+    if (!label.isEmpty()) {
+        qDebug() << label;
+    }
+    printDesmosEdgeList(edge_list);
+}
+
+} // namespace GeometryDebug
+} // namespace ORNL

--- a/src/step/layer/regions/skeleton.cpp
+++ b/src/step/layer/regions/skeleton.cpp
@@ -2,6 +2,7 @@
 
 #include "boost/graph/undirected_dfs.hpp"
 #include "boost/polygon/voronoi.hpp"
+#include "geometry/geometry_debug.h"
 #include "geometry/path_modifier.h"
 #include "geometry/segments/line.h"
 #include "optimizers/polyline_order_optimizer.h"
@@ -581,60 +582,27 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
 }
 
 void Skeleton::inspectSkeleton() {
-    static QMutex lock;
-    QMutexLocker locker(&lock);
-
-#define precision_qDebug() qDebug() << Qt::fixed << qSetRealNumberPrecision(1)
-
-    //! Print input geometry
-    qDebug() << "Layer " << m_layer_num << "Input Geometry:";
-    for (Polygon& poly : m_geometry) {
-        for (uint i = 0, max = poly.size() - 1; i < max; ++i) {
-            precision_qDebug() << "polygon((" << poly[i].x() << "," << poly[i].y() << "),(" << poly[i + 1].x() << ","
-                               << poly[i + 1].y() << "))";
-        }
-        precision_qDebug() << "polygon((" << poly.first().x() << "," << poly.first().y() << "),(" << poly.last().x()
-                           << "," << poly.last().y() << "))";
-    }
-
-    //! Print skeleton geometry
-    qDebug() << "Layer " << m_layer_num << "Skeleton Geometry";
-    for (Polyline& seg : m_computed_geometry) {
-        for (uint i = 0, max = seg.size() - 1; i < max; ++i) {
-            precision_qDebug() << "polygon((" << seg[i].x() << "," << seg[i].y() << "),(" << seg[i + 1].x() << ","
-                               << seg[i + 1].y() << "))";
-        }
-    }
+    GeometryDebug::printDesmos(m_geometry, "Layer " + QString::number(m_layer_num) + " Skeleton Input Geometry");
+    GeometryDebug::printDesmos(m_computed_geometry,
+                               "Layer " + QString::number(m_layer_num) + " Skeleton Output Geometry");
 }
 
 void Skeleton::inspectSkeletonGraph() {
-    static QMutex lock;
-    QMutexLocker locker(&lock);
+    GeometryDebug::printDesmos(m_geometry, "Layer " + QString::number(m_layer_num) + " Skeleton Input Geometry");
 
-#define precision_qDebug() qDebug() << Qt::fixed << qSetRealNumberPrecision(1)
+    GeometryDebug::EdgeList edge_list;
+    edge_list.reserve(boost::num_edges(m_skeleton_graph));
 
-    //! Print input geometry
-    qDebug() << "Layer " << m_layer_num << "Input Geometry:";
-    for (Polygon& poly : m_geometry) {
-        for (uint i = 0, max = poly.size() - 1; i < max; ++i) {
-            precision_qDebug() << "polygon((" << poly[i].x() << "," << poly[i].y() << "),(" << poly[i + 1].x() << ","
-                               << poly[i + 1].y() << "))";
-        }
-        precision_qDebug() << "polygon((" << poly.first().x() << "," << poly.first().y() << "),(" << poly.last().x()
-                           << "," << poly.last().y() << "))";
-    }
-
-    //! Print skeleton graph
-    qDebug() << "Skeleton Graph";
     boost::graph_traits<SkeletonGraph>::edge_iterator edge_iter, edge_iter_end;
     boost::tie(edge_iter, edge_iter_end) = edges(m_skeleton_graph);
     while (edge_iter != edge_iter_end) {
-        precision_qDebug() << "polygon((" << m_skeleton_graph[edge_iter->m_source].x() << ","
-                           << m_skeleton_graph[edge_iter->m_source].y() << "),("
-                           << m_skeleton_graph[edge_iter->m_target].x() << ","
-                           << m_skeleton_graph[edge_iter->m_target].y() << "))";
-        edge_iter++;
+        const SkeletonVertex source = boost::source(*edge_iter, m_skeleton_graph);
+        const SkeletonVertex target = boost::target(*edge_iter, m_skeleton_graph);
+        edge_list.append(QPair<Point, Point>(m_skeleton_graph[source], m_skeleton_graph[target]));
+        ++edge_iter;
     }
+
+    GeometryDebug::printDesmos(edge_list, "Layer " + QString::number(m_layer_num) + " Skeleton Graph");
 }
 
 void Skeleton::populateSegmentSettings(QSharedPointer<SettingsBase> segment_sb,

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "major":  "1",
     "minor":  "3",
-    "patch":  "008",
+    "patch":  "009",
     "suffix": "BETA"
 }


### PR DESCRIPTION
This pull request introduces a new utility for printing geometric data in a Desmos-compatible format and refactors skeleton inspection methods to use this utility, resulting in cleaner and more maintainable code. The changes also include a minor version bump.

**New Geometry Debugging Utility:**

* Added new header `geometry_debug.h` and implementation `geometry_debug.cpp` providing the `GeometryDebug::printDesmos` functions for printing polylines, polygons, polygon lists, and skeleton graphs in Desmos-compatible line segment format. This improves debugging and visualization of geometry data. [[1]](diffhunk://#diff-a63a77394f1a131d4ad662b20ac6a3d7f19f49500573c03ad39fa8498dca3e59R1-R49) [[2]](diffhunk://#diff-14f55474f416e55b62e000d4b85e11b9ec6ed9fd742a9b1281aad2f70cd26f60R1-R117)

**Refactoring of Skeleton Inspection:**

* Refactored `Skeleton::inspectSkeleton` and `Skeleton::inspectSkeletonGraph` to use the new `GeometryDebug::printDesmos` utility, removing custom output code and mutex handling for simpler and more consistent output.

**Version Update:**

* Incremented the patch version in `version.json` from `008` to `009` to reflect these changes.