### PR TITLE
fix/settings-polygon-infill-angle

### DIFF
--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -58,6 +58,8 @@ void Infill::compute(uint layer_num, QSharedPointer<SyncManager>& sync) {
             QSharedPointer<SettingsBase> region_settings = QSharedPointer<SettingsBase>::create(*m_sb);
             region_settings->setSetting(PS::Infill::kLineSpacing,
                                         settings_polygon.getSettings()->setting<Distance>(PS::Infill::kLineSpacing));
+            region_settings->setSetting(PS::Infill::kAngle,
+                                        settings_polygon.getSettings()->setting<Angle>(PS::Infill::kAngle));
 
             fillGeometry(geometry, region_settings);
         }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "major":  "1",
     "minor":  "3",
-    "patch":  "011",
+    "patch":  "012",
     "suffix": "BETA"
 }


### PR DESCRIPTION
## Summary

Addresses issue where infill angle was not being applied for settings polygons.