### PR TITLE
fix(settings): migrate settings files to v3

### DIFF
--- a/include/managers/settings/settings_version_control.h
+++ b/include/managers/settings/settings_version_control.h
@@ -30,5 +30,10 @@ class SettingsVersionControl {
     //! \param version: current version in settings file
     //! \param settings: settings to alter
     static void pre_2_0To2_0(double& version, fifojson& settings);
+
+    //! \brief Rolls settings after deleted, added, and positional enum changes to version 3.0
+    //! \param version: current version in settings file
+    //! \param settings: settings to alter
+    static void pre_3_0To3_0(double& version, fifojson& settings);
 };
 } // namespace ORNL

--- a/resources/configs/versions.conf
+++ b/resources/configs/versions.conf
@@ -1,3 +1,3 @@
 {
-  "master_version": 2.0
+  "master_version": 3.0
 }

--- a/src/managers/settings/settings_version_control.cpp
+++ b/src/managers/settings/settings_version_control.cpp
@@ -1,5 +1,6 @@
 #include "managers/settings/settings_version_control.h"
 
+#include <array>
 #include <list>
 #include <string>
 #include <utility>
@@ -11,12 +12,161 @@
 #include "utilities/constants.h"
 #include "utilities/qt_json_conversion.h"
 
+namespace {
+constexpr int kCincinnatiSyntax = 1;
+constexpr int kThermwoodSyntax = 16;
+constexpr int kPolymerSlicer = 0;
+constexpr int kMetalSlicer = 2;
+constexpr int kAllPerimeterBoundaries = 0;
+
+constexpr std::array<int, 35> kSyntaxV2ToV3 = {
+    0,                // Beam
+    1,                // Cincinnati
+    2,                // Common
+    3,                // Dmg Dmu
+    kCincinnatiSyntax, // GKN removed
+    4,                // Gudel
+    5,                // Haas Inch
+    6,                // Haas Metric
+    7,                // Haas Metric No Comments
+    8,                // Hurco
+    9,                // Ingersoll
+    10,               // Marlin
+    11,               // Marlin Pellet
+    12,               // Mazak
+    13,               // MVP
+    14,               // RomiFanuc
+    kCincinnatiSyntax, // RPBF removed
+    15,               // Siemens
+    kThermwoodSyntax, // SkyBaam removed; concrete templates now use Thermwood
+    16,               // Thermwood
+    17,               // Wolf
+    18,               // RepRap
+    19,               // Mach4
+    20,               // AeroBasic
+    21,               // Meld
+    22,               // ORNL
+    23,               // Okuma
+    24,               // Tormach
+    25,               // AML3D
+    26,               // KraussMaffei
+    27,               // Sandia
+    28,               // 5AxisMarlin
+    29,               // Meltio
+    30,               // Adamantine
+    31                // ORNL Metric
+};
+
+constexpr std::array<int, 7> kSlicerTypeV2ToV3 = {
+    0,              // Polymer
+    1,              // Metal Embossing
+    2,              // Metal
+    kMetalSlicer,   // RPBF removed
+    kPolymerSlicer, // Real Time Polymer removed
+    kMetalSlicer,   // Real Time RPBF removed
+    3               // Image
+};
+
+constexpr std::array<const char*, 47> kRemovedV3Settings = {
+    // GKN syntax settings
+    "base_coordinate",
+    "gkn_laser_power",
+    "gkn_melt_pool",
+    "gkn_print_speed",
+    "gkn_wire_speed",
+    "supports_E1",
+    "supports_E2",
+    "tool_coordinate",
+
+    // RPBF and metal sector settings
+    "clocking_angle",
+    "enable_partition_scheme",
+    "enable_radial_split",
+    "infill_focus",
+    "infill_partition_scheme",
+    "infill_power",
+    "infill_sector_count",
+    "infill_spot_size",
+    "perimeter_focus",
+    "perimeter_power",
+    "perimeter_spot_size",
+    "sector_offsetting_enable",
+    "sector_overlap",
+    "sector_size",
+    "sector_stagger_angle",
+    "sector_stagger_enable",
+
+    // Single path and real-time settings
+    "corner_exclusion_distance",
+    "enable_bridge_exclusion",
+    "enable_single_path",
+    "enable_zippering",
+    "max_bridge_length",
+    "min_bridge_separation",
+    "previous_layer_exclusion_distance",
+
+    // Removed writer/path modifier settings
+    "laser_power_multiplier",
+    "pyrometer_move",
+    "rotation_origin_offset_x",
+    "rotation_origin_offset_y",
+    "wire_feed_multiplier",
+
+    // Wire-feed and anchor settings
+    "anchor_enable",
+    "anchor_height",
+    "anchor_object_distance_left",
+    "anchor_object_distance_right",
+    "anchor_width",
+    "setting_region_mesh_split",
+    "wire_feed_cutoff_distance",
+    "wire_feed_enable",
+    "wire_feed_initial_travel",
+    "wire_feed_prestart_distance",
+    "wire_feed_stickout_distance"
+};
+
+template <std::size_t N>
+void migrateIndexedSetting(fifojson& settings_group, const QString& setting_key, const std::array<int, N>& mapping) {
+    if (!settings_group.is_object())
+        return;
+
+    auto setting = settings_group.find(setting_key.toStdString());
+    if (setting == settings_group.end() || !setting.value().is_number_integer())
+        return;
+
+    int setting_value = setting.value().get<int>();
+    if (setting_value >= 0 && static_cast<std::size_t>(setting_value) < mapping.size())
+        setting.value() = mapping[setting_value];
+}
+
+void removeV2Settings(fifojson& settings_group) {
+    if (!settings_group.is_object())
+        return;
+
+    for (const char* removed_setting : kRemovedV3Settings)
+        settings_group.erase(std::string(removed_setting));
+}
+
+void addV3Settings(fifojson& settings_group) {
+    if (!settings_group.is_object())
+        return;
+
+    const std::string perimeter_boundary_selection =
+        ORNL::Constants::ProfileSettings::Perimeter::kBoundarySelection.toStdString();
+    if (settings_group.find(perimeter_boundary_selection) == settings_group.end())
+        settings_group[perimeter_boundary_selection] = kAllPerimeterBoundaries;
+}
+} // namespace
+
 namespace ORNL {
 void SettingsVersionControl::rollSettingsForward(double& version, fifojson& settings) {
     if (version < 1)
         pre_1_0To1_0(version, settings);
     if (version < 2) // all versions converted to Version 2.0
         pre_2_0To2_0(version, settings);
+    if (version < 3)
+        pre_3_0To3_0(version, settings);
 }
 
 void SettingsVersionControl::formatSettings(double version, fifojson& settings) {
@@ -96,6 +246,28 @@ void SettingsVersionControl::pre_2_0To2_0(double& version, fifojson& settings) {
 
     new_format[Constants::SettingFileStrings::kSettings] = settings_array;
     version = 2.0;
+    settings = new_format;
+}
+
+void SettingsVersionControl::pre_3_0To3_0(double& version, fifojson& settings) {
+    QString dt = QDateTime::currentDateTime().toString();
+    fifojson new_format = settings;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] =
+        dt.toStdString();
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 3.0;
+
+    auto settings_array = new_format.find(Constants::SettingFileStrings::kSettings);
+    if (settings_array != new_format.end() && settings_array.value().is_array()) {
+        for (auto& settings_group : settings_array.value()) {
+            removeV2Settings(settings_group);
+            migrateIndexedSetting(settings_group, Constants::PrinterSettings::MachineSetup::kSyntax, kSyntaxV2ToV3);
+            migrateIndexedSetting(settings_group, Constants::ExperimentalSettings::PrinterConfig::kSlicerType,
+                                  kSlicerTypeV2ToV3);
+            addV3Settings(settings_group);
+        }
+    }
+
+    version = 3.0;
     settings = new_format;
 }
 } // namespace ORNL

--- a/templates/Concrete_2in.s2c
+++ b/templates/Concrete_2in.s2c
@@ -3,7 +3,7 @@
         "created_by": "Alex Roschli",
         "created_on": "Mon Aug 30 09:00:00 2021",
         "last_modified": "Fri Sep 15 11:36:35 2023",
-        "version": 2.0,
+        "version": 3.0,
         "lock": "true"
     },
     "settings": [
@@ -189,6 +189,7 @@
             "minimum_extrude_length": 12700,
             "perimeter": true,
             "perimeter_count": 1,
+            "perimeter_boundary_selection": 0,
             "perimeter_width": 50800,
             "perimeter_speed": 25400,
             "perimeter_extruder_speed": 400,

--- a/templates/Desktop_04mm.s2c
+++ b/templates/Desktop_04mm.s2c
@@ -3,7 +3,7 @@
         "created_by": "Alex Roschli",
         "created_on": "Fri Sep 17 09:10:00 2021",
         "last_modified": "Fri Sep 15 11:36:35 2023",
-        "version": 2.0,
+        "version": 3.0,
         "lock": "true"
     },
     "settings": [
@@ -183,6 +183,7 @@
             "minimum_extrude_length": 2000,
             "perimeter": true,
             "perimeter_count": 1,
+            "perimeter_boundary_selection": 0,
             "perimeter_width": 400,
             "perimeter_speed": 60000,
             "perimeter_extruder_speed": 0,

--- a/templates/LFAM_03in.s2c
+++ b/templates/LFAM_03in.s2c
@@ -3,7 +3,7 @@
         "created_by": "Alex Roschli",
         "created_on": "Mon Aug 30 09:25:00 2021",
         "last_modified": "Tue Jul 9 14:19:57 2024",
-        "version": 2.0,
+        "version": 3.0,
         "lock": "true"
     },
     "settings": [
@@ -179,6 +179,7 @@
             "minimum_extrude_length": 12700,
             "perimeter": true,
             "perimeter_count": 1,
+            "perimeter_boundary_selection": 0,
             "perimeter_width": 8636,
             "perimeter_speed": 279400,
             "perimeter_extruder_speed": 400,

--- a/templates/MFAM_6mm.s2c
+++ b/templates/MFAM_6mm.s2c
@@ -3,7 +3,7 @@
         "created_by": "Alex Roschli",
         "created_on": "Mon Aug 2 09:10:00 2021",
         "last_modified": "Fri Sep 15 11:36:35 2023",
-        "version": 2.0,
+        "version": 3.0,
         "lock": "true"
     },
     "settings": [
@@ -196,6 +196,7 @@
             "minimum_extrude_length": 4000,
             "perimeter": true,
             "perimeter_count": 1,
+            "perimeter_boundary_selection": 0,
             "perimeter_width": 7200,
             "perimeter_speed": 32000,
             "perimeter_extruder_speed": 175,


### PR DESCRIPTION
## Summary

Adds the v3 settings migration path and updates bundled settings templates to the current settings schema.


## Related issues

- Depends on #140 


## Details

This fixes outdated settings files after the v2 settings schema by:
- bumping the master settings version to `3.0`
- mapping old `syntax` and `slicer_type` enum indices to their current values
- removing settings that were deleted by recent slicer, syntax, and pathing cleanup work
- adding the new `perimeter_boundary_selection` setting with the default `All Boundaries` value
- updating bundled `.s2c` templates to version `3.0`


## Impact

Existing v2 settings files can be rolled forward instead of loading stale enum indices or missing new required settings. Risk is low to medium because the change is isolated to settings migration and bundled template metadata, but it affects compatibility with existing user settings files.


## Testing strategy

- Compared old v2 `syntax` and `slicer_type` option ordering against the current settings metadata.
- Verified all bundled `.s2c` templates parse as valid JSON.
- Verified bundled templates report `version=3.0` and include `perimeter_boundary_selection=0`.