### PR TITLE
feat(polygon_list): add polygonlist boundary getters

### DIFF
--- a/include/geometry/polygon_list.h
+++ b/include/geometry/polygon_list.h
@@ -6,7 +6,6 @@
 #include <clipper.hpp>
 #include <qcontainerfwd.h>
 #include <qpolygon.h>
-#include <qtypes.h>
 #include <qvectornd.h>
 
 #include "geometry/polygon.h"
@@ -17,7 +16,6 @@ namespace ORNL {
 class Point;
 
 const static int clipper_init = (0);
-#define NO_INDEX (std::numeric_limits<uint>::max())
 
 /*!
  * \class PolygonList
@@ -30,20 +28,9 @@ const static int clipper_init = (0);
  */
 class PolygonList : public QVector<Polygon> {
   public:
-    // QVector constructors.
     using QVector<Polygon>::QVector;
 
     PolygonList();
-
-    PolygonList(QVector<QVector<QPair<double, double>>> raw_poly_list);
-    /*!
-     * \brief getRawPoints - returns points of all polygons in list as raw values
-     * \return Vector of polygons comprised of pairs (x, y)
-     */
-    QVector<QVector<QPair<double, double>>> getRawPoints();
-
-    //! The total number of points in all the individual polygons
-    uint pointCount() const;
 
     /*!
      * \brief Offsets each of the polygons.
@@ -70,28 +57,6 @@ class PolygonList : public QVector<Polygon> {
     bool inside(Point p, bool border_result = false) const;
 
     /*!
-     * \brief Implements monotone chain convex hull algorithm
-     *
-     * See <a
-     * href="https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain">Monotone
-     * Chain</a>
-     */
-    Polygon convexHull() const;
-
-    /*!
-     * \brief Smooth out small perpendicular segments
-     *
-     * Smoothing is performed by removing the inner most vertex of a line
-     * segment smaller than \p remove_length which has an angle with the
-     * next and previous line segment smaller than roughly 150*
-     *
-     * Note that in its current implementation this function doesn't remove
-     * line segments with an angle smaller than 30* Such would be the case
-     * for an N shape.
-     */
-    PolygonList smooth(const Distance& remove_length);
-
-    /*!
      * \brief removes all middle collinear points judged by the specified tolerance angle
      * tolerance is defaulted to 0.01 degree
      */
@@ -113,34 +78,12 @@ class PolygonList : public QVector<Polygon> {
     PolygonList getOutsidePolygons() const;
 
     /*!
-     * Exclude holes which have no parts inside of them.
-     * \return the resulting polygons.
-     */
-    PolygonList removeEmptyHoles() const;
-
-    /*!
-     * Return hole polygons which have no parts inside of them.
-     * \return the resulting polygons.
-     */
-    PolygonList getEmptyHoles() const;
-
-    // Jingyang-optimizer
-    /*!
      * \brief Returns the sum of parimeters of polygons
      */
     int64_t totalLength();
 
-    // Nitish-support
-    //! \brief Calculates the area of a the boundary of the polygonList
-    Area outerArea();
-
     //! \brief Calcultes the area of a PolygonList accounting for holes
     Area netArea();
-
-    PolygonList shift(Point shift);
-
-    // intersection over union of two polygonlist
-    float commonArea(PolygonList cur_layer_outline);
 
     // Peform union by even-odd on all polygons at once.
     void addAll(QVector<Polygon> polygons);
@@ -157,19 +100,6 @@ class PolygonList : public QVector<Polygon> {
      */
     QVector<Polyline> getEdges() const;
 
-  private:
-    /*!
-     * recursive part of \ref Polygons::removeEmptyHoles and \ref
-     * Polygons::getEmptyHoles
-     * \param node The node of the polygons part to process
-     * \param remove_holes Whether to remove empty holes or everything but
-     * the empty holes \param ret Where to store polygons which are not
-     * empty holes
-     */
-    void removeEmptyHoles_processPolyTreeNode(const ClipperLib2::PolyNode& node, const bool remove_holes,
-                                              PolygonList& ret) const;
-
-  public:
     /*!
      * Split up the polygons into groups according to the even-odd rule.
      * Each PolygonsPart in the result has an outline as first polygon,
@@ -188,18 +118,10 @@ class PolygonList : public QVector<Polygon> {
     //! \brief Reverses the direction of normals for the points of this polygon list
     PolygonList reverseNormalDirections();
 
-    //! \brief Returns the closest point to `rhs`
-    //! \param rhs: the point in question
-    //! \return The closest point
-    Point closestPointTo(const Point& rhs);
-
   private:
     void splitIntoParts_processPolyTreeNode(ClipperLib2::PolyNode* node, QVector<PolygonList>& ret) const;
 
   public:
-    //! \brief Removes polygons with area smaller than \p minAreaSize.
-    PolygonList removeSmallAreas(Area minAreaSize);
-
     //! \brief Removes overlapping consecutive line segments which don't
     //! delimit a positive area.
     PolygonList removeDegenerateVertices();
@@ -304,9 +226,6 @@ class PolygonList : public QVector<Polygon> {
 
     //! \brief Tracks geometry that is lost as a result of inward offsetting
     QVector<Polygon> lost_geometry;
-
-    //! \brief Returns distance from between point and edge of island
-    float distanceTo(Point point);
 
   protected:
     //! \brief Private operator for use with internal clipper functions

--- a/include/geometry/polygon_list.h
+++ b/include/geometry/polygon_list.h
@@ -71,11 +71,16 @@ class PolygonList : public QVector<Polygon> {
     PolygonList cleanPolygons(const Distance distance = 10);
 
     /*!
-     * Remove all but the polygons on the very outside.
-     * Exclude holes and parts within holes.
-     * \return the resulting polygons.
+     * \brief Returns the external polygon boundaries.
+     * \return PolygonList containing each part's outer boundary.
      */
-    PolygonList getOutsidePolygons() const;
+    PolygonList externalPolygonBoundaries() const;
+
+    /*!
+     * \brief Returns the internal polygon boundaries.
+     * \return PolygonList containing each part's hole boundaries.
+     */
+    PolygonList internalPolygonBoundaries() const;
 
     /*!
      * \brief Returns the sum of parimeters of polygons

--- a/src/geometry/polygon_list.cpp
+++ b/src/geometry/polygon_list.cpp
@@ -1,17 +1,11 @@
 
 #include "geometry/polygon_list.h"
 
-#include <algorithm>
-#include <cfloat>
-#include <cmath>
 #include <cstdint>
 #include <limits>
 
 #include <QPolygon>
 #include <clipper.hpp>
-#include <qcontainerfwd.h>
-#include <qmath.h>
-#include <qminmax.h>
 #include <qpoint.h>
 #include <qtypes.h>
 #include <qvectornd.h>
@@ -19,41 +13,9 @@
 #include "geometry/polygon.h"
 #include "geometry/polyline.h"
 #include "units/unit.h"
-#include "utilities/mathutils.h"
 
 namespace ORNL {
 PolygonList::PolygonList() {}
-
-PolygonList::PolygonList(QVector<QVector<QPair<double, double>>> raw_poly_list) {
-    for (QVector<QPair<double, double>> raw_poly : raw_poly_list) {
-        Polygon poly;
-        for (QPair<double, double> pt : raw_poly)
-            poly.push_back(Point(pt.first, pt.second));
-
-        append(poly);
-    }
-}
-
-QVector<QVector<QPair<double, double>>> PolygonList::getRawPoints() {
-    QVector<QVector<QPair<double, double>>> polylist;
-
-    for (Polygon poly : *this) {
-        QVector<QPair<double, double>> pts;
-        for (Point p : poly) {
-            pts.push_back(QPair<double, double>(p.x(), p.y()));
-        }
-        polylist.push_back(pts);
-    }
-    return polylist;
-}
-
-uint PolygonList::pointCount() const {
-    uint rv = 0;
-    for (Polygon p : (*this)) {
-        rv += p.size();
-    }
-    return rv;
-}
 
 PolygonList PolygonList::offset(Distance distance, Distance real_offset, ClipperLib2::JoinType joinType) const {
     ClipperLib2::Paths paths;
@@ -100,76 +62,6 @@ bool PolygonList::inside(Point p, bool border_result) const {
         poly_count_inside += is_inside_this_poly;
     }
     return (poly_count_inside % 2) == 1;
-}
-
-Polygon PolygonList::convexHull() const {
-    uint num_points = 0;
-    for (const ClipperLib2::Path& path : (*this)()) {
-        num_points += path.size();
-    }
-
-    QVector<ClipperLib2::IntPoint> all_points;
-    for (const ClipperLib2::Path& path : (*this)()) {
-        for (const ClipperLib2::IntPoint& point : path) {
-            all_points.push_back(point);
-        }
-    }
-
-    struct HullSort {
-        bool operator()(const ClipperLib2::IntPoint& a, const ClipperLib2::IntPoint& b) {
-            return (a.X < b.X) || (a.X == b.X && a.Y < b.Y);
-        }
-    };
-
-    std::sort(all_points.begin(), all_points.end(), HullSort());
-
-    // positive for left turn, 0 for straight, negative for right turn
-    auto ccw = [](const ClipperLib2::IntPoint& p0, const ClipperLib2::IntPoint& p1,
-                  const ClipperLib2::IntPoint& p2) -> int64_t {
-        ClipperLib2::IntPoint v01(p1.X - p0.X, p1.Y - p0.Y);
-        ClipperLib2::IntPoint v12(p2.X - p1.X, p2.Y - p1.Y);
-
-        return static_cast<int64_t>(v01.X) * v12.Y - static_cast<int64_t>(v01.Y) * v12.X;
-    };
-
-    Polygon hull_poly;
-    ClipperLib2::Path hull_points = hull_poly();
-    hull_points.resize(num_points + 1);
-
-    // index to insert next hull point, also number of valid hull points
-    uint hull_idx = 0;
-
-    // Build lower hull
-    for (uint pt_idx = 0; pt_idx < num_points; pt_idx++) {
-        while (hull_idx >= 2 && ccw(hull_points[hull_idx - 2], hull_points[hull_idx - 1], all_points[pt_idx]) <= 0) {
-            hull_idx--;
-        }
-        hull_points[hull_idx] = all_points[pt_idx];
-        hull_idx++;
-    }
-
-    // Build upper hull
-    uint min_upper_hull_chain_end_idx = hull_idx + 1;
-    for (int pt_idx = num_points - 2; pt_idx >= 0; pt_idx--) {
-        while (hull_idx >= min_upper_hull_chain_end_idx &&
-               ccw(hull_points[hull_idx - 2], hull_points[hull_idx - 1], all_points[pt_idx]) <= 0) {
-            hull_idx--;
-        }
-        hull_points[hull_idx] = all_points[pt_idx];
-        hull_idx++;
-    }
-
-    // assert(hull_idx <= hull_points.size());
-
-    // Last point is duplicted with first.  It is removed in the resize.
-    hull_points.resize(hull_idx - 2);
-
-    return hull_poly;
-}
-
-PolygonList PolygonList::smooth(const Distance& removeLength) {
-    //! \todo psmooth
-    return PolygonList();
 }
 
 PolygonList PolygonList::simplify(const Angle tolerance) {
@@ -222,55 +114,6 @@ PolygonList PolygonList::getOutsidePolygons() const {
     return polygons;
 }
 
-PolygonList PolygonList::removeEmptyHoles() const {
-    PolygonList ret;
-    ClipperLib2::Clipper clipper(clipper_init);
-    ClipperLib2::PolyTree poly_tree;
-    constexpr bool paths_are_closed_polys = true;
-    clipper.AddPaths((*this)(), ClipperLib2::ptSubject, paths_are_closed_polys);
-    clipper.Execute(ClipperLib2::ctUnion, poly_tree);
-
-    bool remove_holes = true;
-    removeEmptyHoles_processPolyTreeNode(poly_tree, remove_holes, ret);
-
-    ret.restoreNormals(*this);
-
-    return ret;
-}
-
-PolygonList PolygonList::getEmptyHoles() const {
-    PolygonList ret;
-    ClipperLib2::Clipper clipper(clipper_init);
-    ClipperLib2::PolyTree poly_tree;
-    constexpr bool paths_are_closed_polys = true;
-    clipper.AddPaths((*this)(), ClipperLib2::ptSubject, paths_are_closed_polys);
-    clipper.Execute(ClipperLib2::ctUnion, poly_tree);
-
-    bool remove_holes = false;
-    removeEmptyHoles_processPolyTreeNode(poly_tree, remove_holes, ret);
-
-    ret.restoreNormals(*this);
-
-    return ret;
-}
-
-void PolygonList::removeEmptyHoles_processPolyTreeNode(const ClipperLib2::PolyNode& node, const bool remove_holes,
-                                                       PolygonList& ret) const {
-    for (int outer_poly_idx = 0; outer_poly_idx < node.ChildCount(); outer_poly_idx++) {
-        ClipperLib2::PolyNode* child = node.Childs[outer_poly_idx];
-        if (remove_holes) {
-            ret += child->Contour;
-        }
-        for (int hole_node_idx = 0; hole_node_idx < child->ChildCount(); hole_node_idx++) {
-            ClipperLib2::PolyNode& hole_node = *child->Childs[hole_node_idx];
-            if ((hole_node.ChildCount() > 0) == remove_holes) {
-                ret += hole_node.Contour;
-                removeEmptyHoles_processPolyTreeNode(hole_node, remove_holes, ret);
-            }
-        }
-    }
-}
-
 QVector<PolygonList> PolygonList::splitIntoParts(bool unionAll) const {
     QVector<PolygonList> result;
     ClipperLib2::Clipper clipper(clipper_init);
@@ -313,9 +156,7 @@ void PolygonList::restoreNormals(QVector<Polygon> all_polys, bool offset) {
     {
         auto index = [](uint i, uint last) {
             uint ret = i;
-            if (i < 0)
-                ret = last;
-            else if (i > last)
+            if (i > last)
                 ret = 0;
 
             return ret;
@@ -372,21 +213,6 @@ void PolygonList::splitIntoParts_processPolyTreeNode(ClipperLib2::PolyNode* node
         if (part.size() > 0)
             ret.push_back(part);
     }
-}
-
-PolygonList PolygonList::removeSmallAreas(Area minAreaSize) {
-    PolygonList ret(*this);
-    for (uint i = 0; i < ret.size(); i++) {
-        Area area = Area(fabs(ret[i].area()()));
-        if (area < minAreaSize) // Only create an up/down skin if the area
-                                // is large enough. So you do not create
-                                // tiny blobs of "trying to fill"
-        {
-            ret.remove(i);
-            i -= 1;
-        }
-    }
-    return ret;
 }
 
 PolygonList PolygonList::removeDegenerateVertices() {
@@ -515,22 +341,6 @@ Area PolygonList::totalArea() {
     return total_area;
 }
 
-Point PolygonList::closestPointTo(const Point& rhs) {
-    Distance min_dist = Distance(std::numeric_limits<float>::max());
-    Point closest, candidate;
-
-    for (Polygon& poly : *this) {
-        candidate = poly.closestPointTo(rhs);
-
-        if (rhs.distance(candidate) < min_dist) {
-            closest = candidate;
-            min_dist = rhs.distance(closest);
-        }
-    }
-
-    return closest;
-}
-
 bool PolygonList::operator==(const PolygonList& rhs) const {
     PolygonList pl1 = *this;
     PolygonList pl2 = rhs;
@@ -596,20 +406,6 @@ PolygonList PolygonList::operator^(const PolygonList& rhs) { return _xor(rhs); }
 PolygonList PolygonList::operator^(const Polygon& rhs) { return _xor(rhs); }
 
 PolygonList PolygonList::operator^=(const PolygonList& rhs) { return _xor_with_this(rhs); }
-
-float PolygonList::distanceTo(Point point) // used by poleOfInaccessibility
-{
-    float rv = FLT_MAX;
-    for (const Polygon& ring : *this) {
-        for (int i = 0, len = ring.length(), j = len - 1; i < len; j = i++) {
-            Point a = ring[i];
-            Point b = ring[j];
-
-            rv = qMin(rv, MathUtils::distanceFromLineSegSqrd(point, a, b));
-        }
-    }
-    return (this->inside(point) ? 1 : -1) * qSqrt(rv);
-}
 
 PolygonList PolygonList::operator^=(const Polygon& rhs) { return _xor_with_this(rhs); }
 
@@ -880,47 +676,12 @@ PolygonList PolygonList::_xor_with_this(const PolygonList& other) {
     return (*this);
 }
 
-Area PolygonList::outerArea() {
-    for (Polygon p : *this) {
-        if (p.orientation()) {
-            return p.area();
-        }
-    }
-
-    return Area();
-}
-
 Area PolygonList::netArea() {
     Area a;
     for (Polygon p : *this) {
         a = a + p.area();
     }
     return a;
-}
-
-PolygonList PolygonList::shift(Point shift) {
-    PolygonList pl;
-    for (Polygon pgon : *this) {
-        // std::cout << "shifting\n";
-        Polygon pgon2;
-        for (Point p : pgon) {
-            p = p + shift;
-            pgon2.append(p);
-        }
-        pl.append(pgon2);
-    }
-    return pl;
-}
-
-float PolygonList::commonArea(PolygonList cur_layer_outline) {
-    PolygonList temp = *this;
-    PolygonList p = temp & cur_layer_outline;
-    PolygonList n_intrsctn = temp - p;
-    Area a = p.outerArea();
-    Area b = temp.outerArea();
-    float ratio = a() / b();
-
-    return ratio;
 }
 
 void PolygonList::addAll(QVector<Polygon> polygons) {
@@ -932,8 +693,6 @@ void PolygonList::addAll(QVector<Polygon> polygons) {
     clipperLoad(paths);
 
     restoreNormals(polygons);
-
-    return;
 }
 
 QVector<QPolygon> PolygonList::toQPolygons() const {

--- a/src/geometry/polygon_list.cpp
+++ b/src/geometry/polygon_list.cpp
@@ -95,23 +95,28 @@ PolygonList PolygonList::cleanPolygons(const Distance distance) {
     return cleaned_polygons;
 }
 
-PolygonList PolygonList::getOutsidePolygons() const {
-    PolygonList polygons;
-    int polygonId = 0;
+PolygonList PolygonList::externalPolygonBoundaries() const {
+    PolygonList boundaries;
 
-    for (Polygon p : (*this)) {
-        // based on an assumption: the first polygon is the most exterior one
-        if (polygonId == 0)
-            polygons.append(p);
-        else {
-            // this should not happen in ORNLSlicer as a PolyhonList only contains a polygon and some interior polygons
-            if (!polygons.first().inside(p.boundingRectCenter())) {
-                polygons.append(p);
-            }
+    for (const PolygonList& part : splitIntoParts()) {
+        if (!part.isEmpty()) {
+            boundaries.append(part.first());
         }
-        polygonId++;
     }
-    return polygons;
+
+    return boundaries;
+}
+
+PolygonList PolygonList::internalPolygonBoundaries() const {
+    PolygonList boundaries;
+
+    for (const PolygonList& part : splitIntoParts()) {
+        for (int i = 1; i < part.size(); ++i) {
+            boundaries.append(part[i]);
+        }
+    }
+
+    return boundaries;
 }
 
 QVector<PolygonList> PolygonList::splitIntoParts(bool unionAll) const {

--- a/src/slicing/layer_additions.cpp
+++ b/src/slicing/layer_additions.cpp
@@ -87,7 +87,7 @@ void LayerAdditions::addBrim(QSharedPointer<Layer> layer) {
     for (PolygonList poly : islandOutlines) {
         // get the subset of the polygon list that only describes the outer boundary
         //  and set the Brim with an offset from that polygon list
-        PolygonList outerPoly = poly.getOutsidePolygons();
+        PolygonList outerPoly = poly.externalPolygonBoundaries();
         newOutlines |= outerPoly.offset(brim_offset);
     }
     QVector<PolygonList> newIslands = newOutlines.splitIntoParts();

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -44,8 +44,6 @@
 #include "gcode/parsers/rpbf_parser.h"
 #include "gcode/parsers/siemens_parser.h"
 #include "gcode/parsers/tormach_parser.h"
-#include "geometry/mesh/mesh_face.h"
-#include "geometry/mesh/mesh_vertex.h"
 #include "geometry/point.h"
 #include "geometry/segment_base.h"
 #include "geometry/segments/arc.h"
@@ -428,7 +426,6 @@ void GCodeLoader::run() {
 
                     ret = QFile::rename(tempFile.fileName(), m_filename);
                 }
-
             }
         } catch (ExceptionBase& exception) {
             QString message = "Error parsing GCode: " + QString(exception.what());


### PR DESCRIPTION
## Summary

Adds explicit `PolygonList` helpers for retrieving external and internal polygon boundaries, and removes unused `PolygonList` APIs and stale includes.


## Related issues

- Depends on: #132 


## Details

This PR adds `externalPolygonBoundaries()` and `internalPolygonBoundaries()` to `PolygonList`. Both are implemented using `splitIntoParts()`, where each part's first polygon is treated as the outer boundary and subsequent polygons are treated as internal hole boundaries.

`LayerAdditions::addBrim()` now uses `externalPolygonBoundaries()` instead of the older outside-polygon helper when generating brim offsets.

This also removes unused `PolygonList` methods and related implementation code, including raw point conversion, convex hull, smoothing, empty-hole filtering, area helpers, shifting, closest-point lookup, common-area calculation, and distance-to-edge logic. Stale includes and an impossible unsigned-index check in normal restoration were also cleaned up.


## Impact

This reduces the public `PolygonList` API surface and makes boundary extraction more explicit. Brim generation now relies on the existing polygon-part splitting behavior rather than the previous outside-polygon heuristic.

Risk level: Medium. The removed methods appear unused in the current codebase, but this is still an API-removal change. The brim path also changes which helper identifies external boundaries, so geometry output should be validated on representative sliced parts.


## Testing strategy

Built and sliced locally.