### PR TITLE
refactor(draw): optimize segment rendering with run-length encoding

### DIFF
--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -314,12 +314,33 @@ const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriang
 
 void GCodeObject::draw() {
     for (uint i = m_low_layer; i <= m_high_layer; i++) {
-        for (const auto& segment : m_segments[i]) {
-            if (segment->hidden)
-                continue;
+        uint run_offset = 0;
+        uint run_length = 0;
 
-            this->view()->glDrawArrays(this->renderMode(), segment->offset, segment->length);
+        auto drawRun = [&]() {
+            if (run_length > 0) {
+                this->view()->glDrawArrays(this->renderMode(), run_offset, run_length);
+                run_length = 0;
+            }
+        };
+
+        for (const auto& segment : m_segments[i]) {
+            if (segment->hidden) {
+                drawRun();
+                continue;
+            }
+
+            if (run_length > 0 && run_offset + run_length == segment->offset) {
+                run_length += segment->length;
+            }
+            else {
+                drawRun();
+                run_offset = segment->offset;
+                run_length = segment->length;
+            }
         }
+
+        drawRun();
     }
 }
 


### PR DESCRIPTION
## Summary

This reduces G-code preview draw-call overhead by batching contiguous visible segment ranges in `GCodeObject::draw()`.

Previously, each visible G-code segment issued its own `glDrawArrays` call. Large files with millions of segments could still render poorly even when using the lightweight `GL_LINES` fallback, because the renderer still attempted one draw call per segment per frame.

The new draw path accumulates adjacent visible segments into contiguous runs and draws each run once. Hidden segments flush the current run so layer/segment filtering behavior remains unchanged.

## Motivation

The sample `hub_helical.gcode` contains about `1.33M` motion segments. Full bead mesh rendering is not practical for this file with the current architecture, but the lightweight line path should be much cheaper than it was. This patch addresses the immediate draw-call bottleneck without changing visual output or segment metadata.