### PR TITLE
feat: enable issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,12 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior in the project.
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
 ## Summary
 <!-- Briefly describe the bug and why it matters. -->
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/development_task.md
+++ b/.github/ISSUE_TEMPLATE/development_task.md
@@ -1,3 +1,12 @@
+---
+name: Development task
+about: Create a task for development work such as refactoring, performance improvement, or maintenance.
+title: ''
+labels: 'development'
+assignees: ''
+
+---
+
 ## Summary
 <!-- Briefly describe the development task being requested. -->
 <!-- This may be a refactor, performance improvement, chore, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,12 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement to improve the project.
+title: ''
+labels: 'feature'
+assignees: ''
+
+---
+
 ## Summary
 <!-- Briefly describe the feature being requested and the outcome it should enable. -->
 


### PR DESCRIPTION
## Summary

Enable GitHub’s issue template chooser for the repository’s issue templates.

This adds GitHub issue template metadata to the bug report, feature request, and development task templates so they appear as selectable options with names, descriptions, and default labels.

## Related issues

- No related issues.

## Details

This feature improves the GitHub issue creation workflow by making the existing Markdown issue templates visible in GitHub’s template chooser.

The change adds front matter to:

- `bug_report.md`
- `feature_request.md`
- `development_task.md`

The generic `task.md` template is also renamed to `development_task.md` to better describe its intended use for development maintenance, refactoring, and implementation work.

## Impact

GitHub users will now see clearer issue template choices when opening a new issue. This should make issue creation more consistent and help apply the intended default labels automatically.

Risk level: Low. This only changes GitHub issue template metadata and does not affect application runtime behavior.

## Testing strategy

No tests were run because this change only updates GitHub issue template metadata.
