### PR TITLE
refactor(geometry): remove point normal tracking

### DIFF
--- a/include/geometry/point.h
+++ b/include/geometry/point.h
@@ -225,20 +225,6 @@ class Point {
     //! \return a settings base
     QSharedPointer<SettingsBase> getSettings();
 
-    //! \brief Sets the normals at this point
-    //! \param normal: vector of normals to set
-    void setNormals(QVector<QVector3D> normals);
-
-    //! \brief gets the normals at this point
-    //! \return vector of normals
-    QVector<QVector3D> getNormals() const;
-
-    //! \brief Reverses the order of normals at this point
-    void reverseNormals();
-
-    //! \brief Reverses the direction of normals at this point
-    void reverseNormalDirections();
-
     //! \brief returns this points with it X,Y, and Z values as a CSV string
     //! \return a string
     QString toCSVString();
@@ -249,9 +235,6 @@ class Point {
     float m_y;
 
     float m_z;
-
-    //! \brief Vector of normals
-    QVector<QVector3D> m_normals;
 
     //! \brief settings to apply at this point. Used in settings polygons/ regions
     QSharedPointer<SettingsBase> m_sb;

--- a/include/geometry/polygon.h
+++ b/include/geometry/polygon.h
@@ -67,17 +67,6 @@ class Polygon : public QVector<Point> {
     //! \brief Rotate the polygon around a specified point
     Polygon rotateAround(const Point& center, const Angle& angle, const QVector3D& axis = {0, 0, 1}) const;
 
-    //! \brief Restores point normals to geometry after it has been modified
-    //! \param all_polys: List of Polygons to retrieve normals from
-    //! \param offset: Whether normals are being restored after an offset operation.
-    //! If true: normals will be restored from the closest point found within all_polys.
-    //! If false: normals will be restored from exact matching point found within all_polys.
-    //! If no exact match can be found, the bisecting normal will be computed and assigned.
-    void restoreNormals(QVector<Polygon> all_polys, bool offset = false);
-
-    //! \brief Reverses the direction of normals for the points of this polygon
-    Polygon reverseNormalDirections();
-
     //! \brief shifts every point in the polygon by the vector
     //! \param vector of direction/length to shift
     Polygon translate(const QVector3D& shift);

--- a/include/geometry/polygon_list.h
+++ b/include/geometry/polygon_list.h
@@ -112,17 +112,6 @@ class PolygonList : public QVector<Polygon> {
      */
     QVector<PolygonList> splitIntoParts(bool unionAll = false) const;
 
-    //! \brief Restores point normals to geometry after it has been modified
-    //! \param all_polys: List of Polygons to retrieve normals from
-    //! \param offset: Whether normals are being restored after an offset operation.
-    //! If true: normals will be restored from the closest point found within all_polys.
-    //! If false: normals will be restored from exact matching point found within all_polys.
-    //! If no exact match can be found, the bisecting normal will be computed and assigned.
-    void restoreNormals(QVector<Polygon> all_polys, bool offset = false);
-
-    //! \brief Reverses the direction of normals for the points of this polygon list
-    PolygonList reverseNormalDirections();
-
   private:
     void splitIntoParts_processPolyTreeNode(ClipperLib2::PolyNode* node, QVector<PolygonList>& ret) const;
 

--- a/src/cross_section/cross_section_object.cpp
+++ b/src/cross_section/cross_section_object.cpp
@@ -185,10 +185,6 @@ PolygonList CrossSectionObject::makePolygons() {
                     (quint64)(possiblePoints[closest].x() * 1000) << 32 | (quint64)(possiblePoints[closest].y() * 1000);
             }
 
-            QVector<QVector3D> normals;
-            normals.push_back(m_segments[endPointHash.value(key)].normal);
-            normals.push_back(m_segments[startPointHash.value(key)].normal);
-            p.setNormals(normals);
         }
     }
 

--- a/src/geometry/point.cpp
+++ b/src/geometry/point.cpp
@@ -3,7 +3,6 @@
 #include <cmath>
 
 #include <clipper.hpp>
-#include <qassert.h>
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qmath.h>
@@ -106,7 +105,6 @@ Point::Point(const Point& p) {
     m_y = p.m_y;
     m_z = p.m_z;
     m_sb = p.m_sb;
-    m_normals = p.m_normals;
 }
 
 Point::Point(const QVector3D& p) {
@@ -157,16 +155,7 @@ Point Point::rotateAround(Point center, Angle angle, QVector3D axis) {
     p -= c;
     p = m * p;
     p += c;
-    Point result = Point::fromQVector3D(p);
-
-    if (!m_normals.isEmpty()) {
-        QVector<QVector3D> normals = m_normals;
-        normals[0] = (m * normals[0]).normalized();
-        normals[1] = (m * normals[1]).normalized();
-        result.setNormals(normals);
-    }
-
-    return result;
+    return Point::fromQVector3D(p);
 }
 
 void Point::moveTowards(const Point& target, const Distance dist) {
@@ -198,9 +187,7 @@ MeshTypes::Kernel::Point_3 Point::toCartesian3D() const { return MeshTypes::Kern
 MeshTypes::Vector_3 Point::toVector_3() const { return MeshTypes::Vector_3(m_x, m_y, m_z); }
 
 Point Point::operator+(const Point& rhs) {
-    Point result = Point(m_x + rhs.m_x, m_y + rhs.m_y, m_z + rhs.m_z);
-    result.setNormals(this->getNormals());
-    return result;
+    return Point(m_x + rhs.m_x, m_y + rhs.m_y, m_z + rhs.m_z);
 }
 
 Point Point::operator+=(const Point& rhs) {
@@ -211,9 +198,7 @@ Point Point::operator+=(const Point& rhs) {
 }
 
 Point Point::operator-(const Point& rhs) {
-    Point result = Point(m_x - rhs.m_x, m_y - rhs.m_y, m_z - rhs.m_z);
-    result.setNormals(this->getNormals());
-    return result;
+    return Point(m_x - rhs.m_x, m_y - rhs.m_y, m_z - rhs.m_z);
 }
 
 Point Point::operator-=(const Point& rhs) {
@@ -224,15 +209,11 @@ Point Point::operator-=(const Point& rhs) {
 }
 
 Point Point::operator*(const float rhs) const {
-    Point result = Point(rhs * m_x, rhs * m_y, rhs * m_z);
-    result.setNormals(this->getNormals());
-    return result;
+    return Point(rhs * m_x, rhs * m_y, rhs * m_z);
 }
 
 Point Point::operator*(const float rhs) {
-    Point result = Point(rhs * m_x, rhs * m_y, rhs * m_z);
-    result.setNormals(this->getNormals());
-    return result;
+    return Point(rhs * m_x, rhs * m_y, rhs * m_z);
 }
 
 Point Point::operator*=(const float rhs) {
@@ -243,9 +224,7 @@ Point Point::operator*=(const float rhs) {
 }
 
 Point Point::operator/(const float rhs) {
-    Point result = Point(m_x / rhs, m_y / rhs, m_z / rhs);
-    result.setNormals(this->getNormals());
-    return result;
+    return Point(m_x / rhs, m_y / rhs, m_z / rhs);
 }
 
 Point Point::operator/=(const float m) {
@@ -292,41 +271,13 @@ void Point::setSettings(QSharedPointer<SettingsBase> sb) { m_sb = sb; }
 
 QSharedPointer<SettingsBase> Point::getSettings() { return m_sb; }
 
-void Point::setNormals(QVector<QVector3D> normals) { m_normals = normals; }
-
-QVector<QVector3D> Point::getNormals() const { return m_normals; }
-
-void Point::reverseNormals() {
-    Q_ASSERT(!m_normals.isEmpty());
-
-    QVector3D temp = m_normals[0];
-    m_normals[0] = m_normals[1];
-    m_normals[1] = temp;
-}
-
-void Point::reverseNormalDirections() {
-    Q_ASSERT(!m_normals.isEmpty());
-
-    m_normals[0] *= -1;
-    m_normals[1] *= -1;
-}
-
 QString Point::toCSVString() {
     return QString(QString::number(m_x) + "," + QString::number(m_y) + "," + QString::number(m_z));
 }
 
 Point operator*(const QMatrix4x4& lhs, const Point& rhs) {
     QVector3D p = rhs.toQVector3D();
-    Point result = Point(lhs * p);
-
-    if (!rhs.getNormals().isEmpty()) {
-        QVector<QVector3D> normals = rhs.getNormals();
-        normals[0] = (lhs * normals[0]).normalized();
-        normals[1] = (lhs * normals[1]).normalized();
-        result.setNormals(normals);
-    }
-
-    return result;
+    return Point(lhs * p);
 }
 
 Point operator*(const float lhs, Point& rhs) { return rhs * lhs; }

--- a/src/geometry/polygon.cpp
+++ b/src/geometry/polygon.cpp
@@ -40,11 +40,7 @@ PolygonList Polygon::offset(const Distance& distance, const ClipperLib2::JoinTyp
     ClipperLib2::ClipperOffset clipper;
     clipper.AddPath(operator()(), joinType, ClipperLib2::etClosedPolygon);
     clipper.Execute(paths, distance());
-    PolygonList polygons(paths);
-
-    polygons.restoreNormals(QVector<Polygon> {*this}, true);
-
-    return polygons;
+    return PolygonList(paths);
 }
 
 int64_t Polygon::polygonLength() const {
@@ -104,71 +100,6 @@ Polygon Polygon::rotateAround(const Point& center, const Angle& rotation_angle, 
         polygon.append(point.rotateAround(center, rotation_angle, axis));
     }
     return polygon;
-}
-
-void Polygon::restoreNormals(QVector<Polygon> all_polys, bool offset) {
-    if (offset) //! Offset operation: assign normals of closest point
-    {
-        for (Point& p1 : *this) {
-            Distance min_dist = Distance(std::numeric_limits<float>::max());
-
-            for (const Polygon& poly : all_polys) {
-                Point p2 = poly.closestPointTo(p1);
-
-                if (p1.distance(p2) < min_dist) {
-                    min_dist = p1.distance(p2);
-                    p1.setNormals(p2.getNormals());
-                }
-            }
-        }
-    }
-    else //! Clipping operation: assign normals of exact point. If point can't be found, compute bisecting normal.
-    {
-        auto index = [](uint i, uint last) {
-            uint ret = i;
-            if (i < 0)
-                ret = last;
-            else if (i > last)
-                ret = 0;
-
-            return ret;
-        };
-
-        for (uint i = 0, size = this->size(); i < size; ++i) {
-            bool found = false;
-            for (Polygon& poly : all_polys) {
-                for (Point& p : poly) {
-                    if ((*this)[i] == p) {
-                        (*this)[i].setNormals(p.getNormals());
-                        found = true;
-                        break;
-                    }
-                }
-                if (found)
-                    break;
-            }
-
-            if (!found) //! Compute bisecting normal
-            {
-                uint last = (*this).size() - 1;
-
-                QVector3D unit_z {0, 0, 1};
-                QVector3D prev = ((*this)[index(i - 1, last)] - (*this)[i]).toQVector3D().normalized();
-                QVector3D next = ((*this)[index(i + 1, last)] - (*this)[i]).toQVector3D().normalized();
-
-                QVector3D normal =
-                    (QVector3D::crossProduct(unit_z, prev) + QVector3D::crossProduct(next, unit_z)).normalized();
-                (*this)[i].setNormals(QVector<QVector3D> {normal, normal});
-            }
-        }
-    }
-}
-
-Polygon Polygon::reverseNormalDirections() {
-    for (Point& point : *this)
-        point.reverseNormalDirections();
-
-    return *this;
 }
 
 Polygon Polygon::translate(const QVector3D& shift) {
@@ -257,79 +188,48 @@ QVector<Polyline> Polygon::getEdges() const {
 }
 
 PolygonList Polygon::operator+(const PolygonList& rhs) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {rhs};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPath((*this)(), ClipperLib2::ptSubject, true);
     clipper.AddPaths(rhs(), ClipperLib2::ptSubject, true);
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList Polygon::operator+(const Polygon& rhs) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {rhs};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPath((*this)(), ClipperLib2::ptSubject, true);
     clipper.AddPath(rhs(), ClipperLib2::ptSubject, true);
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList Polygon::operator-(const PolygonList& other) {
-    QVector<Polygon> all_polys =
-        QVector<Polygon> {*this} + QVector<Polygon> {PolygonList(other).reverseNormalDirections()};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPath((*this)(), ClipperLib2::ptSubject, true);
     clipper.AddPaths(other(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctDifference, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList Polygon::operator-(const Polygon& rhs) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {Polygon(rhs).reverseNormalDirections()};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPath((*this)(), ClipperLib2::ptSubject, true);
     clipper.AddPath(rhs(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctDifference, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList Polygon::operator|(const PolygonList& rhs) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {rhs};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPath((*this)(), ClipperLib2::ptSubject, true);
     clipper.AddPaths(rhs(), ClipperLib2::ptSubject, true);
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList Polygon::operator|(const Polygon& rhs) {
@@ -338,26 +238,16 @@ PolygonList Polygon::operator|(const Polygon& rhs) {
     clipper.AddPath((*this)(), ClipperLib2::ptSubject, true);
     clipper.AddPath(rhs(), ClipperLib2::ptSubject, true);
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals({*this, rhs});
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList Polygon::operator&(const PolygonList& rhs) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {rhs};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPath((*this)(), ClipperLib2::ptSubject, true);
     clipper.AddPaths(rhs(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctIntersection, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList Polygon::operator&(const Polygon& rhs) {
@@ -366,11 +256,7 @@ PolygonList Polygon::operator&(const Polygon& rhs) {
     clipper.AddPath((*this)(), ClipperLib2::ptSubject, true);
     clipper.AddPath(rhs(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctIntersection, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals({*this, rhs});
-
-    return result;
+    return PolygonList(paths);
 }
 
 QVector<Polyline> Polygon::operator&(const Polyline& rhs) {

--- a/src/geometry/polygon_list.cpp
+++ b/src/geometry/polygon_list.cpp
@@ -24,8 +24,6 @@ PolygonList PolygonList::offset(Distance distance, Distance real_offset, Clipper
     clipper.Execute(paths, distance());
     PolygonList polygons(paths);
 
-    polygons.restoreNormals(*this, true);
-
     //! Save any lost geometry
     if (distance() < 0) {
         polygons.lost_geometry = this->lost_geometry;
@@ -36,15 +34,11 @@ PolygonList PolygonList::offset(Distance distance, Distance real_offset, Clipper
         clipper.Execute(paths, real_offset());
         PolygonList original_geometry(paths);
 
-        original_geometry.restoreNormals(*this, true);
-
         paths.clear();
         clipper.Clear();
         clipper.AddPaths(polygons(), joinType, ClipperLib2::etClosedPolygon);
         clipper.Execute(paths, -distance() + 10); //! +10 buffer
         PolygonList reversed_offset_geometry(paths);
-
-        reversed_offset_geometry.restoreNormals(polygons, true);
 
         PolygonList lost_geometry = original_geometry - reversed_offset_geometry;
         polygons.lost_geometry += lost_geometry;
@@ -90,8 +84,6 @@ PolygonList PolygonList::cleanPolygons(const Distance distance) {
             ++it;
     }
 
-    cleaned_polygons.restoreNormals(*this);
-
     return cleaned_polygons;
 }
 
@@ -133,77 +125,7 @@ QVector<PolygonList> PolygonList::splitIntoParts(bool unionAll) const {
 
     splitIntoParts_processPolyTreeNode(&resultPolyTree, result);
 
-    for (PolygonList& poly_list : result)
-        poly_list.restoreNormals(*this);
-
     return result;
-}
-
-void PolygonList::restoreNormals(QVector<Polygon> all_polys, bool offset) {
-    if (offset) //! Offset operation: assign normals of closest point
-    {
-        for (Polygon& subject : *this) {
-            for (Point& p1 : subject) {
-                Distance min_dist = Distance(std::numeric_limits<float>::max());
-
-                for (Polygon& poly : all_polys) {
-                    Point p2 = poly.closestPointTo(p1);
-
-                    if (p1.distance(p2) < min_dist) {
-                        min_dist = p1.distance(p2);
-                        p1.setNormals(p2.getNormals());
-                    }
-                }
-            }
-        }
-    }
-    else //! Clipping operation: assign normals of exact point. If point can't be found, compute bisecting normal.
-    {
-        auto index = [](uint i, uint last) {
-            uint ret = i;
-            if (i > last)
-                ret = 0;
-
-            return ret;
-        };
-
-        for (Polygon& subject : *this) {
-            for (uint i = 0, size = subject.size(); i < size; ++i) {
-                bool found = false;
-                for (Polygon& poly : all_polys) {
-                    for (Point& p : poly) {
-                        if (subject[i] == p) {
-                            subject[i].setNormals(p.getNormals());
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (found)
-                        break;
-                }
-
-                if (!found) //! Compute bisecting normal
-                {
-                    uint last = subject.size() - 1;
-
-                    QVector3D unit_z {0, 0, 1};
-                    QVector3D prev = (subject[index(i - 1, last)] - subject[i]).toQVector3D().normalized();
-                    QVector3D next = (subject[index(i + 1, last)] - subject[i]).toQVector3D().normalized();
-
-                    QVector3D normal =
-                        (QVector3D::crossProduct(unit_z, prev) + QVector3D::crossProduct(next, unit_z)).normalized();
-                    subject[i].setNormals(QVector<QVector3D> {normal, normal});
-                }
-            }
-        }
-    }
-}
-
-PolygonList PolygonList::reverseNormalDirections() {
-    for (Polygon& poly : *this)
-        poly.reverseNormalDirections();
-
-    return *this;
 }
 
 void PolygonList::splitIntoParts_processPolyTreeNode(ClipperLib2::PolyNode* node, QVector<PolygonList>& ret) const {
@@ -440,53 +362,35 @@ ClipperLib2::Paths PolygonList::operator()() const {
 }
 
 PolygonList PolygonList::_add(const Polygon& other) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {other};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
     clipper.AddPath(other(), ClipperLib2::ptSubject, true);
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList PolygonList::_add(const PolygonList& other) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {other};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
     clipper.AddPaths(other(), ClipperLib2::ptSubject, true);
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList PolygonList::_add_to_this(const Polygon& other) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {other};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
     clipper.AddPath(other(), ClipperLib2::ptSubject, true);
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
     clipperLoad(paths);
-
-    restoreNormals(all_polys);
 
     return (*this);
 }
 
 PolygonList PolygonList::_add_to_this(const PolygonList& other) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {other};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
@@ -494,61 +398,39 @@ PolygonList PolygonList::_add_to_this(const PolygonList& other) {
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
     clipperLoad(paths);
 
-    restoreNormals(all_polys);
-
     return (*this);
 }
 
 PolygonList PolygonList::_subtract(const Polygon& other) const {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {Polygon(other).reverseNormalDirections()};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
     clipper.AddPath(other(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctDifference, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList PolygonList::_subtract(const PolygonList& other) const {
-    QVector<Polygon> all_polys =
-        QVector<Polygon> {*this} + QVector<Polygon> {PolygonList(other).reverseNormalDirections()};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
     clipper.AddPaths(other(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctDifference, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList PolygonList::_subtract_from_this(const Polygon& other) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {Polygon(other).reverseNormalDirections()};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
     clipper.AddPath(other(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctDifference, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
     clipperLoad(paths);
-
-    restoreNormals(all_polys);
 
     return (*this);
 }
 
 PolygonList PolygonList::_subtract_from_this(const PolygonList& other) {
-    QVector<Polygon> all_polys =
-        QVector<Polygon> {*this} + QVector<Polygon> {PolygonList(other).reverseNormalDirections()};
-
     ClipperLib2::Paths paths;
     ClipperLib2::Clipper clipper;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
@@ -556,39 +438,25 @@ PolygonList PolygonList::_subtract_from_this(const PolygonList& other) {
     clipper.Execute(ClipperLib2::ctDifference, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
     clipperLoad(paths);
 
-    restoreNormals(all_polys);
-
     return (*this);
 }
 
 PolygonList PolygonList::_intersect(const Polygon& other) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {other};
-
     ClipperLib2::Clipper clipper;
     ClipperLib2::Paths paths;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
     clipper.AddPath(other(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctIntersection, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 PolygonList PolygonList::_intersect(const PolygonList& other) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {other};
-
     ClipperLib2::Clipper clipper;
     ClipperLib2::Paths paths;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
     clipper.AddPaths(other(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctIntersection, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
-    PolygonList result(paths);
-
-    result.restoreNormals(all_polys);
-
-    return result;
+    return PolygonList(paths);
 }
 
 QVector<Polyline> PolygonList::_intersect(const Polyline& polyline) {
@@ -608,8 +476,6 @@ QVector<Polyline> PolygonList::_intersect(const Polyline& polyline) {
 }
 
 PolygonList PolygonList::_intersect_with_this(const Polygon& other) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {other};
-
     ClipperLib2::Clipper clipper;
     ClipperLib2::Paths paths;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
@@ -617,22 +483,16 @@ PolygonList PolygonList::_intersect_with_this(const Polygon& other) {
     clipper.Execute(ClipperLib2::ctIntersection, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
     clipperLoad(paths);
 
-    restoreNormals(all_polys);
-
     return (*this);
 }
 
 PolygonList PolygonList::_intersect_with_this(const PolygonList& other) {
-    QVector<Polygon> all_polys = QVector<Polygon> {*this} + QVector<Polygon> {other};
-
     ClipperLib2::Clipper clipper;
     ClipperLib2::Paths paths;
     clipper.AddPaths(operator()(), ClipperLib2::ptSubject, true);
     clipper.AddPaths(other(), ClipperLib2::ptClip, true);
     clipper.Execute(ClipperLib2::ctIntersection, paths, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
     clipperLoad(paths);
-
-    restoreNormals(all_polys);
 
     return (*this);
 }
@@ -696,8 +556,6 @@ void PolygonList::addAll(QVector<Polygon> polygons) {
         clipper.AddPath(poly.getPath(), ClipperLib2::ptSubject, true);
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftEvenOdd, ClipperLib2::pftEvenOdd);
     clipperLoad(paths);
-
-    restoreNormals(polygons);
 }
 
 QVector<QPolygon> PolygonList::toQPolygons() const {

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -7,7 +7,6 @@
 #include <qsharedpointer.h>
 #include <qtypes.h>
 
-#include "algorithms/knn.h"
 #include "configs/settings_base.h"
 #include "gcode/writers/writer_base.h"
 #include "geometry/path.h"
@@ -27,37 +26,12 @@
 
 namespace ORNL {
 namespace {
-QVector<Point> collectNormalSourcePoints(const PolygonList& geometry) {
-    QVector<Point> points;
-    for (const Polygon& poly : geometry) {
-        for (const Point& point : poly) {
-            points.push_back(point);
-        }
-    }
-
-    return points;
-}
-
-void appendPathLinesWithNormals(PolygonList& path_lines, QVector<Point>& previous_points,
-                                QVector<Polyline>& computed_geometry) {
-    QVector<Point> current_points;
-
+void appendPathLines(PolygonList& path_lines, QVector<Polyline>& computed_geometry) {
     for (Polygon& poly : path_lines) {
-        for (Point& p : poly) {
-            kNN neighbor(previous_points, QVector<Point> {p}, 1);
-            neighbor.execute();
-
-            int closest = neighbor.getNearestIndices().first();
-            p.setNormals(previous_points[closest].getNormals());
-            current_points.push_back(p);
-        }
-
         Polyline line = poly.toPolyline();
         line.pop_back();
         computed_geometry.push_back(line);
     }
-
-    previous_points = current_points;
 }
 
 PolygonList selectedBoundaryOffsetGeometry(const PolygonList& external_boundaries,
@@ -102,14 +76,12 @@ void Perimeter::compute(uint layer_num) {
         static_cast<PerimeterBoundarySelection>(m_sb->setting<int>(PS::Perimeter::kBoundarySelection));
 
     const PolygonList original_geometry = m_geometry;
-    QVector<Point> previous_points = collectNormalSourcePoints(original_geometry);
-
     if (boundary_selection == PerimeterBoundarySelection::kAll) {
         PolygonList path_lines = m_geometry.offset(-beadWidth / 2);
 
         for (int perimeter_number = 0; !path_lines.isEmpty() && perimeter_number < perimeter_count;
              ++perimeter_number) {
-            appendPathLinesWithNormals(path_lines, previous_points, m_computed_geometry);
+            appendPathLines(path_lines, m_computed_geometry);
 
             m_geometry = path_lines.offset(-beadWidth / 2, -beadWidth / 2);
             path_lines = path_lines.offset(-beadWidth, -beadWidth / 2);
@@ -134,7 +106,7 @@ void Perimeter::compute(uint layer_num) {
             break;
         }
 
-        appendPathLinesWithNormals(path_lines, previous_points, m_computed_geometry);
+        appendPathLines(path_lines, m_computed_geometry);
 
         const Distance remaining_offset = beadWidth * (perimeter_number + 1);
         m_geometry = selectedBoundaryOffsetGeometry(external_boundaries, internal_boundaries, boundary_selection,


### PR DESCRIPTION
## Summary

Removes the unused point normal tracking and propagation code left behind after GKN syntax support was removed.


## Related issues

- Depends on #138 


## Details

This refactor removes per-point normal storage from `Point`, along with the helper APIs that copied, reversed, restored, and transformed those normals through polygon operations.

Cross-section polygon creation no longer seeds segment normals into points, and perimeter generation no longer uses KNN to pipe point normals into generated path lines. Polygon and polygon-list clipping, offsetting, union, difference, and intersection operations now return geometry directly without restoring point normals.

Mesh normals, slicing-plane normals, and graphics render-buffer normals remain intact because they still support non-GKN behavior.


## Impact

Risk level: Low to Medium.

The removed code had no remaining consumers after GKN support was removed, so this reduces dead state propagation without changing intended active toolpath behavior. The main residual risk is any hidden external caller expecting `Point` to carry normal metadata.


## Testing strategy

-Built and sliced locallay without issue.
