### PR TITLE
feat(settings): add composite vector inputs for grouped settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,9 @@ function(CreateSettingsTarget)
 
             message(STATUS "Python interpreter found, enabling automatic master settings generator.")
             add_custom_command(
-                OUTPUT  ${CMAKE_CURRENT_SOURCE_DIR}/resources/configs/master.conf
+                OUTPUT
+                    ${CMAKE_CURRENT_SOURCE_DIR}/resources/configs/master.conf
+                    ${CMAKE_CURRENT_SOURCE_DIR}/resources/configs/setting_inputs.conf
                 DEPENDS
                     ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_master_config.py
                     ${MASTER_SETTING_SOURCES}
@@ -215,9 +217,15 @@ function(CreateSettingsTarget)
                     ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_master_config.py
                     ${CMAKE_CURRENT_SOURCE_DIR}/resources/settings
                     ${CMAKE_CURRENT_SOURCE_DIR}/resources/configs/master.conf
+                    ${CMAKE_CURRENT_SOURCE_DIR}/resources/configs/setting_inputs.conf
                 VERBATIM
             )
-            add_custom_target(generate_master_config DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/resources/configs/master.conf)
+            add_custom_target(
+                generate_master_config
+                DEPENDS
+                    ${CMAKE_CURRENT_SOURCE_DIR}/resources/configs/master.conf
+                    ${CMAKE_CURRENT_SOURCE_DIR}/resources/configs/setting_inputs.conf
+            )
             add_dependencies(${PROJECT_NAME}_obj generate_master_config)
         else()
             message(FATAL_ERROR "Python not found, master settings generator cannot be enabled.")

--- a/docs/wiki/Adding-a-New-User-Setting.md
+++ b/docs/wiki/Adding-a-New-User-Setting.md
@@ -67,7 +67,7 @@ Each setting entry has these fields:
 Run CMake/build, or run the generator directly:
 
 ```bash
-python3 scripts/generate_master_config.py resources/settings resources/configs/master.conf
+python3 scripts/generate_master_config.py resources/settings resources/configs/master.conf resources/configs/setting_inputs.conf
 ```
 
 See [Generating the Master Settings File](Generating-the-Master-Settings-File) for more information.

--- a/docs/wiki/Generating-the-Master-Settings-File.md
+++ b/docs/wiki/Generating-the-Master-Settings-File.md
@@ -4,8 +4,9 @@ The canonical settings metadata lives in `resources/settings/*.yaml`. These file
 the metadata used by the UI, including display name, type, tooltip, dependencies, enum options, default value, category,
 and local-setting support.
 
-`resources/configs/master.conf` is generated from those YAML files and embedded in the application through Qt resources.
-ORNL Slicer still reads `master.conf` at runtime, but it should not be edited by hand.
+`resources/configs/master.conf` and `resources/configs/setting_inputs.conf` are generated from those YAML files and
+embedded in the application through Qt resources. ORNL Slicer still reads the generated config files at runtime, but
+they should not be edited by hand.
 
 To create or edit a setting:
 
@@ -13,12 +14,16 @@ To create or edit a setting:
 2. Run CMake/build, or run the generator directly:
 
    ```bash
-   python3 scripts/generate_master_config.py resources/settings resources/configs/master.conf
+   python3 scripts/generate_master_config.py resources/settings resources/configs/master.conf resources/configs/setting_inputs.conf
    ```
 
-3. Verify that `resources/configs/master.conf` changed as expected.
+3. Verify that the generated files changed as expected.
 
 The generator uses only the Python standard library. It validates duplicate setting names, required fields, setting
-types, enum defaults, enum options, and dependency references.
+types, enum defaults, enum options, dependency references, and grouped input component references.
 
-**DO NOT edit `resources/configs/master.conf` directly.**
+Use a top-level `inputs:` section when scalar settings should be shown as one composite UI row, such as `vector2` or
+`vector3` inputs. Keep each component as a normal setting under `settings:` so saved settings remain flat, and list the
+component setting names under the grouped input.
+
+**DO NOT edit `resources/configs/master.conf` or `resources/configs/setting_inputs.conf` directly.**

--- a/include/managers/settings/settings_manager.h
+++ b/include/managers/settings/settings_manager.h
@@ -38,6 +38,12 @@ class SettingsManager : public QObject {
     //!        for display purposes.
     QSharedPointer<SettingsBase> getMaster() const;
 
+    //! \brief Obtains input metadata used to group scalar settings into composite UI rows.
+    fifojson getSettingInputs() const;
+
+    //! \brief Returns the composite input metadata for a setting key, or null if the key is not grouped.
+    fifojson getSettingInput(const QString& setting_key) const;
+
     // ---- Global Configuration ----
 
     bool loadAllGlobals(QString path);
@@ -182,6 +188,9 @@ class SettingsManager : public QObject {
 
     //! \brief Master settings.
     QSharedPointer<SettingsBase> m_master;
+
+    //! \brief UI input group metadata generated from settings YAML files.
+    fifojson m_setting_inputs;
 
     //! \brief Valid file suffixes for settings files
     QVector<QString> m_validSuffixes;

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -923,6 +923,24 @@ class Constants {
             static const std::string kDependencyGroup;
             static const std::string kLocal;
         };
+        class Input {
+          public:
+            static const std::string kName;
+            static const std::string kDisplay;
+            static const std::string kWidget;
+            static const std::string kToolTip;
+            static const std::string kDepends;
+            static const std::string kMinor;
+            static const std::string kMajor;
+            static const std::string kLocal;
+            static const std::string kComponents;
+            static const std::string kSetting;
+            static const std::string kLabel;
+            static const std::string kType;
+            static const std::string kDefault;
+            static const std::string kVector2;
+            static const std::string kVector3;
+        };
         class Session {
           public:
             static const std::string kParts;
@@ -1003,6 +1021,7 @@ class Constants {
             static const Angle kMaxAngle;
             static const Area kMaxArea;
             static const Voltage kMaxVoltage;
+            static const double kMaxUnitlessFloat;
             static const float kMaxFloat;
             static const float kInfFloat;
         };
@@ -1022,6 +1041,7 @@ class Constants {
             static const Temperature kMinTemperature;
             static const Angle kMinAngle;
             static const Area kMinArea;
+            static const double kMinUnitlessFloat;
             static const float kMinFloat;
         };
     };

--- a/include/widgets/settings/setting_tab.h
+++ b/include/widgets/settings/setting_tab.h
@@ -51,7 +51,7 @@ class SettingTab : public QWidget {
     QList<QSharedPointer<SettingsBase>> m_settings_bases;
 
     //! \brief Adds a row to this tab.
-    void addRow(QString key, fifojson& json);
+    void addRow(QString key, const fifojson& json, const fifojson& input = fifojson());
 
     //! \brief Get all rows in this tab.
     QList<QSharedPointer<SettingRowBase>> getRows();
@@ -147,6 +147,9 @@ class SettingTab : public QWidget {
 
     //! \brief Map of key to input row.
     QHash<QString, QSharedPointer<SettingRowBase>> m_rows;
+
+    //! \brief Alternate keys handled by a composite input row.
+    QHash<QString, QSharedPointer<SettingRowBase>> m_row_aliases;
 
     //! \brief Settings bases this tab uses.
     QSharedPointer<SettingsBase> m_sb;

--- a/include/widgets/settings/vector2_input_widget.h
+++ b/include/widgets/settings/vector2_input_widget.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <array>
+
+#include <QDoubleSpinBox>
+#include <QEvent>
+#include <QGridLayout>
+#include <QSharedPointer>
+#include <QString>
+#include <QVariant>
+#include <QWidget>
+#include <qobject.h>
+#include <qtmetamacros.h>
+
+#include "configs/settings_base.h"
+#include "units/unit.h"
+#include "utilities/qt_json_conversion.h"
+#include "widgets/settings/setting_row_base.h"
+#include "widgets/settings/setting_tab.h"
+
+namespace ORNL {
+class SettingTab;
+
+//! \brief Composite row that edits two distance/location components on one settings line.
+class Vector2InputWidget : public QWidget, public SettingRowBase {
+    Q_OBJECT
+
+  public:
+    Vector2InputWidget(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString primary_key,
+                       QString secondary_key, fifojson json, QGridLayout* layout, int index, Distance primary_default,
+                       Distance secondary_default, QString primary_label = "X", QString secondary_label = "Y");
+
+    //! \brief Hides current row.
+    void hide() override;
+
+    //! \brief Shows current row.
+    void show() override;
+
+    //! \brief Enable/disable row.
+    void setEnabled(bool enabled) override;
+
+  signals:
+    //! \brief Signal emitted when a setting is modified by user.
+    void modified(QString key);
+
+    //! \brief Signal emitted to pass a warning up to the next level.
+    void warnParent(int count);
+
+  public slots:
+    //! \brief Slot to satisfy SettingRowBase; updates the primary setting.
+    void valueChanged(QVariant val) override;
+
+    //! \brief Slot to handle setting reload when user changes units or selects another setting profile.
+    void reloadValue() override;
+
+  protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+    void setNotification(QString msg) override;
+
+    void clearNotification() override;
+
+  private:
+    struct Component {
+        QString key;
+        QDoubleSpinBox* spin_box;
+        Distance default_value;
+    };
+
+    void configureSpinBox(QDoubleSpinBox* spin_box);
+    void ensureSetting(const QString& key, Distance default_value);
+    void updateSetting(const QString& key, double displayed_value);
+    Distance reloadDistanceValue(const QString& key, Distance default_value, bool& consistent);
+    bool areConsistent(const QString& key, QSharedPointer<SettingsBase> a, QSharedPointer<SettingsBase> b,
+                       Distance default_value);
+    Distance effectiveDistanceValue(const QString& key, QSharedPointer<SettingsBase> settings_base,
+                                    Distance default_value);
+    bool hasConsistentEffectiveValues(const QString& key, Distance default_value);
+    bool hasAnyInconsistentValue();
+    void updateWarningStateAfterEdit();
+    void setSpinBoxValue(QDoubleSpinBox* spin_box, const QString& key, Distance default_value,
+                         bool only_if_consistent, bool& consistent);
+
+    std::array<Component, 2> m_components;
+    bool m_warn;
+    int m_precision = 4;
+};
+} // namespace ORNL

--- a/include/widgets/settings/vector3_input_widget.h
+++ b/include/widgets/settings/vector3_input_widget.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <array>
+
+#include <QDoubleSpinBox>
+#include <QEvent>
+#include <QGridLayout>
+#include <QSharedPointer>
+#include <QString>
+#include <QVariant>
+#include <QWidget>
+#include <qobject.h>
+#include <qtmetamacros.h>
+
+#include "configs/settings_base.h"
+#include "utilities/qt_json_conversion.h"
+#include "widgets/settings/setting_row_base.h"
+#include "widgets/settings/setting_tab.h"
+
+namespace ORNL {
+class SettingTab;
+
+//! \brief Composite row that edits three unitless vector components on one settings line.
+class Vector3InputWidget : public QWidget, public SettingRowBase {
+    Q_OBJECT
+
+  public:
+    Vector3InputWidget(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString primary_key, QString secondary_key,
+                       QString tertiary_key, fifojson json, QGridLayout* layout, int index, double primary_default,
+                       double secondary_default, double tertiary_default, QString primary_label = "X",
+                       QString secondary_label = "Y", QString tertiary_label = "Z");
+
+    //! \brief Hides current row.
+    void hide() override;
+
+    //! \brief Shows current row.
+    void show() override;
+
+    //! \brief Enable/disable row.
+    void setEnabled(bool enabled) override;
+
+  signals:
+    //! \brief Signal emitted when a setting is modified by user.
+    void modified(QString key);
+
+    //! \brief Signal emitted to pass a warning up to the next level.
+    void warnParent(int count);
+
+  public slots:
+    //! \brief Slot to satisfy SettingRowBase; updates the primary setting.
+    void valueChanged(QVariant val) override;
+
+    //! \brief Slot to handle setting reload when user selects another setting profile.
+    void reloadValue() override;
+
+  protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+    void setNotification(QString msg) override;
+
+    void clearNotification() override;
+
+  private:
+    struct Component {
+        QString key;
+        QDoubleSpinBox* spin_box;
+        double default_value;
+    };
+
+    void configureSpinBox(QDoubleSpinBox* spin_box);
+    void ensureSetting(const QString& key, double default_value);
+    void updateSetting(const QString& key, double value);
+    double reloadDoubleValue(const QString& key, double default_value, bool& consistent);
+    bool areConsistent(const QString& key, QSharedPointer<SettingsBase> a, QSharedPointer<SettingsBase> b,
+                       double default_value);
+    double effectiveDoubleValue(const QString& key, QSharedPointer<SettingsBase> settings_base, double default_value);
+    bool hasConsistentEffectiveValues(const QString& key, double default_value);
+    bool hasAnyInconsistentValue();
+    void updateWarningStateAfterEdit();
+    void setSpinBoxValue(QDoubleSpinBox* spin_box, const QString& key, double default_value, bool only_if_consistent,
+                         bool& consistent);
+
+    std::array<Component, 3> m_components;
+    bool m_warn;
+    int m_precision = 4;
+};
+} // namespace ORNL

--- a/resources/configs/configs.qrc
+++ b/resources/configs/configs.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/configs">
         <file>master.conf</file>
+        <file>setting_inputs.conf</file>
         <file>versions.conf</file>
     </qresource>
     <qresource prefix="/"/>

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -3420,9 +3420,15 @@
   },
   "radial_axis_x": {
       "display":"Radial Axis X",
+<<<<<<< HEAD
       "type":"distance",
       "tooltip":"X coordinate for the radial cylinder or helical axis when Radial Axis Mode is Custom XY.",
       "depends":{"AND":[{"OR":[{"slicer_type":2},{"slicer_type":3}]},{"radial_axis_mode":1}]},
+=======
+      "type":"location",
+      "tooltip":"X coordinate for the radial cylinder axis when Radial Axis Mode is Custom XY.",
+      "depends":{"AND":[{"slicer_type":2},{"radial_axis_mode":1}]},
+>>>>>>> bf798247 (feat(settings): enhance user settings management with composite input support)
       "options":"",
       "default":0,
       "minor":"Slicing",
@@ -3433,7 +3439,7 @@
   },
   "radial_axis_y": {
       "display":"Radial Axis Y",
-      "type":"distance",
+      "type":"location",
       "tooltip":"Y coordinate for the radial cylinder or helical axis when Radial Axis Mode is Custom XY.",
       "depends":{"AND":[{"OR":[{"slicer_type":2},{"slicer_type":3}]},{"radial_axis_mode":1}]},
       "options":"",

--- a/resources/configs/setting_inputs.conf
+++ b/resources/configs/setting_inputs.conf
@@ -1,0 +1,65 @@
+{
+  "radial_axis": {
+    "name": "radial_axis",
+    "display": "Radial Axis",
+    "widget": "vector2",
+    "tooltip": "Defines the custom XY coordinate used as the radial cylinder axis when Radial Axis Mode is Custom XY.",
+    "depends": {
+      "AND": [
+        {
+          "slicer_type": 2
+        },
+        {
+          "radial_axis_mode": 1
+        }
+      ]
+    },
+    "minor": "Slicing",
+    "major": "Profile",
+    "local": true,
+    "components": [
+      {
+        "setting": "radial_axis_x",
+        "label": "X",
+        "type": "location",
+        "default": 0
+      },
+      {
+        "setting": "radial_axis_y",
+        "label": "Y",
+        "type": "location",
+        "default": 0
+      }
+    ]
+  },
+  "slicing_vector": {
+    "name": "slicing_vector",
+    "display": "Slicing Vector",
+    "widget": "vector3",
+    "tooltip": "Defines the slicing vector used as the slicing plane normal. Values are normalized before use; {0, 0, 1} produces horizontal XY layers, while tilted vectors produce angled slicing planes.",
+    "depends": "",
+    "minor": "Slicing",
+    "major": "Profile",
+    "local": false,
+    "components": [
+      {
+        "setting": "slicing_vector_x",
+        "label": "X",
+        "type": "unitless_float",
+        "default": 0
+      },
+      {
+        "setting": "slicing_vector_y",
+        "label": "Y",
+        "type": "unitless_float",
+        "default": 0
+      },
+      {
+        "setting": "slicing_vector_z",
+        "label": "Z",
+        "type": "unitless_float",
+        "default": 1
+      }
+    ]
+  }
+}

--- a/resources/settings/019_profile_slicing.yaml
+++ b/resources/settings/019_profile_slicing.yaml
@@ -33,7 +33,7 @@ settings:
     local: true
   - name: "radial_axis_x"
     display: "Radial Axis X"
-    type: "distance"
+    type: "location"
     tooltip: "X coordinate for the radial cylinder or helical axis when Radial Axis Mode is Custom XY."
     depends: {"AND":[{"OR":[{"slicer_type":2},{"slicer_type":3}]},{"radial_axis_mode":1}]}
     options: []
@@ -45,7 +45,7 @@ settings:
     local: true
   - name: "radial_axis_y"
     display: "Radial Axis Y"
-    type: "distance"
+    type: "location"
     tooltip: "Y coordinate for the radial cylinder or helical axis when Radial Axis Mode is Custom XY."
     depends: {"AND":[{"OR":[{"slicer_type":2},{"slicer_type":3}]},{"radial_axis_mode":1}]}
     options: []
@@ -118,3 +118,30 @@ settings:
     namespace: "Profile::Slicing"
     symbol: "kSlicingVectorZ"
     local: false
+inputs:
+  - name: "radial_axis"
+    display: "Radial Axis"
+    widget: "vector2"
+    tooltip: "Defines the custom XY coordinate used as the radial cylinder axis when Radial Axis Mode is Custom XY."
+    depends: {"AND":[{"slicer_type":2},{"radial_axis_mode":1}]}
+    minor: "Slicing"
+    major: "Profile"
+    components:
+      - setting: "radial_axis_x"
+        label: "X"
+      - setting: "radial_axis_y"
+        label: "Y"
+  - name: "slicing_vector"
+    display: "Slicing Vector"
+    widget: "vector3"
+    tooltip: "Defines the slicing vector used as the slicing plane normal. Values are normalized before use; {0, 0, 1} produces horizontal XY layers, while tilted vectors produce angled slicing planes."
+    depends: {}
+    minor: "Slicing"
+    major: "Profile"
+    components:
+      - setting: "slicing_vector_x"
+        label: "X"
+      - setting: "slicing_vector_y"
+        label: "Y"
+      - setting: "slicing_vector_z"
+        label: "Z"

--- a/resources/settings/README.md
+++ b/resources/settings/README.md
@@ -1,10 +1,10 @@
 # Settings Metadata
 
 These YAML files are the canonical source for ORNL Slicer setting metadata. Edit these files, then regenerate
-`resources/configs/master.conf`:
+`resources/configs/master.conf` and `resources/configs/setting_inputs.conf`:
 
 ```bash
-python3 scripts/generate_master_config.py resources/settings resources/configs/master.conf
+python3 scripts/generate_master_config.py resources/settings resources/configs/master.conf resources/configs/setting_inputs.conf
 ```
 
 Files are loaded in sorted path order. Settings inside each file are emitted in file order, which controls the order in
@@ -13,3 +13,7 @@ the generated master settings file and UI.
 The generator intentionally supports a small YAML subset and uses only the Python standard library. Keep scalar field
 values on one line, use JSON-style values for dependency objects, and use either `options: []` or a block list for enum
 options.
+
+Grouped UI controls live in an optional top-level `inputs:` section. Use those entries to group existing scalar settings
+into composite rows such as `vector2` and `vector3` without making one component setting carry the display name and
+tooltip for the whole group.

--- a/scripts/generate_master_config.py
+++ b/scripts/generate_master_config.py
@@ -31,6 +31,25 @@ REQUIRED_FIELDS = (
 
 OPTIONAL_FIELDS = ("name",)
 
+INPUT_REQUIRED_FIELDS = (
+    "display",
+    "widget",
+    "tooltip",
+    "depends",
+    "minor",
+    "major",
+    "components",
+)
+
+INPUT_OPTIONAL_FIELDS = ("name",)
+
+INPUT_COMPONENT_FIELDS = ("setting", "label")
+
+VALID_INPUT_WIDGETS = {
+    "vector2",
+    "vector3",
+}
+
 VALID_TYPES = {
     "accel",
     "angle",
@@ -87,60 +106,124 @@ def parse_scalar(value: str, path: Path, line_number: int) -> Any:
         return value
 
 
-def parse_settings_file(path: Path) -> list[OrderedDict[str, Any]]:
+def parse_field(field_line: str, path: Path, line_number: int) -> tuple[str, str]:
+    if ":" not in field_line:
+        raise ValueError(f"{path}:{line_number}: expected 'key: value' field")
+
+    key, value = field_line.split(":", 1)
+    return key.strip(), value
+
+
+def parse_settings_file(path: Path) -> tuple[list[OrderedDict[str, Any]], list[OrderedDict[str, Any]]]:
     settings: list[OrderedDict[str, Any]] = []
-    current: OrderedDict[str, Any] | None = None
-    saw_header = False
+    inputs: list[OrderedDict[str, Any]] = []
+    current_setting: OrderedDict[str, Any] | None = None
+    current_input: OrderedDict[str, Any] | None = None
+    current_component: OrderedDict[str, Any] | None = None
+    section: str | None = None
+    saw_settings = False
     active_list_key: str | None = None
 
     for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         if not raw_line.strip() or raw_line.lstrip().startswith("#"):
             continue
 
-        if active_list_key is not None and raw_line.startswith("      - "):
-            current[active_list_key].append(parse_scalar(raw_line[len("      - ") :], path, line_number))
+        if raw_line == "settings:":
+            section = "settings"
+            saw_settings = True
+            active_list_key = None
             continue
+
+        if raw_line == "inputs:":
+            section = "inputs"
+            active_list_key = None
+            continue
+
+        if section is None:
+            raise ValueError(f"{path}:{line_number}: expected top-level 'settings:' key")
+
+        if section == "settings":
+            if active_list_key == "options" and raw_line.startswith("      - "):
+                current_setting[active_list_key].append(parse_scalar(raw_line[len("      - ") :], path, line_number))
+                continue
+
+            active_list_key = None
+
+            if raw_line.startswith("  - name: "):
+                current_setting = OrderedDict()
+                current_setting["name"] = parse_scalar(raw_line[len("  - name: ") :], path, line_number)
+                settings.append(current_setting)
+                continue
+
+            if current_setting is None:
+                raise ValueError(f"{path}:{line_number}: setting fields must follow '- name:'")
+
+            if not raw_line.startswith("    "):
+                raise ValueError(f"{path}:{line_number}: expected 4-space-indented setting field")
+
+            field_line = raw_line[4:]
+            key, value = parse_field(field_line, path, line_number)
+            if key in current_setting:
+                raise ValueError(f"{path}:{line_number}: duplicate field '{key}'")
+
+            if value.strip() == "" and key == "options":
+                current_setting[key] = []
+                active_list_key = key
+            else:
+                current_setting[key] = parse_scalar(value, path, line_number)
+            continue
+
+        if active_list_key == "components":
+            if raw_line.startswith("      - "):
+                component = OrderedDict()
+                key, value = parse_field(raw_line[len("      - ") :], path, line_number)
+                component[key] = parse_scalar(value, path, line_number)
+                current_input[active_list_key].append(component)
+                current_component = component
+                continue
+
+            if raw_line.startswith("        "):
+                if current_component is None:
+                    raise ValueError(f"{path}:{line_number}: component fields must follow '- setting:'")
+
+                key, value = parse_field(raw_line[8:], path, line_number)
+                if key in current_component:
+                    raise ValueError(f"{path}:{line_number}: duplicate component field '{key}'")
+
+                current_component[key] = parse_scalar(value, path, line_number)
+                continue
 
         active_list_key = None
 
-        if raw_line == "settings:":
-            saw_header = True
-            continue
-
         if raw_line.startswith("  - name: "):
-            current = OrderedDict()
-            current["name"] = parse_scalar(raw_line[len("  - name: ") :], path, line_number)
-            settings.append(current)
+            current_input = OrderedDict()
+            current_input["name"] = parse_scalar(raw_line[len("  - name: ") :], path, line_number)
+            inputs.append(current_input)
+            current_component = None
             continue
 
-        if not saw_header:
-            raise ValueError(f"{path}:{line_number}: expected top-level 'settings:' key")
-
-        if current is None:
-            raise ValueError(f"{path}:{line_number}: setting fields must follow '- name:'")
+        if current_input is None:
+            raise ValueError(f"{path}:{line_number}: input fields must follow '- name:'")
 
         if not raw_line.startswith("    "):
-            raise ValueError(f"{path}:{line_number}: expected 4-space-indented setting field")
+            raise ValueError(f"{path}:{line_number}: expected 4-space-indented input field")
 
         field_line = raw_line[4:]
-        if ":" not in field_line:
-            raise ValueError(f"{path}:{line_number}: expected 'key: value' field")
-
-        key, value = field_line.split(":", 1)
-        key = key.strip()
-        if key in current:
+        key, value = parse_field(field_line, path, line_number)
+        if key in current_input:
             raise ValueError(f"{path}:{line_number}: duplicate field '{key}'")
 
-        if value.strip() == "" and key == "options":
-            current[key] = []
+        if value.strip() == "" and key == "components":
+            current_input[key] = []
             active_list_key = key
+            current_component = None
         else:
-            current[key] = parse_scalar(value, path, line_number)
+            current_input[key] = parse_scalar(value, path, line_number)
 
-    if not saw_header:
+    if not saw_settings:
         raise ValueError(f"{path}: missing top-level 'settings:' key")
 
-    return settings
+    return settings, inputs
 
 
 def dependency_is_empty(depends: Any) -> bool:
@@ -217,6 +300,76 @@ def validate_setting(setting: OrderedDict[str, Any], setting_names: set[str]) ->
     validate_dependency(setting["depends"], setting_names, name)
 
 
+def validate_input(setting_input: OrderedDict[str, Any], settings_by_name: OrderedDict[str, OrderedDict[str, Any]],
+                   used_components: set[str]) -> None:
+    name = setting_input.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("input is missing non-empty name")
+
+    valid_fields = set(INPUT_REQUIRED_FIELDS) | set(INPUT_OPTIONAL_FIELDS)
+    unknown_fields = sorted(set(setting_input) - valid_fields)
+    if unknown_fields:
+        raise ValueError(f"{name}: unknown input fields: {', '.join(unknown_fields)}")
+
+    missing_fields = [field for field in INPUT_REQUIRED_FIELDS if field not in setting_input]
+    if missing_fields:
+        raise ValueError(f"{name}: missing input fields: {', '.join(missing_fields)}")
+
+    widget = setting_input["widget"]
+    if widget not in VALID_INPUT_WIDGETS:
+        raise ValueError(f"{name}: unknown input widget '{widget}'")
+
+    components = setting_input["components"]
+    if not isinstance(components, list):
+        raise ValueError(f"{name}: components must be a list")
+
+    expected_count = 2 if widget == "vector2" else 3
+    if len(components) != expected_count:
+        raise ValueError(f"{name}: {widget} inputs must define exactly {expected_count} components")
+
+    validate_dependency(setting_input["depends"], set(settings_by_name), name)
+
+    component_settings: list[str] = []
+    for component in components:
+        unknown_component_fields = sorted(set(component) - set(INPUT_COMPONENT_FIELDS))
+        if unknown_component_fields:
+            raise ValueError(f"{name}: unknown component fields: {', '.join(unknown_component_fields)}")
+
+        missing_component_fields = [field for field in INPUT_COMPONENT_FIELDS if field not in component]
+        if missing_component_fields:
+            raise ValueError(f"{name}: component missing fields: {', '.join(missing_component_fields)}")
+
+        setting_name = component["setting"]
+        if setting_name not in settings_by_name:
+            raise ValueError(f"{name}: component references unknown setting '{setting_name}'")
+        if setting_name in used_components:
+            raise ValueError(f"{name}: setting '{setting_name}' is already used by another input")
+        if not isinstance(component["label"], str) or not component["label"]:
+            raise ValueError(f"{name}: component label must be a non-empty string")
+
+        component_settings.append(setting_name)
+        used_components.add(setting_name)
+
+    majors = {settings_by_name[setting]["major"] for setting in component_settings}
+    minors = {settings_by_name[setting]["minor"] for setting in component_settings}
+    locals_ = {settings_by_name[setting]["local"] for setting in component_settings}
+    if majors != {setting_input["major"]}:
+        raise ValueError(f"{name}: input major must match all component settings")
+    if minors != {setting_input["minor"]}:
+        raise ValueError(f"{name}: input minor must match all component settings")
+    if len(locals_) != 1:
+        raise ValueError(f"{name}: all components must have the same local value")
+
+    component_types = [settings_by_name[setting]["type"] for setting in component_settings]
+    if widget == "vector2":
+        if any(component_type not in {"distance", "location"} for component_type in component_types):
+            raise ValueError(f"{name}: vector2 components must be distance or location settings")
+        if len(set(component_types)) != 1:
+            raise ValueError(f"{name}: vector2 components must share the same setting type")
+    elif any(component_type != "unitless_float" for component_type in component_types):
+        raise ValueError(f"{name}: vector3 components must be unitless_float settings")
+
+
 def normalize_for_master(setting: OrderedDict[str, Any]) -> OrderedDict[str, Any]:
     entry = OrderedDict()
     for field in REQUIRED_FIELDS:
@@ -229,14 +382,49 @@ def normalize_for_master(setting: OrderedDict[str, Any]) -> OrderedDict[str, Any
     return entry
 
 
-def load_settings(source_dir: Path) -> OrderedDict[str, OrderedDict[str, Any]]:
+def normalize_input_for_config(setting_input: OrderedDict[str, Any],
+                               settings_by_name: OrderedDict[str, OrderedDict[str, Any]]) -> OrderedDict[str, Any]:
+    entry = OrderedDict()
+    entry["name"] = setting_input["name"]
+    for field in INPUT_REQUIRED_FIELDS:
+        if field == "components":
+            continue
+
+        value = setting_input[field]
+        if field == "depends" and dependency_is_empty(value):
+            value = ""
+        entry[field] = value
+
+    component_settings = [component["setting"] for component in setting_input["components"]]
+    entry["local"] = settings_by_name[component_settings[0]]["local"]
+    entry["components"] = []
+    for component in setting_input["components"]:
+        setting = settings_by_name[component["setting"]]
+        entry["components"].append(
+            OrderedDict(
+                (
+                    ("setting", component["setting"]),
+                    ("label", component["label"]),
+                    ("type", setting["type"]),
+                    ("default", setting["default"]),
+                )
+            )
+        )
+
+    return entry
+
+
+def load_settings(source_dir: Path) -> tuple[OrderedDict[str, OrderedDict[str, Any]], OrderedDict[str, OrderedDict[str, Any]]]:
     paths = sorted(source_dir.rglob("*.yaml"))
     if not paths:
         raise ValueError(f"{source_dir}: no .yaml settings files found")
 
     raw_settings: list[OrderedDict[str, Any]] = []
+    raw_inputs: list[OrderedDict[str, Any]] = []
     for path in paths:
-        raw_settings.extend(parse_settings_file(path))
+        settings, inputs = parse_settings_file(path)
+        raw_settings.extend(settings)
+        raw_inputs.extend(inputs)
 
     names = [setting["name"] for setting in raw_settings]
     duplicates = sorted({name for name in names if names.count(name) > 1})
@@ -249,7 +437,18 @@ def load_settings(source_dir: Path) -> OrderedDict[str, OrderedDict[str, Any]]:
         validate_setting(setting, setting_names)
         master[setting["name"]] = normalize_for_master(setting)
 
-    return master
+    input_names = [setting_input["name"] for setting_input in raw_inputs]
+    duplicate_inputs = sorted({name for name in input_names if input_names.count(name) > 1})
+    if duplicate_inputs:
+        raise ValueError(f"duplicate input names: {', '.join(duplicate_inputs)}")
+
+    used_components: set[str] = set()
+    setting_inputs: OrderedDict[str, OrderedDict[str, Any]] = OrderedDict()
+    for setting_input in raw_inputs:
+        validate_input(setting_input, master, used_components)
+        setting_inputs[setting_input["name"]] = normalize_input_for_config(setting_input, master)
+
+    return master, setting_inputs
 
 
 def write_master(master: OrderedDict[str, OrderedDict[str, Any]], destination: Path) -> None:
@@ -271,14 +470,23 @@ def write_master(master: OrderedDict[str, OrderedDict[str, Any]], destination: P
         output.write("\n}")
 
 
+def write_setting_inputs(setting_inputs: OrderedDict[str, OrderedDict[str, Any]], destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8", newline="\n") as output:
+        json.dump(setting_inputs, output, indent=2, separators=(",", ": "), ensure_ascii=True)
+        output.write("\n")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("source_dir", type=Path, help="Directory containing split settings .yaml files")
     parser.add_argument("destination", type=Path, help="Generated master.conf destination")
+    parser.add_argument("inputs_destination", type=Path, help="Generated setting_inputs.conf destination")
     args = parser.parse_args()
 
-    master = load_settings(args.source_dir)
+    master, setting_inputs = load_settings(args.source_dir)
     write_master(master, args.destination)
+    write_setting_inputs(setting_inputs, args.inputs_destination)
 
 
 if __name__ == "__main__":

--- a/src/managers/settings/settings_manager.cpp
+++ b/src/managers/settings/settings_manager.cpp
@@ -44,6 +44,16 @@ SettingsManager::SettingsManager() : m_global(new SettingsBase()), m_master(new 
 
     QString master_data = master_file.readAll();
     m_master->json(json::parse(master_data.toStdString()));
+
+    QFile setting_inputs_file(":/configs/setting_inputs.conf");
+    if (setting_inputs_file.open(QIODevice::ReadOnly)) {
+        QString input_data = setting_inputs_file.readAll();
+        m_setting_inputs = input_data.isEmpty() ? fifojson::object() : json::parse(input_data.toStdString());
+    }
+    else {
+        m_setting_inputs = fifojson::object();
+    }
+
     for (auto& el : m_master->json().items()) {
         if (!m_allGlobals.contains(QString::fromStdString(el.value()[Constants::Settings::Master::kMajor]))) {
             m_allGlobals.insert(QString::fromStdString(el.value()[Constants::Settings::Master::kMajor]),
@@ -65,6 +75,20 @@ SettingsManager::SettingsManager() : m_global(new SettingsBase()), m_master(new 
 }
 
 QSharedPointer<SettingsBase> SettingsManager::getMaster() const { return m_master; }
+
+fifojson SettingsManager::getSettingInputs() const { return m_setting_inputs; }
+
+fifojson SettingsManager::getSettingInput(const QString& setting_key) const {
+    for (auto& input : m_setting_inputs.items()) {
+        for (auto& component : input.value().at(Constants::Settings::Input::kComponents).items()) {
+            if (QString::fromStdString(component.value().at(Constants::Settings::Input::kSetting).get<std::string>()) ==
+                setting_key)
+                return input.value();
+        }
+    }
+
+    return fifojson();
+}
 
 bool SettingsManager::loadGlobalJson(QString path) {
 

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -842,6 +842,23 @@ const std::string Constants::Settings::Master::kDefault = "default";
 const std::string Constants::Settings::Master::kDependencyGroup = "dependency_group";
 const std::string Constants::Settings::Master::kLocal = "local";
 
+// Input
+const std::string Constants::Settings::Input::kName = "name";
+const std::string Constants::Settings::Input::kDisplay = "display";
+const std::string Constants::Settings::Input::kWidget = "widget";
+const std::string Constants::Settings::Input::kToolTip = "tooltip";
+const std::string Constants::Settings::Input::kDepends = "depends";
+const std::string Constants::Settings::Input::kMinor = "minor";
+const std::string Constants::Settings::Input::kMajor = "major";
+const std::string Constants::Settings::Input::kLocal = "local";
+const std::string Constants::Settings::Input::kComponents = "components";
+const std::string Constants::Settings::Input::kSetting = "setting";
+const std::string Constants::Settings::Input::kLabel = "label";
+const std::string Constants::Settings::Input::kType = "type";
+const std::string Constants::Settings::Input::kDefault = "default";
+const std::string Constants::Settings::Input::kVector2 = "vector2";
+const std::string Constants::Settings::Input::kVector3 = "vector3";
+
 // Session
 const std::string Constants::Settings::Session::kParts = "parts";
 const std::string Constants::Settings::Session::kName = "name";
@@ -902,6 +919,7 @@ const Temperature Constants::Limits::Maximums::kMaxTemperature = std::numeric_li
 const Angle Constants::Limits::Maximums::kMaxAngle = 2 * pi;
 const Area Constants::Limits::Maximums::kMaxArea = std::numeric_limits<float>::max();
 const Voltage Constants::Limits::Maximums::kMaxVoltage = std::numeric_limits<float>::max();
+const double Constants::Limits::Maximums::kMaxUnitlessFloat = 9999.99;
 const float Constants::Limits::Maximums::kMaxFloat = std::numeric_limits<float>::max();
 const float Constants::Limits::Maximums::kInfFloat = std::numeric_limits<float>::infinity();
 
@@ -915,6 +933,7 @@ const Time Constants::Limits::Minimums::kMinTime = std::numeric_limits<float>::l
 const Temperature Constants::Limits::Minimums::kMinTemperature = std::numeric_limits<float>::lowest();
 const Angle Constants::Limits::Minimums::kMinAngle = -2 * pi;
 const Area Constants::Limits::Minimums::kMinArea = std::numeric_limits<float>::lowest();
+const double Constants::Limits::Minimums::kMinUnitlessFloat = -9999.99;
 const float Constants::Limits::Minimums::kMinFloat = std::numeric_limits<float>::lowest();
 
 //================================================================================

--- a/src/widgets/settings/setting_bar.cpp
+++ b/src/widgets/settings/setting_bar.cpp
@@ -441,8 +441,9 @@ void SettingBar::setupGlobalSettings() {
         SettingTab* curr_tab = this->getTab(curr_json[Constants::Settings::Master::kMajor],
                                             curr_json[Constants::Settings::Master::kMinor]);
         QString key = QString::fromStdString(it.key());
+        fifojson input_json = GSM->getSettingInput(key);
 
-        curr_tab->addRow(key, curr_json);
+        curr_tab->addRow(key, curr_json, input_json);
     }
     enableDependRows();
 

--- a/src/widgets/settings/setting_double_spin_box.cpp
+++ b/src/widgets/settings/setting_double_spin_box.cpp
@@ -51,8 +51,8 @@ SettingDoubleSpinBox::SettingDoubleSpinBox(SettingTab* parent, QSharedPointer<Se
         unitText = "%";
     }
     else if (type == "unitless_float") {
-        this->setMinimum(-9999.99);
-        this->setMaximum(9999.99);
+        this->setMinimum(Constants::Limits::Minimums::kMinUnitlessFloat);
+        this->setMaximum(Constants::Limits::Maximums::kMaxUnitlessFloat);
         this->setDecimals(m_precision);
     }
 

--- a/src/widgets/settings/setting_tab.cpp
+++ b/src/widgets/settings/setting_tab.cpp
@@ -1,5 +1,7 @@
 #include "widgets/settings/setting_tab.h"
 
+#include <cstddef>
+
 #include <qboxlayout.h>
 #include <qframe.h>
 #include <qgridlayout.h>
@@ -32,8 +34,32 @@
 #include "widgets/settings/setting_plain_text_edit.h"
 #include "widgets/settings/setting_row_base.h"
 #include "widgets/settings/setting_spin_box.h"
+#include "widgets/settings/vector2_input_widget.h"
+#include "widgets/settings/vector3_input_widget.h"
 
 namespace ORNL {
+namespace {
+QString jsonString(const fifojson& object, const std::string& key) {
+    return QString::fromStdString(object.at(key).get<std::string>());
+}
+
+QString componentSetting(const fifojson& component) {
+    return jsonString(component, Constants::Settings::Input::kSetting);
+}
+
+QString componentLabel(const fifojson& component) { return jsonString(component, Constants::Settings::Input::kLabel); }
+
+fifojson makeInputRowJson(const fifojson& setting_json, const fifojson& input) {
+    fifojson row_json = setting_json;
+    row_json[Constants::Settings::Master::kDisplay] = input.at(Constants::Settings::Input::kDisplay);
+    row_json[Constants::Settings::Master::kToolTip] = input.at(Constants::Settings::Input::kToolTip);
+    row_json[Constants::Settings::Master::kDepends] = input.at(Constants::Settings::Input::kDepends);
+    row_json[Constants::Settings::Master::kMinor] = input.at(Constants::Settings::Input::kMinor);
+    row_json[Constants::Settings::Master::kMajor] = input.at(Constants::Settings::Input::kMajor);
+    row_json[Constants::Settings::Master::kLocal] = input.at(Constants::Settings::Input::kLocal);
+    return row_json;
+}
+} // namespace
 
 SettingTab::SettingTab(QWidget* parent, QString name, QIcon icon, int index, bool isHidden,
                        QSharedPointer<SettingsBase> sb)
@@ -78,13 +104,58 @@ void SettingTab::setSettingBase(QSharedPointer<SettingsBase> sb) {
 
 QList<QSharedPointer<SettingRowBase>> SettingTab::getRows() { return m_rows.values(); }
 
-QSharedPointer<SettingRowBase> SettingTab::getRow(QString key) { return m_rows[key]; }
+QSharedPointer<SettingRowBase> SettingTab::getRow(QString key) {
+    if (m_rows.contains(key))
+        return m_rows[key];
+
+    return m_row_aliases.value(key);
+}
 
 int SettingTab::getIndex() { return m_index; }
 
 QString SettingTab::getName() { return m_name; }
 
-void SettingTab::addRow(QString key, fifojson& json) {
+void SettingTab::addRow(QString key, const fifojson& json, const fifojson& input) {
+    if (m_row_aliases.contains(key))
+        return;
+
+    if (!input.is_null()) {
+        const fifojson& components = input.at(Constants::Settings::Input::kComponents);
+        const QString primary_key = componentSetting(components.at(0));
+        if (key != primary_key)
+            return;
+
+        const fifojson row_json = makeInputRowJson(json, input);
+        const std::string widget = input.at(Constants::Settings::Input::kWidget).get<std::string>();
+
+        QSharedPointer<SettingRowBase> newRow;
+        if (widget == Constants::Settings::Input::kVector2) {
+            newRow = QSharedPointer<SettingRowBase>(new Vector2InputWidget(
+                this, m_sb, primary_key, componentSetting(components.at(1)), row_json, m_container_layout, m_size,
+                components.at(0).at(Constants::Settings::Input::kDefault).get<Distance>(),
+                components.at(1).at(Constants::Settings::Input::kDefault).get<Distance>(),
+                componentLabel(components.at(0)), componentLabel(components.at(1))));
+        }
+        else if (widget == Constants::Settings::Input::kVector3) {
+            newRow = QSharedPointer<SettingRowBase>(new Vector3InputWidget(
+                this, m_sb, primary_key, componentSetting(components.at(1)), componentSetting(components.at(2)),
+                row_json, m_container_layout, m_size,
+                components.at(0).at(Constants::Settings::Input::kDefault).get<double>(),
+                components.at(1).at(Constants::Settings::Input::kDefault).get<double>(),
+                components.at(2).at(Constants::Settings::Input::kDefault).get<double>(),
+                componentLabel(components.at(0)), componentLabel(components.at(1)), componentLabel(components.at(2))));
+        }
+
+        if (!newRow.isNull()) {
+            m_rows.insert(primary_key, newRow);
+            for (std::size_t i = 1; i < components.size(); ++i)
+                m_row_aliases.insert(componentSetting(components.at(i)), newRow);
+            ++m_size;
+        }
+
+        return;
+    }
+
     QSharedPointer<SettingRowBase> newRow =
         QSharedPointer<SettingRowBase>(m_creation_mapping[json.at(Constants::Settings::Master::kType)](
             this, m_sb, key, json, m_container_layout, m_size));

--- a/src/widgets/settings/vector2_input_widget.cpp
+++ b/src/widgets/settings/vector2_input_widget.cpp
@@ -1,0 +1,306 @@
+#include "widgets/settings/vector2_input_widget.h"
+
+#include <QFont>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPoint>
+#include <QRect>
+#include <QSizePolicy>
+#include <QToolTip>
+#include <qevent.h>
+#include <qnamespace.h>
+#include <qoverload.h>
+
+#include "managers/preferences_manager.h"
+#include "utilities/constants.h"
+#include "widgets/settings/setting_tab.h"
+
+namespace ORNL {
+namespace {
+constexpr int kComponentLabelWidth = 18;
+constexpr int kComponentMinimumHeight = 22;
+constexpr int kComponentSpacing = 4;
+constexpr int kComponentGroupSpacing = 6;
+constexpr int kSpinBoxWidth = 96;
+
+QLabel* createComponentLabel(QWidget* parent, const QString& text) {
+    QLabel* label = new QLabel(text, parent);
+    label->setAlignment(Qt::AlignCenter);
+    label->setFixedWidth(kComponentLabelWidth);
+    label->setMinimumHeight(kComponentMinimumHeight);
+    label->setStyleSheet("QLabel { image: none; margin: 0px; padding: 0px; }");
+
+    QFont font = label->font();
+    font.setBold(true);
+    label->setFont(font);
+
+    return label;
+}
+
+void addComponentEditor(QHBoxLayout* layout, QWidget* parent, const QString& label_text, QDoubleSpinBox* spin_box) {
+    layout->addWidget(createComponentLabel(parent, label_text));
+    layout->addWidget(spin_box);
+}
+} // namespace
+
+Vector2InputWidget::Vector2InputWidget(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString primary_key,
+                                       QString secondary_key, fifojson json, QGridLayout* layout, int index,
+                                       Distance primary_default, Distance secondary_default, QString primary_label,
+                                       QString secondary_label)
+    : QWidget(parent), SettingRowBase(parent, sb, primary_key, json, layout, index),
+      m_components {{{primary_key, new QDoubleSpinBox(this), primary_default},
+                     {secondary_key, new QDoubleSpinBox(this), secondary_default}}},
+      m_warn(false) {
+    QHBoxLayout* vector_layout = new QHBoxLayout(this);
+    vector_layout->setContentsMargins(0, 0, 0, 0);
+    vector_layout->setSpacing(kComponentSpacing);
+
+    const std::array<QString, 2> labels {primary_label, secondary_label};
+    const Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
+
+    for (std::size_t i = 0; i < m_components.size(); ++i) {
+        Component& component = m_components[i];
+        ensureSetting(component.key, component.default_value);
+
+        if (i != 0)
+            vector_layout->addSpacing(kComponentGroupSpacing);
+        addComponentEditor(vector_layout, this, labels[i], component.spin_box);
+
+        configureSpinBox(component.spin_box);
+        component.spin_box->installEventFilter(this);
+        component.spin_box->setValue(m_sb->setting<Distance>(component.key).to(unit));
+
+        const QString component_key = component.key;
+        connect(component.spin_box, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+                [this, component_key](double value) { updateSetting(component_key, value); });
+    }
+
+    connect(this, &Vector2InputWidget::modified, parent, &SettingTab::keyModified);
+    connect(this, &Vector2InputWidget::warnParent, parent, &SettingTab::headerWarning);
+
+    layout->addWidget(this, index, 1, Qt::AlignRight | Qt::AlignVCenter);
+
+    m_unit_label.reset(new QLabel(PreferencesManager::getInstance()->getDistanceUnitText()));
+    layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+}
+
+void Vector2InputWidget::hide() {
+    QWidget::hide();
+    SettingRowBase::hide();
+}
+
+void Vector2InputWidget::show() {
+    QWidget::show();
+    SettingRowBase::show();
+}
+
+void Vector2InputWidget::setEnabled(bool enabled) {
+    QWidget::setEnabled(enabled);
+    SettingRowBase::setEnabled(enabled);
+}
+
+void Vector2InputWidget::valueChanged(QVariant val) { updateSetting(m_components[0].key, val.toDouble()); }
+
+void Vector2InputWidget::reloadValue() {
+    for (Component& component : m_components)
+        component.spin_box->blockSignals(true);
+
+    m_unit_label->setText(PreferencesManager::getInstance()->getDistanceUnitText());
+
+    bool all_consistent = true;
+    for (Component& component : m_components) {
+        configureSpinBox(component.spin_box);
+
+        bool component_consistent = true;
+        setSpinBoxValue(component.spin_box, component.key, component.default_value, true, component_consistent);
+        all_consistent = all_consistent && component_consistent;
+    }
+
+    for (Component& component : m_components)
+        component.spin_box->blockSignals(false);
+
+    for (const Component& component : m_components)
+        emit modified(component.key);
+
+    if (!all_consistent) {
+        setNotification("Multiple Values");
+        styleLabel(false);
+        m_warn = true;
+        emit warnParent(1);
+    }
+    else {
+        clearNotification();
+        styleLabel(true);
+        m_warn = false;
+        emit warnParent(0);
+    }
+}
+
+bool Vector2InputWidget::eventFilter(QObject* watched, QEvent* event) {
+    if (event->type() == QEvent::Wheel) {
+        QDoubleSpinBox* spin_box = qobject_cast<QDoubleSpinBox*>(watched);
+        if (spin_box != nullptr && !spin_box->hasFocus()) {
+            event->ignore();
+            return true;
+        }
+    }
+
+    return QWidget::eventFilter(watched, event);
+}
+
+void Vector2InputWidget::setNotification(QString msg) {
+    for (Component& component : m_components) {
+        setStyleFromFile(component.spin_box, m_theme_path + "setting_rows_warning.qss");
+        component.spin_box->setToolTip(msg);
+    }
+
+    QToolTip::showText(this->mapToGlobal(QPoint(0, 0)), msg, nullptr, QRect(), 30000);
+}
+
+void Vector2InputWidget::clearNotification() {
+    for (Component& component : m_components) {
+        setStyleFromFile(component.spin_box, m_theme_path + "setting_rows_normal.qss");
+        component.spin_box->setToolTip("");
+    }
+}
+
+void Vector2InputWidget::configureSpinBox(QDoubleSpinBox* spin_box) {
+    Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
+    spin_box->setFocusPolicy(Qt::StrongFocus);
+    spin_box->setAlignment(Qt::AlignRight);
+    spin_box->setMaximum(Constants::Limits::Maximums::kMaxDistance.to(unit));
+    if (m_json[Constants::Settings::Master::kType] == "distance")
+        spin_box->setMinimum(Constants::Limits::Minimums::kMinDistance.to(unit));
+    else
+        spin_box->setMinimum(Constants::Limits::Minimums::kMinLocation.to(unit));
+    spin_box->setDecimals(m_precision);
+    spin_box->setFixedWidth(kSpinBoxWidth);
+    spin_box->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+}
+
+void Vector2InputWidget::ensureSetting(const QString& key, Distance default_value) {
+    if (!m_sb->contains(key))
+        m_sb->setSetting(key, default_value());
+}
+
+void Vector2InputWidget::updateSetting(const QString& key, double displayed_value) {
+    Distance base_value;
+    base_value.from(displayed_value, PreferencesManager::getInstance()->getDistanceUnit());
+
+    if (m_settings_bases.size() != 0) {
+        for (QSharedPointer<SettingsBase> range : m_settings_bases)
+            range->setSetting(key, base_value());
+    }
+    else {
+        m_sb->setSetting(key, base_value());
+    }
+
+    for (QSharedPointer<SettingRowBase> row : m_rows_to_notify)
+        row->checkDependencies();
+
+    checkDynamicDependencies();
+    updateWarningStateAfterEdit();
+    emit modified(key);
+}
+
+Distance Vector2InputWidget::reloadDistanceValue(const QString& key, Distance default_value, bool& consistent) {
+    if (m_settings_bases.size() > 0) {
+        bool all_bases_consistent = true;
+        for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
+            auto sb_1 = m_settings_bases[i - 1];
+            auto sb_2 = m_settings_bases[i];
+            all_bases_consistent = all_bases_consistent && areConsistent(key, sb_1, sb_2, default_value);
+        }
+
+        if (all_bases_consistent)
+            return effectiveDistanceValue(key, m_settings_bases[0], default_value);
+
+        consistent = false;
+        return default_value;
+    }
+
+    return effectiveDistanceValue(key, m_sb, default_value);
+}
+
+bool Vector2InputWidget::areConsistent(const QString& key, QSharedPointer<SettingsBase> a,
+                                       QSharedPointer<SettingsBase> b, Distance default_value) {
+    const Distance base_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : default_value;
+
+    if (a->contains(key) && base_value == a->setting<Distance>(key))
+        a->remove(key);
+
+    if (b->contains(key) && base_value == b->setting<Distance>(key))
+        b->remove(key);
+
+    bool containsA = a->contains(key);
+    bool containsB = b->contains(key);
+
+    return (containsA == containsB) &&
+           ((containsA && (a->setting<Distance>(key) == b->setting<Distance>(key))) || !containsA);
+}
+
+Distance Vector2InputWidget::effectiveDistanceValue(const QString& key, QSharedPointer<SettingsBase> settings_base,
+                                                    Distance default_value) {
+    if (settings_base->contains(key))
+        return settings_base->setting<Distance>(key);
+
+    if (m_sb->contains(key))
+        return m_sb->setting<Distance>(key);
+
+    return default_value;
+}
+
+bool Vector2InputWidget::hasConsistentEffectiveValues(const QString& key, Distance default_value) {
+    if (m_settings_bases.size() <= 1)
+        return true;
+
+    Distance first_value = effectiveDistanceValue(key, m_settings_bases[0], default_value);
+    for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
+        if (effectiveDistanceValue(key, m_settings_bases[i], default_value) != first_value)
+            return false;
+    }
+
+    return true;
+}
+
+bool Vector2InputWidget::hasAnyInconsistentValue() {
+    for (const Component& component : m_components) {
+        if (!hasConsistentEffectiveValues(component.key, component.default_value))
+            return true;
+    }
+
+    return false;
+}
+
+void Vector2InputWidget::updateWarningStateAfterEdit() {
+    if (hasAnyInconsistentValue()) {
+        setNotification("Multiple Values");
+        styleLabel(false);
+        if (!m_warn)
+            emit warnParent(1);
+        else
+            emit warnParent(0);
+        m_warn = true;
+    }
+    else {
+        clearNotification();
+        styleLabel(true);
+        if (m_warn)
+            emit warnParent(-1);
+        else
+            emit warnParent(0);
+        m_warn = false;
+    }
+}
+
+void Vector2InputWidget::setSpinBoxValue(QDoubleSpinBox* spin_box, const QString& key, Distance default_value,
+                                         bool only_if_consistent, bool& consistent) {
+    Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
+    bool setting_consistent = true;
+    Distance value = reloadDistanceValue(key, default_value, setting_consistent);
+    consistent = setting_consistent;
+
+    if (!only_if_consistent || setting_consistent)
+        spin_box->setValue(value.to(unit));
+}
+} // namespace ORNL

--- a/src/widgets/settings/vector3_input_widget.cpp
+++ b/src/widgets/settings/vector3_input_widget.cpp
@@ -1,0 +1,295 @@
+#include "widgets/settings/vector3_input_widget.h"
+
+#include <QFont>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPoint>
+#include <QRect>
+#include <QSizePolicy>
+#include <QToolTip>
+#include <qevent.h>
+#include <qnamespace.h>
+#include <qoverload.h>
+
+#include "utilities/constants.h"
+#include "widgets/settings/setting_tab.h"
+
+namespace ORNL {
+namespace {
+constexpr int kComponentLabelWidth = 18;
+constexpr int kComponentMinimumHeight = 22;
+constexpr int kComponentSpacing = 4;
+constexpr int kSpinBoxWidth = 82;
+
+QLabel* createComponentLabel(QWidget* parent, const QString& text) {
+    QLabel* label = new QLabel(text, parent);
+    label->setAlignment(Qt::AlignCenter);
+    label->setFixedWidth(kComponentLabelWidth);
+    label->setMinimumHeight(kComponentMinimumHeight);
+    label->setStyleSheet("QLabel { image: none; margin: 0px; padding: 0px; }");
+
+    QFont font = label->font();
+    font.setBold(true);
+    label->setFont(font);
+
+    return label;
+}
+
+void addComponentEditor(QHBoxLayout* layout, QWidget* parent, const QString& label_text, QDoubleSpinBox* spin_box) {
+    layout->addWidget(createComponentLabel(parent, label_text));
+    layout->addWidget(spin_box);
+}
+} // namespace
+
+Vector3InputWidget::Vector3InputWidget(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString primary_key,
+                                       QString secondary_key, QString tertiary_key, fifojson json,
+                                       QGridLayout* layout, int index, double primary_default,
+                                       double secondary_default, double tertiary_default, QString primary_label,
+                                       QString secondary_label, QString tertiary_label)
+    : QWidget(parent), SettingRowBase(parent, sb, primary_key, json, layout, index),
+      m_components {{{primary_key, new QDoubleSpinBox(this), primary_default},
+                     {secondary_key, new QDoubleSpinBox(this), secondary_default},
+                     {tertiary_key, new QDoubleSpinBox(this), tertiary_default}}},
+      m_warn(false) {
+    QHBoxLayout* vector_layout = new QHBoxLayout(this);
+    vector_layout->setContentsMargins(0, 0, 0, 0);
+    vector_layout->setSpacing(kComponentSpacing);
+
+    const std::array<QString, 3> labels {primary_label, secondary_label, tertiary_label};
+
+    for (std::size_t i = 0; i < m_components.size(); ++i) {
+        Component& component = m_components[i];
+        ensureSetting(component.key, component.default_value);
+
+        if (i != 0)
+            vector_layout->addSpacing(kComponentSpacing);
+        addComponentEditor(vector_layout, this, labels[i], component.spin_box);
+
+        configureSpinBox(component.spin_box);
+        component.spin_box->installEventFilter(this);
+        component.spin_box->setValue(m_sb->setting<double>(component.key));
+
+        const QString component_key = component.key;
+        connect(component.spin_box, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+                [this, component_key](double value) { updateSetting(component_key, value); });
+    }
+
+    connect(this, &Vector3InputWidget::modified, parent, &SettingTab::keyModified);
+    connect(this, &Vector3InputWidget::warnParent, parent, &SettingTab::headerWarning);
+
+    layout->addWidget(this, index, 1, Qt::AlignRight | Qt::AlignVCenter);
+
+    m_unit_label.reset(new QLabel(""));
+    layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+}
+
+void Vector3InputWidget::hide() {
+    QWidget::hide();
+    SettingRowBase::hide();
+}
+
+void Vector3InputWidget::show() {
+    QWidget::show();
+    SettingRowBase::show();
+}
+
+void Vector3InputWidget::setEnabled(bool enabled) {
+    QWidget::setEnabled(enabled);
+    SettingRowBase::setEnabled(enabled);
+}
+
+void Vector3InputWidget::valueChanged(QVariant val) { updateSetting(m_components[0].key, val.toDouble()); }
+
+void Vector3InputWidget::reloadValue() {
+    for (Component& component : m_components)
+        component.spin_box->blockSignals(true);
+
+    bool all_consistent = true;
+    for (Component& component : m_components) {
+        configureSpinBox(component.spin_box);
+
+        bool component_consistent = true;
+        setSpinBoxValue(component.spin_box, component.key, component.default_value, true, component_consistent);
+        all_consistent = all_consistent && component_consistent;
+    }
+
+    for (Component& component : m_components)
+        component.spin_box->blockSignals(false);
+
+    for (const Component& component : m_components)
+        emit modified(component.key);
+
+    if (!all_consistent) {
+        setNotification("Multiple Values");
+        styleLabel(false);
+        m_warn = true;
+        emit warnParent(1);
+    }
+    else {
+        clearNotification();
+        styleLabel(true);
+        m_warn = false;
+        emit warnParent(0);
+    }
+}
+
+bool Vector3InputWidget::eventFilter(QObject* watched, QEvent* event) {
+    if (event->type() == QEvent::Wheel) {
+        QDoubleSpinBox* spin_box = qobject_cast<QDoubleSpinBox*>(watched);
+        if (spin_box != nullptr && !spin_box->hasFocus()) {
+            event->ignore();
+            return true;
+        }
+    }
+
+    return QWidget::eventFilter(watched, event);
+}
+
+void Vector3InputWidget::setNotification(QString msg) {
+    for (Component& component : m_components) {
+        setStyleFromFile(component.spin_box, m_theme_path + "setting_rows_warning.qss");
+        component.spin_box->setToolTip(msg);
+    }
+
+    QToolTip::showText(this->mapToGlobal(QPoint(0, 0)), msg, nullptr, QRect(), 30000);
+}
+
+void Vector3InputWidget::clearNotification() {
+    for (Component& component : m_components) {
+        setStyleFromFile(component.spin_box, m_theme_path + "setting_rows_normal.qss");
+        component.spin_box->setToolTip("");
+    }
+}
+
+void Vector3InputWidget::configureSpinBox(QDoubleSpinBox* spin_box) {
+    spin_box->setFocusPolicy(Qt::StrongFocus);
+    spin_box->setAlignment(Qt::AlignRight);
+    spin_box->setMinimum(Constants::Limits::Minimums::kMinUnitlessFloat);
+    spin_box->setMaximum(Constants::Limits::Maximums::kMaxUnitlessFloat);
+    spin_box->setDecimals(m_precision);
+    spin_box->setFixedWidth(kSpinBoxWidth);
+    spin_box->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+}
+
+void Vector3InputWidget::ensureSetting(const QString& key, double default_value) {
+    if (!m_sb->contains(key))
+        m_sb->setSetting(key, default_value);
+}
+
+void Vector3InputWidget::updateSetting(const QString& key, double value) {
+    if (m_settings_bases.size() != 0) {
+        for (QSharedPointer<SettingsBase> range : m_settings_bases)
+            range->setSetting(key, value);
+    }
+    else {
+        m_sb->setSetting(key, value);
+    }
+
+    for (QSharedPointer<SettingRowBase> row : m_rows_to_notify)
+        row->checkDependencies();
+
+    checkDynamicDependencies();
+    updateWarningStateAfterEdit();
+    emit modified(key);
+}
+
+double Vector3InputWidget::reloadDoubleValue(const QString& key, double default_value, bool& consistent) {
+    if (m_settings_bases.size() > 0) {
+        bool all_bases_consistent = true;
+        for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
+            auto sb_1 = m_settings_bases[i - 1];
+            auto sb_2 = m_settings_bases[i];
+            all_bases_consistent = all_bases_consistent && areConsistent(key, sb_1, sb_2, default_value);
+        }
+
+        if (all_bases_consistent)
+            return effectiveDoubleValue(key, m_settings_bases[0], default_value);
+
+        consistent = false;
+        return default_value;
+    }
+
+    return effectiveDoubleValue(key, m_sb, default_value);
+}
+
+bool Vector3InputWidget::areConsistent(const QString& key, QSharedPointer<SettingsBase> a,
+                                       QSharedPointer<SettingsBase> b, double default_value) {
+    const double base_value = m_sb->contains(key) ? m_sb->setting<double>(key) : default_value;
+
+    if (a->contains(key) && base_value == a->setting<double>(key))
+        a->remove(key);
+
+    if (b->contains(key) && base_value == b->setting<double>(key))
+        b->remove(key);
+
+    bool containsA = a->contains(key);
+    bool containsB = b->contains(key);
+
+    return (containsA == containsB) &&
+           ((containsA && (a->setting<double>(key) == b->setting<double>(key))) || !containsA);
+}
+
+double Vector3InputWidget::effectiveDoubleValue(const QString& key, QSharedPointer<SettingsBase> settings_base,
+                                                double default_value) {
+    if (settings_base->contains(key))
+        return settings_base->setting<double>(key);
+
+    if (m_sb->contains(key))
+        return m_sb->setting<double>(key);
+
+    return default_value;
+}
+
+bool Vector3InputWidget::hasConsistentEffectiveValues(const QString& key, double default_value) {
+    if (m_settings_bases.size() <= 1)
+        return true;
+
+    double first_value = effectiveDoubleValue(key, m_settings_bases[0], default_value);
+    for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
+        if (effectiveDoubleValue(key, m_settings_bases[i], default_value) != first_value)
+            return false;
+    }
+
+    return true;
+}
+
+bool Vector3InputWidget::hasAnyInconsistentValue() {
+    for (const Component& component : m_components) {
+        if (!hasConsistentEffectiveValues(component.key, component.default_value))
+            return true;
+    }
+
+    return false;
+}
+
+void Vector3InputWidget::updateWarningStateAfterEdit() {
+    if (hasAnyInconsistentValue()) {
+        setNotification("Multiple Values");
+        styleLabel(false);
+        if (!m_warn)
+            emit warnParent(1);
+        else
+            emit warnParent(0);
+        m_warn = true;
+    }
+    else {
+        clearNotification();
+        styleLabel(true);
+        if (m_warn)
+            emit warnParent(-1);
+        else
+            emit warnParent(0);
+        m_warn = false;
+    }
+}
+
+void Vector3InputWidget::setSpinBoxValue(QDoubleSpinBox* spin_box, const QString& key, double default_value,
+                                         bool only_if_consistent, bool& consistent) {
+    bool setting_consistent = true;
+    double value = reloadDoubleValue(key, default_value, setting_consistent);
+    consistent = setting_consistent;
+
+    if (!only_if_consistent || setting_consistent)
+        spin_box->setValue(value);
+}
+} // namespace ORNL


### PR DESCRIPTION
## Summary

This PR adds generated metadata and UI support for grouping related scalar settings into composite input rows, starting with `vector2` and `vector3` controls for profile slicing settings.

## What Changed

- Adds optional top-level `inputs:` metadata in `resources/settings/*.yaml`.
- Generates and embeds `resources/configs/setting_inputs.conf` alongside `master.conf`.
- Loads grouped input metadata through `SettingsManager`.
- Updates `SettingTab` to render composite rows and alias secondary component keys back to the same row.
- Adds `Vector2InputWidget` for distance/location pairs and `Vector3InputWidget` for unitless float triples.
- Groups `radial_axis_x/y` as `Radial Axis` and `slicing_vector_x/y/z` as `Slicing Vector`.
- Adds shared min/max constants for unitless float spin boxes.
- Updates CMake generation and settings documentation for the new generated config.

## Reviewer Focus

- Confirm grouped input metadata keeps saved settings flat and backward compatible.
- Verify `Vector2InputWidget` and `Vector3InputWidget` correctly handle multi-profile “Multiple Values” warning state.
- Check that dependency behavior still works for secondary component keys routed through row aliases.