### PR TITLE
fix(project): preserve embedded models and transform history

### DIFF
--- a/src/geometry/mesh/mesh_base.cpp
+++ b/src/geometry/mesh/mesh_base.cpp
@@ -116,6 +116,10 @@ void MeshBase::setTransformations(const QVector<QMatrix4x4> matrixes) {
 
         m_all_transformations.append(matrix);
     }
+
+    // Replaying a saved transform list can call setTransformation(), which records rotations as a side effect. Keep the
+    // saved history stable so load -> save does not duplicate rotations.
+    m_all_transformations = matrixes;
 }
 
 void MeshBase::alignAxis(const QMatrix4x4& matrix) {
@@ -144,10 +148,12 @@ void MeshBase::resetAlignedAxis(const QMatrix4x4& matrix) {
 const QMatrix4x4& MeshBase::transformation() const { return m_transformation; }
 
 QVector<QMatrix4x4> MeshBase::transformations() {
-    if (m_all_transformations.isEmpty() || m_all_transformations.last() != m_transformation)
-        m_all_transformations.append(m_transformation);
+    QVector<QMatrix4x4> transformations = m_all_transformations;
 
-    return m_all_transformations;
+    if (transformations.isEmpty() || transformations.last() != m_transformation)
+        transformations.append(m_transformation);
+
+    return transformations;
 }
 
 void MeshBase::scale(Distance3D bounds) {

--- a/src/threading/session_loader.cpp
+++ b/src/threading/session_loader.cpp
@@ -7,8 +7,8 @@
 #include <CGAL/property_map.h>
 #include <qcontainerfwd.h>
 #include <qfileinfo.h>
-#include <qmap.h>
 #include <qobject.h>
+#include <qset.h>
 #include <qsharedpointer.h>
 #include <qtmetamacros.h>
 #include <zip/zip.h>
@@ -37,13 +37,29 @@ void SessionLoader::saveSession() {
     if (zip == nullptr)
         return;
 
-    QMap<QString, QSharedPointer<Part>> meshes;
+    QSet<QString> active_model_names;
+    auto addActiveModelName = [&active_model_names](const QString& name) {
+        if (name.isEmpty())
+            return;
+
+        QFileInfo file_info(name);
+        active_model_names.insert(name);
+        active_model_names.insert(file_info.fileName());
+
+        QString base_name = file_info.baseName();
+        if (!base_name.isEmpty())
+            active_model_names.insert(base_name);
+    };
+
     auto parts = CSM->parts();
     for (auto& part : parts) {
-        meshes.insert(part->rootMesh()->name(), part);
+        addActiveModelName(part->rootMesh()->name());
+        addActiveModelName(part->rootMesh()->path());
 
-        for (auto& submesh : part->subMeshes())
-            meshes.insert(submesh->name(), part);
+        for (auto& submesh : part->subMeshes()) {
+            addActiveModelName(submesh->name());
+            addActiveModelName(submesh->path());
+        }
     }
 
     // Save models
@@ -51,10 +67,10 @@ void SessionLoader::saveSession() {
         QString file_name = it.key();
         QFileInfo file_info(file_name);
 
-        // Hack to make sure mesh can be found if loaded from project or stl.
-        // This is bad.
-        QString basename = file_info.baseName();
-        if (meshes.contains(basename) || meshes.contains(file_name)) // If this mesh was in the list of active meshes
+        // Embed model data when the active part still references this source file. Projects can carry a display name
+        // that differs from the model file name, so both mesh names and mesh paths are considered.
+        if (active_model_names.contains(file_name) || active_model_names.contains(file_info.fileName()) ||
+            active_model_names.contains(file_info.baseName()))
         {
             // To and back from QString in a single line. What an adventure.
             std::string filename = it.key().split("/").back().toStdString();
@@ -182,6 +198,11 @@ void SessionLoader::loadSession() {
     for (auto& part_json : parts_and_ranges) {
         std::string name = part_json[Constants::Settings::Session::LocalFile::kName];
         QSharedPointer<Part> part = CSM->getPart(QString::fromStdString(name));
+        if (part.isNull()) {
+            emit error("Project references settings for a part that was not loaded: " + QString::fromStdString(name));
+            continue;
+        }
+
         part->getSb()->json(part_json[Constants::Settings::Session::LocalFile::kSettings]);
 
         auto ranges = part_json[Constants::Settings::Session::LocalFile::kRanges];


### PR DESCRIPTION
## Summary

Fixes project save/load behavior for projects whose part display names differ from their embedded model filenames, and stabilizes saved part transform history across load-save cycles.

## Related issues

- No related issues.

## Details

This is a bug fix for project reload failures after saving an already-loadable `.s2p`.

The save path previously decided whether to embed model bytes by comparing active mesh names against model archive keys. The attached project exposes a mismatch: the active part name uses an older `.STL` display name, while the embedded model file is a `.3MF`. Saving that project could therefore omit the referenced `model/...` entry from the new `.s2p`, causing reload to fail.

The fix updates `SessionLoader::saveSession()` to track active model references from both mesh names and mesh source paths, including file names and base names. This allows the saved project to keep model data when the display name and source filename differ.

This also fixes transform persistence. Loading saved transform lists can call `setTransformation()`, which records rotation transforms as a side effect. `MeshBase::setTransformations()` now restores the loaded transform list after replay, and `MeshBase::transformations()` now returns a copy instead of mutating the mesh while saving. This prevents duplicated rotations or transform drift across load-save cycles.

A null guard was added when applying local part settings so malformed or incomplete projects do not dereference a missing part.

## Impact

Users should be able to save and reload projects like the provided `Impact-Limiter-Bottom-v16 1.s2p` without losing the embedded model entry or corrupting part transforms.

Risk level: Low to Medium. The change is localized to project save/load and mesh transform serialization, but those paths are central to `.s2p` persistence.

## Testing strategy

Validated by inspecting the `.s2p` save/load paths for projects where the displayed part name can differ from the embedded source model filename.

The change covers these cases:

- Saving active model data by source path as well as mesh/display name
- Reloading saved transform histories without duplicating rotation transforms
- Avoiding null dereference when local part settings reference a part that did not load
