### PR TITLE
feat(perimeter): add boundary selection for perimeter paths

### DIFF
--- a/include/geometry/polygon_list.h
+++ b/include/geometry/polygon_list.h
@@ -170,10 +170,10 @@ class PolygonList : public QVector<Polygon> {
     PolygonList operator+=(const Polygon& rhs);
 
     //! \brief difference
-    PolygonList operator-(const PolygonList& rhs);
+    PolygonList operator-(const PolygonList& rhs) const;
 
     //! \brief difference
-    PolygonList operator-(const Polygon& rhs);
+    PolygonList operator-(const Polygon& rhs) const;
 
     //! \brief difference
     PolygonList operator-=(const PolygonList& rhs);
@@ -274,13 +274,13 @@ class PolygonList : public QVector<Polygon> {
      * \brief Remove any regions of this that overlap with other
      *        The result is returned.
      */
-    PolygonList _subtract(const Polygon& rhs);
+    PolygonList _subtract(const Polygon& rhs) const;
 
     /*!
      * \brief Remove any regions of the polygon that overlap with other's
      * Polygons The result is returned.
      */
-    PolygonList _subtract(const PolygonList& rhs);
+    PolygonList _subtract(const PolygonList& rhs) const;
 
     /*!
      * \brief Remove any regions of this that overlap with other

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -617,6 +617,7 @@ class Constants {
           public:
             static const QString kEnable;
             static const QString kCount;
+            static const QString kBoundarySelection;
             static const QString kBeadWidth;
             static const QString kFirstLayerBeadWidth;
             static const QString kSpeed;

--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -618,6 +618,8 @@ enum class SeamSelection : uint8_t { kRandom, kOptimized, kRotating };
 
 enum class PrintDirection : uint8_t { kReverse_off, kReverse_All_Layers, kReverse_Alternating_Layers };
 
+enum class PerimeterBoundarySelection : uint8_t { kAll = 0, kInternal = 1, kExternal = 2 };
+
 enum class ForceMinimumLayerTime : uint8_t { kUse_Purge_Dwells, kSlow_Feedrate };
 
 enum class PreferenceChoice : uint8_t { kAsk = 0, kPerformAutomatically = 1, kSkipAutomatically = 2 };

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -3639,6 +3639,19 @@
       "symbol":"kNumberofPerimeters",
       "local":true
   },
+  "perimeter_boundary_selection": {
+      "display":"Perimeter Boundaries",
+      "type":"enumeration",
+      "tooltip":"Selects which polygon boundaries are used to generate perimeter paths.",
+      "depends":{"perimeter":true},
+      "options":"All Boundaries, Internal Boundaries, External Boundaries",
+      "default":0,
+      "minor":"Perimeter",
+      "major":"Profile",
+      "namespace":"Profile::Perimeter",
+      "symbol":"kPerimeterBoundarySelection",
+      "local":true
+  },
   "perimeter_width": {
       "display":"Perimeter Bead Width",
       "type":"distance",

--- a/resources/settings/021_profile_perimeter.yaml
+++ b/resources/settings/021_profile_perimeter.yaml
@@ -25,6 +25,21 @@ settings:
     namespace: "Profile::Perimeter"
     symbol: "kNumberofPerimeters"
     local: true
+  - name: "perimeter_boundary_selection"
+    display: "Perimeter Boundaries"
+    type: "enumeration"
+    tooltip: "Selects which polygon boundaries are used to generate perimeter paths."
+    depends: {"perimeter":true}
+    options:
+      - "All Boundaries"
+      - "Internal Boundaries"
+      - "External Boundaries"
+    default: 0
+    minor: "Perimeter"
+    major: "Profile"
+    namespace: "Profile::Perimeter"
+    symbol: "kPerimeterBoundarySelection"
+    local: true
   - name: "perimeter_width"
     display: "Perimeter Bead Width"
     type: "distance"

--- a/src/geometry/polygon_list.cpp
+++ b/src/geometry/polygon_list.cpp
@@ -376,9 +376,9 @@ PolygonList PolygonList::operator+=(const PolygonList& rhs) { return _add_to_thi
 
 PolygonList PolygonList::operator+=(const Polygon& rhs) { return _add_to_this(rhs); }
 
-PolygonList PolygonList::operator-(const PolygonList& rhs) { return _subtract(rhs); }
+PolygonList PolygonList::operator-(const PolygonList& rhs) const { return _subtract(rhs); }
 
-PolygonList PolygonList::operator-(const Polygon& rhs) { return _subtract(rhs); }
+PolygonList PolygonList::operator-(const Polygon& rhs) const { return _subtract(rhs); }
 
 PolygonList PolygonList::operator-=(const PolygonList& rhs) { return _subtract_from_this(rhs); }
 
@@ -499,7 +499,7 @@ PolygonList PolygonList::_add_to_this(const PolygonList& other) {
     return (*this);
 }
 
-PolygonList PolygonList::_subtract(const Polygon& other) {
+PolygonList PolygonList::_subtract(const Polygon& other) const {
     QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {Polygon(other).reverseNormalDirections()};
 
     ClipperLib2::Paths paths;
@@ -514,7 +514,7 @@ PolygonList PolygonList::_subtract(const Polygon& other) {
     return result;
 }
 
-PolygonList PolygonList::_subtract(const PolygonList& other) {
+PolygonList PolygonList::_subtract(const PolygonList& other) const {
     QVector<Polygon> all_polys =
         QVector<Polygon> {*this} + QVector<Polygon> {PolygonList(other).reverseNormalDirections()};
 

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -26,6 +26,54 @@
 #include "utilities/enums.h"
 
 namespace ORNL {
+namespace {
+QVector<Point> collectNormalSourcePoints(const PolygonList& geometry) {
+    QVector<Point> points;
+    for (const Polygon& poly : geometry) {
+        for (const Point& point : poly) {
+            points.push_back(point);
+        }
+    }
+
+    return points;
+}
+
+void appendPathLinesWithNormals(PolygonList& path_lines, QVector<Point>& previous_points,
+                                QVector<Polyline>& computed_geometry) {
+    QVector<Point> current_points;
+
+    for (Polygon& poly : path_lines) {
+        for (Point& p : poly) {
+            kNN neighbor(previous_points, QVector<Point> {p}, 1);
+            neighbor.execute();
+
+            int closest = neighbor.getNearestIndices().first();
+            p.setNormals(previous_points[closest].getNormals());
+            current_points.push_back(p);
+        }
+
+        Polyline line = poly.toPolyline();
+        line.pop_back();
+        computed_geometry.push_back(line);
+    }
+
+    previous_points = current_points;
+}
+
+PolygonList selectedBoundaryOffsetGeometry(const PolygonList& external_boundaries,
+                                           const PolygonList& internal_boundaries, PerimeterBoundarySelection selection,
+                                           Distance offset_distance) {
+    if (selection == PerimeterBoundarySelection::kInternal) {
+        return external_boundaries - internal_boundaries.offset(offset_distance);
+    }
+
+    PolygonList offset_external_geometry = external_boundaries.offset(-offset_distance);
+    PolygonList offset_geometry = offset_external_geometry - internal_boundaries;
+    offset_geometry.lost_geometry = offset_external_geometry.lost_geometry;
+    return offset_geometry;
+}
+} // namespace
+
 Perimeter::Perimeter(const QSharedPointer<SettingsBase>& sb, const int index,
                      const QVector<SettingsPolygon>& settings_polygons, PolygonList uncut_geometry)
     : RegionBase(sb, index, settings_polygons, uncut_geometry) {}
@@ -49,43 +97,48 @@ void Perimeter::compute(uint layer_num) {
 
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum));
     Distance beadWidth = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
-    int rings = m_sb->setting<int>(PS::Perimeter::kCount);
+    int perimeter_count = m_sb->setting<int>(PS::Perimeter::kCount);
+    const PerimeterBoundarySelection boundary_selection =
+        static_cast<PerimeterBoundarySelection>(m_sb->setting<int>(PS::Perimeter::kBoundarySelection));
 
-    PolygonList path_line = m_geometry.offset(-beadWidth / 2);
+    const PolygonList original_geometry = m_geometry;
+    QVector<Point> previous_points = collectNormalSourcePoints(original_geometry);
 
-    QVector<Point> previousPoints;
-    QVector<Point> currentPoints;
-    for (Polygon& poly : m_geometry) {
-        for (Point& p : poly) {
-            previousPoints.push_back(p);
+    if (boundary_selection == PerimeterBoundarySelection::kAll) {
+        PolygonList path_lines = m_geometry.offset(-beadWidth / 2);
+
+        for (int perimeter_number = 0; !path_lines.isEmpty() && perimeter_number < perimeter_count;
+             ++perimeter_number) {
+            appendPathLinesWithNormals(path_lines, previous_points, m_computed_geometry);
+
+            m_geometry = path_lines.offset(-beadWidth / 2, -beadWidth / 2);
+            path_lines = path_lines.offset(-beadWidth, -beadWidth / 2);
         }
+        return;
     }
 
-    int ring_nr = 0;
-    while (!path_line.isEmpty() && ring_nr < rings) {
-        for (Polygon& poly : path_line) {
-            for (Point& p : poly) {
-                kNN neighbor(previousPoints, QVector<Point> {p}, 1);
-                neighbor.execute();
+    // Selective modes offset the full part mask and then extract the requested boundary type. Offsetting a hole or an
+    // outline as a standalone polygon would send paths into void space or through holes because the opposite boundary
+    // would no longer clip the offset.
+    const PolygonList external_boundaries = original_geometry.externalPolygonBoundaries();
+    const PolygonList internal_boundaries = original_geometry.internalPolygonBoundaries();
 
-                int closest = neighbor.getNearestIndices().first();
-                p.setNormals(previousPoints[closest].getNormals());
-                currentPoints.push_back(p);
-            }
-        }
-        previousPoints = currentPoints;
-        currentPoints.clear();
-
-        for (Polygon poly : path_line) {
-            Polyline line = poly.toPolyline();
-            line.pop_back();
-            m_computed_geometry.push_back(line);
+    for (int perimeter_number = 0; perimeter_number < perimeter_count; ++perimeter_number) {
+        const Distance path_offset = beadWidth * perimeter_number + beadWidth / 2;
+        PolygonList offset_geometry =
+            selectedBoundaryOffsetGeometry(external_boundaries, internal_boundaries, boundary_selection, path_offset);
+        PolygonList path_lines = boundary_selection == PerimeterBoundarySelection::kInternal
+                                     ? offset_geometry.internalPolygonBoundaries()
+                                     : offset_geometry.externalPolygonBoundaries();
+        if (path_lines.isEmpty()) {
+            break;
         }
 
-        ring_nr++;
+        appendPathLinesWithNormals(path_lines, previous_points, m_computed_geometry);
 
-        m_geometry = path_line.offset(-beadWidth / 2, -beadWidth / 2);
-        path_line = path_line.offset(-beadWidth, -beadWidth / 2);
+        const Distance remaining_offset = beadWidth * (perimeter_number + 1);
+        m_geometry = selectedBoundaryOffsetGeometry(external_boundaries, internal_boundaries, boundary_selection,
+                                                    remaining_offset);
     }
 }
 

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -564,6 +564,7 @@ const QString Constants::ProfileSettings::Layer::kMinExtrudeLength = "minimum_ex
 // Perimeter
 const QString Constants::ProfileSettings::Perimeter::kEnable = "perimeter";
 const QString Constants::ProfileSettings::Perimeter::kCount = "perimeter_count";
+const QString Constants::ProfileSettings::Perimeter::kBoundarySelection = "perimeter_boundary_selection";
 const QString Constants::ProfileSettings::Perimeter::kBeadWidth = "perimeter_width";
 const QString Constants::ProfileSettings::Perimeter::kSpeed = "perimeter_speed";
 const QString Constants::ProfileSettings::Perimeter::kExtruderSpeed = "perimeter_extruder_speed";


### PR DESCRIPTION
## Summary

Adds a `Perimeter Boundaries` profile setting that lets users generate perimeter paths from all polygon boundaries, only internal boundaries, or only external boundaries.


## Related issues

- Depends on #134 


## Details

This feature adds three perimeter boundary modes:

- `All Boundaries`
- `Internal Boundaries`
- `External Boundaries`

`All Boundaries` is the default and preserves the existing recursive perimeter offset workflow.

For selective modes, perimeter generation separates external polygon boundaries from internal hole boundaries, offsets the full printable mask, and then extracts the requested boundary type. This keeps generated paths inside the printable region:

- Internal boundaries generate paths from holes outward into the part.
- External boundaries generate paths from the exterior inward while preserving holes.

The implementation also adds `PolygonList::externalPolygonBoundaries()` and `PolygonList::internalPolygonBoundaries()` helpers and makes polygon-list subtraction const-correct.


## Impact

Users can now choose whether perimeter paths are applied to all walls, only hole walls, or only exterior walls.

Risk level: Medium. This touches perimeter geometry generation and the remaining geometry passed to downstream regions. The default mode intentionally preserves the prior behavior to reduce risk for existing profiles.


## Testing strategy

- Built and sliced locally with all options.