### PR TITLE
[codex] Include run number in Windows installer artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: cachix/install-nix-action@v27
       - name: Setup Environment
         run: |
-          echo "install_artifact=ornlslicer-installer.exe" >> $GITHUB_ENV
+          echo "install_artifact=$(nix eval --raw .#${{ env.ci_derivation }}.name)-run-${{ github.run_number }}-installer.exe" >> $GITHUB_ENV
           echo "package_artifact=$(nix eval --raw .#${{ env.ci_derivation }}.name)-portable" >> $GITHUB_ENV
           echo "version=$(nix eval --raw .#${{ env.ci_derivation }}.version)" >> $GITHUB_ENV
       - name: Compile Windows Build

--- a/include/geometry/segment_base.h
+++ b/include/geometry/segment_base.h
@@ -9,6 +9,7 @@
 #include <qquaternion.h>
 #include <qsharedpointer.h>
 #include <qtypes.h>
+#include <qvectornd.h>
 
 #include "geometry/point.h"
 #include "units/unit.h"
@@ -80,6 +81,13 @@ class SegmentBase {
     //! \brief Sets the display height of the gcode segment
     //! \param display_height the display height
     void setDisplayHeight(float display_height);
+
+    //! \brief Gets the custom display normal for bead construction.
+    QVector3D displayNormal() const;
+
+    //! \brief Sets the custom display normal for bead construction.
+    //! \param display_normal Segment-local display normal. A zero vector uses the global slicing vector.
+    void setDisplayNormal(QVector3D display_normal);
 
     //! \brief Creates the vertex info for this segment. Requires info set in setGCodeInfo(). Virtual function by
     //! default does nothing. \todo This function expects segments generated using OpenGL scales. A less brittle version
@@ -208,5 +216,8 @@ class SegmentBase {
 
     //! \brief The height of the segment in display units.
     float m_display_height;
+
+    //! \brief Optional normal used as the segment cross-section height direction for visualization.
+    QVector3D m_display_normal;
 };
 } // namespace ORNL

--- a/include/graphics/graphics_object.h
+++ b/include/graphics/graphics_object.h
@@ -273,6 +273,7 @@ class GraphicsObject : public QEnableSharedFromThis<GraphicsObject> {
         int overhangMode;
         int stackingAxis;
         int renderingPartObject;
+        int usingInstancedGcode;
     } m_shader_locs;
 
     //! \brief Current state for the object.

--- a/include/graphics/objects/gcode_object.h
+++ b/include/graphics/objects/gcode_object.h
@@ -9,8 +9,10 @@
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlist.h>
+#include <qpoint.h>
 #include <qsharedpointer.h>
 #include <qtypes.h>
+#include <qvectornd.h>
 
 #include "geometry/segment_base.h"
 #include "graphics/graphics_object.h"
@@ -86,6 +88,14 @@ class GCodeObject : public GraphicsObject {
     //! \return Pairs of (layer number, Triangles) for each segment.
     const QVector<std::pair<uint, std::vector<Triangle>>> segmentTriangles();
 
+    //! \brief Picks a line segment in optimized render modes that do not keep CPU triangles.
+    //! \param projection: Current view projection matrix.
+    //! \param view: Current camera view matrix.
+    //! \param mouse_ndc_pos: Mouse position in normalized device coordinates.
+    //! \param ortho: If the current projection is orthographic.
+    //! \return G-code line number, or 0 when no segment is close enough.
+    uint pickSegment(const QMatrix4x4& projection, const QMatrix4x4& view, const QPointF& mouse_ndc_pos, bool ortho);
+
     //! \brief Allows the object to enable instanced gcode uniforms when needed.
     void configureUniforms() override;
 
@@ -104,6 +114,12 @@ class GCodeObject : public GraphicsObject {
         uint instance_group = 0;
         //! \brief Offset in the group's instance buffer, when using instanced rendering.
         uint instance_offset = 0;
+        //! \brief Segment start for optimized picking.
+        QVector3D pick_start;
+        //! \brief Segment end for optimized picking.
+        QVector3D pick_end;
+        //! \brief Approximate selection radius in display units.
+        float pick_radius = 0.0f;
 
         //! \brief If this segment is hidden.
         bool hidden = false;

--- a/include/graphics/objects/gcode_object.h
+++ b/include/graphics/objects/gcode_object.h
@@ -118,6 +118,8 @@ class GCodeObject : public GraphicsObject {
         QVector3D pick_start;
         //! \brief Segment end for optimized picking.
         QVector3D pick_end;
+        //! \brief Segment display normal for optimized prism picking.
+        QVector3D pick_normal;
         //! \brief Approximate selection radius in display units.
         float pick_radius = 0.0f;
 
@@ -150,6 +152,7 @@ class GCodeObject : public GraphicsObject {
     struct InstancedBeadGroup {
         float width = 0.0f;
         float height = 0.0f;
+        bool prism = false;
         uint template_vertex_count = 0;
 
         std::vector<float> template_vertices;

--- a/include/graphics/objects/gcode_object.h
+++ b/include/graphics/objects/gcode_object.h
@@ -3,6 +3,8 @@
 #include <utility>
 #include <vector>
 
+#include <QOpenGLBuffer>
+#include <QOpenGLVertexArrayObject>
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qhash.h>
@@ -84,9 +86,12 @@ class GCodeObject : public GraphicsObject {
     //! \return Pairs of (layer number, Triangles) for each segment.
     const QVector<std::pair<uint, std::vector<Triangle>>> segmentTriangles();
 
+    //! \brief Allows the object to enable instanced gcode uniforms when needed.
+    void configureUniforms() override;
+
   protected:
     //! \brief Overridden draw call to allow segment hiding.
-    void draw();
+    void draw() override;
 
   private:
     //! \brief Segment metadata.
@@ -95,6 +100,10 @@ class GCodeObject : public GraphicsObject {
         uint offset = 0;
         //! \brief Segment length in GL buffer.
         uint length = 0;
+        //! \brief Instanced bead template group, when using instanced rendering.
+        uint instance_group = 0;
+        //! \brief Offset in the group's instance buffer, when using instanced rendering.
+        uint instance_offset = 0;
 
         //! \brief If this segment is hidden.
         bool hidden = false;
@@ -121,8 +130,45 @@ class GCodeObject : public GraphicsObject {
     //! \param color: Color to paint.
     void paintSegment(QSharedPointer<SegmentDisplayMeta> seg_meta, QColor color);
 
+    //! \brief Instanced bead data for one display-width/display-height shape.
+    struct InstancedBeadGroup {
+        float width = 0.0f;
+        float height = 0.0f;
+        uint template_vertex_count = 0;
+
+        std::vector<float> template_vertices;
+        std::vector<float> template_normals;
+        std::vector<float> instances;
+
+        QSharedPointer<QOpenGLVertexArrayObject> vao;
+        QOpenGLBuffer template_vbo {QOpenGLBuffer::VertexBuffer};
+        QOpenGLBuffer template_nbo {QOpenGLBuffer::VertexBuffer};
+        QOpenGLBuffer instance_vbo {QOpenGLBuffer::VertexBuffer};
+    };
+
+    //! \brief Adds an instance record and returns (group index, instance index).
+    std::pair<uint, uint> appendInstancedBead(const QSharedPointer<SegmentBase>& segment);
+
+    //! \brief Creates GL buffers for all instanced bead groups.
+    void populateInstancedBeadsGL();
+
+    //! \brief Draws visible instanced bead runs.
+    void drawInstancedBeads();
+
+    //! \brief Draws a contiguous run from one instanced bead group.
+    void drawInstancedBeadRun(uint group_index, uint first_instance, uint instance_count);
+
+    //! \brief Updates one instanced bead's color in CPU and GL buffers.
+    void paintInstancedBead(QSharedPointer<SegmentDisplayMeta> seg_meta, QColor color);
+
     //! \brief True when very large gcode is rendered as lightweight GL lines instead of bead meshes.
     bool m_lightweight_lines = false;
+
+    //! \brief True when line gcode is rendered with a shared bead mesh and per-segment instances.
+    bool m_instanced_beads = false;
+
+    //! \brief Shared bead template groups keyed by display width/height.
+    std::vector<QSharedPointer<InstancedBeadGroup>> m_instanced_bead_groups;
 
     //! \brief Segment metadata container.
     QVector<QVector<QSharedPointer<SegmentDisplayMeta>>> m_segments;

--- a/include/graphics/support/shape_factory.h
+++ b/include/graphics/support/shape_factory.h
@@ -89,6 +89,39 @@ class ShapeFactory {
                                     std::vector<float>& vertices, std::vector<float>& colors,
                                     std::vector<float>& normals);
 
+    /*! \brief Append the data for a square-prism gcode segment to the input vector
+     *  @param width: Width of the prism's display envelope
+     *  @param length: Length of the prism
+     *  @param height: Height of the prism's display envelope
+     *  @param start: Start point of the gcode segment
+     *  @param end: Displacement of the gcode segment
+     *  @param color: Color of the prism
+     *  @param vertices Vertices of the prism
+     *  @param colors Vertex colors of the prism
+     *  @param normals Normal vectors of the prism
+     */
+    static void createGcodePrism(const float& width, const float& length, const float& height,
+                                 const QVector3D& start, const QVector3D& end, const QColor& color,
+                                 std::vector<float>& vertices, std::vector<float>& colors,
+                                 std::vector<float>& normals);
+
+    /*! \brief Append the data for a square-prism gcode segment with a custom cross-section normal
+     *  @param width: Width of the prism's display envelope
+     *  @param length: Length of the prism
+     *  @param height: Height of the prism's display envelope
+     *  @param start: Start point of the gcode segment
+     *  @param end: Displacement of the gcode segment
+     *  @param display_normal: Cross-section height direction. A zero vector uses the global slicing vector.
+     *  @param color: Color of the prism
+     *  @param vertices Vertices of the prism
+     *  @param colors Vertex colors of the prism
+     *  @param normals Normal vectors of the prism
+     */
+    static void createGcodePrism(const float& width, const float& length, const float& height,
+                                 const QVector3D& start, const QVector3D& end, const QVector3D& display_normal,
+                                 const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
+                                 std::vector<float>& normals);
+
     /*!
      * \brief appends the data for a arc cylinder to input vectors
      * \note this is an overload that automatically computes the transform

--- a/include/graphics/support/shape_factory.h
+++ b/include/graphics/support/shape_factory.h
@@ -71,6 +71,24 @@ class ShapeFactory {
                                     std::vector<float>& vertices, std::vector<float>& colors,
                                     std::vector<float>& normals);
 
+    /*! \brief Append the data for a clipped cylinder with a custom cross-section normal
+     *  @param width: Width of the clipped cylinder
+     *  @param length: Length of the clipped cylinder
+     *  @param height: Height of the clipped cylinder
+     *  @param start: Start point of the gcode segment
+     *  @param end: Displacement of the gcode segment
+     *  @param display_normal: Cross-section height direction. A zero vector uses the global slicing vector.
+     *  @param color: Color of the clipped cylinder
+     *  @param vertices Vertices of the clipped cylinder
+     *  @param colors Vertex colors of the clipped cylinder
+     *  @param normals Normal vectors of the clipped cylinder
+     */
+    static void createGcodeCylinder(const float& width, const float& length, const float& height,
+                                    const QVector3D& start, const QVector3D& end,
+                                    const QVector3D& display_normal, const QColor& color,
+                                    std::vector<float>& vertices, std::vector<float>& colors,
+                                    std::vector<float>& normals);
+
     /*!
      * \brief appends the data for a arc cylinder to input vectors
      * \note this is an overload that automatically computes the transform
@@ -172,6 +190,15 @@ class ShapeFactory {
      *  @return Transformation matrix to place the cylinder at the correct point and orientation
      */
     static QMatrix4x4 computeGcodeCylinderTransform(const QVector3D& start, const QVector3D& end);
+
+    /*! \brief Helper function to compute the transformation matrix for a gcode cylinder with a custom normal
+     *  @param start Start point of the gcode segment
+     *  @param end Displacement of the gcode segment
+     *  @param display_normal Cross-section height direction. A zero vector uses the global slicing vector.
+     *  @return Transformation matrix to place the cylinder at the correct point and orientation
+     */
+    static QMatrix4x4 computeGcodeCylinderTransform(const QVector3D& start, const QVector3D& end,
+                                                    const QVector3D& display_normal);
 
     /*!
      * \brief appends the data for a clockwise (G2) arc cylinder to input vectors

--- a/include/threading/gcode_loader.h
+++ b/include/threading/gcode_loader.h
@@ -96,6 +96,9 @@ class GCodeLoader : public QThread {
     //! \param lines Uppercase: lines used for ease of parsing/comparison
     void setParser(QStringList& originalLines, QStringList& lines);
 
+    //! \brief Parses visualization hints that are not part of the motion command stream.
+    void parseRadialVisualizationHints();
+
     //! \brief determine color based on comment keywords
     //! \param comment: Comment to parse
     //! \return color based on comment keywords
@@ -123,6 +126,9 @@ class GCodeLoader : public QThread {
     //! \param extruder_speed: The speed of the extruder.
     void setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const QString& comment, QVector3D& info_end_pos,
                             const bool& extruder_on, const bool& info_speed_set, const double& extruder_speed);
+
+    //! \brief Computes a custom display normal for radial/helical gcode commands.
+    QVector3D radialDisplayNormal(const QMap<char, double>& parameters);
 
     //! \brief generate additional export comments
     //! \return string
@@ -211,5 +217,14 @@ class GCodeLoader : public QThread {
 
     //! \brief Current settings for gcode loader
     QSharedPointer<SettingsBase> m_sb;
+
+    //! \brief C-axis offset from radial/helical gcode headers, in degrees.
+    double m_radial_c_axis_offset_degrees = 0.0;
+
+    //! \brief Tracks previous C value so segment normals are computed at segment midpoints.
+    bool m_has_last_radial_c = false;
+
+    //! \brief Previous C-axis angle for radial/helical visualization.
+    double m_last_radial_c_degrees = 0.0;
 }; // class GCodeLoader
 } // namespace ORNL

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -1162,6 +1162,7 @@ class Constants {
             static const char* kOverhangAngleName;
             static const char* kOverhangModeName;
             static const char* kRenderingPartObjectName;
+            static const char* kUsingInstancedGcodeName;
         };
     };
 

--- a/resources/shaders/shader.vert
+++ b/resources/shaders/shader.vert
@@ -6,6 +6,7 @@ layout(location = 3) in vec2 uv;
 layout(location = 4) in vec3 instanceStart;
 layout(location = 5) in vec3 instanceDelta;
 layout(location = 6) in vec4 instanceColor;
+layout(location = 7) in vec3 instanceNormal;
 out vec4 vColor;
 out vec3 fragPos;
 out vec3 vNormal;
@@ -33,12 +34,16 @@ void main()
     {
         float segmentLength = length(instanceDelta);
         vec3 tangent = segmentLength > 0.000001 ? instanceDelta / segmentLength : vec3(0.0, 0.0, 1.0);
-        vec3 normalAxis = normalize(stackingAxis);
+        vec3 normalAxis = dot(instanceNormal, instanceNormal) > 0.000001
+                              ? normalize(instanceNormal)
+                              : normalize(stackingAxis);
         vec3 binormal = cross(tangent, normalAxis);
 
         if (dot(binormal, binormal) < 0.000001)
         {
-            normalAxis = vec3(1.0, 0.0, 0.0);
+            normalAxis = abs(dot(tangent, vec3(0.0, 0.0, 1.0))) < 0.9
+                           ? vec3(0.0, 0.0, 1.0)
+                           : vec3(1.0, 0.0, 0.0);
             binormal = cross(tangent, normalAxis);
         }
 

--- a/resources/shaders/shader.vert
+++ b/resources/shaders/shader.vert
@@ -3,6 +3,9 @@ layout(location = 0) in vec3 position;
 layout(location = 1) in vec3 normal;
 layout(location = 2) in vec4 color;
 layout(location = 3) in vec2 uv;
+layout(location = 4) in vec3 instanceStart;
+layout(location = 5) in vec3 instanceDelta;
+layout(location = 6) in vec4 instanceColor;
 out vec4 vColor;
 out vec3 fragPos;
 out vec3 vNormal;
@@ -17,20 +20,49 @@ uniform vec3 stackingAxis;
 uniform float overhangAngle;
 uniform bool usingOverhangMode;
 uniform bool renderingPartObject;
+uniform bool usingInstancedGcode;
 mat3 rotation;
 
 void main()
 {
-    vec4 temp = (model * vec4(position, 1));
+    vec3 objectPosition = position;
+    vec3 objectNormal = normal;
+    vec4 objectColor = color;
+
+    if (usingInstancedGcode)
+    {
+        float segmentLength = length(instanceDelta);
+        vec3 tangent = segmentLength > 0.000001 ? instanceDelta / segmentLength : vec3(0.0, 0.0, 1.0);
+        vec3 normalAxis = normalize(stackingAxis);
+        vec3 binormal = cross(tangent, normalAxis);
+
+        if (dot(binormal, binormal) < 0.000001)
+        {
+            normalAxis = vec3(1.0, 0.0, 0.0);
+            binormal = cross(tangent, normalAxis);
+        }
+
+        binormal = normalize(binormal);
+        normalAxis = normalize(cross(binormal, tangent));
+
+        objectPosition = instanceStart +
+                         (binormal * position.x) +
+                         (normalAxis * position.y) +
+                         (tangent * (position.z * segmentLength));
+        objectNormal = normalize((binormal * normal.x) + (normalAxis * normal.y) + (tangent * normal.z));
+        objectColor = instanceColor;
+    }
+
+    vec4 temp = (model * vec4(objectPosition, 1));
     vWorldPos = vec3(temp.x, temp.y, temp.z);
     rotation = mat3(model[0][0], model[0][1], model[0][2],
                     model[1][0], model[1][1], model[1][2],
                     model[2][0], model[2][1], model[2][2]);
-    vNormal = normalize(normal);
-    vColor = color;
-    vWorldNormal = rotation * normal;
-    fragPos = vec3(model * vec4(position, 1.0));
-    gl_Position = projection * view * model * vec4(position, 1.0);
+    vNormal = normalize(objectNormal);
+    vColor = objectColor;
+    vWorldNormal = rotation * objectNormal;
+    fragPos = vec3(model * vec4(objectPosition, 1.0));
+    gl_Position = projection * view * model * vec4(objectPosition, 1.0);
     texcoord_uv = uv;
     //We need the know the baryocentric coordinate of each pixel to determine how
     //close each pixel is to an edge of a triangle

--- a/src/gcode/parsers/radial_parser.cpp
+++ b/src/gcode/parsers/radial_parser.cpp
@@ -65,10 +65,13 @@ QVector<QString> RadialParser::stripRotaryAxes(QVector<QString> params) {
         }
 
         bool no_error = false;
-        param.right(param.size() - 1).toDouble(&no_error);
+        const double rotary_value = param.right(param.size() - 1).toDouble(&no_error);
         if (!no_error) {
             throwFloatConversionErrorException();
         }
+
+        const char axis_key = axis.toUpper().toLatin1();
+        m_current_gcode_command.addParameter(axis_key, rotary_value);
 
         if (axis == 'A' || axis == 'a') {
             a_not_used = false;

--- a/src/geometry/segment_base.cpp
+++ b/src/geometry/segment_base.cpp
@@ -1,5 +1,6 @@
 #include "geometry/segment_base.h"
 
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -62,6 +63,15 @@ void SegmentBase::setDisplayInfo(float display_width, float display_length, floa
 void SegmentBase::setDisplayWidth(float display_width) { m_display_width = display_width; }
 
 void SegmentBase::setDisplayHeight(float display_height) { m_display_height = display_height; }
+
+QVector3D SegmentBase::displayNormal() const { return m_display_normal; }
+
+void SegmentBase::setDisplayNormal(QVector3D display_normal) {
+    if (display_normal.lengthSquared() > std::numeric_limits<float>::epsilon()) {
+        display_normal.normalize();
+    }
+    m_display_normal = display_normal;
+}
 
 void SegmentBase::createGraphic(std::vector<float>& vertices, std::vector<float>& normals, std::vector<float>& colors) {
     // NOP

--- a/src/geometry/segments/line.cpp
+++ b/src/geometry/segments/line.cpp
@@ -17,7 +17,7 @@ LineSegment::LineSegment(Point start, Point end) : SegmentBase(start, end) {
 
 void LineSegment::createGraphic(std::vector<float>& vertices, std::vector<float>& normals, std::vector<float>& colors) {
     ShapeFactory::createGcodeCylinder(m_display_width, m_display_length, m_display_height, m_start.toQVector3D(),
-                                      m_end.toQVector3D(), m_color, vertices, colors, normals);
+                                      m_end.toQVector3D(), m_display_normal, m_color, vertices, colors, normals);
 }
 
 QSharedPointer<SegmentBase> LineSegment::clone() const { return QSharedPointer<LineSegment>::create(*this); }

--- a/src/geometry/segments/line.cpp
+++ b/src/geometry/segments/line.cpp
@@ -16,6 +16,12 @@ LineSegment::LineSegment(Point start, Point end) : SegmentBase(start, end) {
 }
 
 void LineSegment::createGraphic(std::vector<float>& vertices, std::vector<float>& normals, std::vector<float>& colors) {
+    if (m_display_type == SegmentDisplayType::kTravel) {
+        ShapeFactory::createGcodePrism(m_display_width, m_display_length, m_display_height, m_start.toQVector3D(),
+                                       m_end.toQVector3D(), m_display_normal, m_color, vertices, colors, normals);
+        return;
+    }
+
     ShapeFactory::createGcodeCylinder(m_display_width, m_display_length, m_display_height, m_start.toQVector3D(),
                                       m_end.toQVector3D(), m_display_normal, m_color, vertices, colors, normals);
 }

--- a/src/graphics/graphics_object.cpp
+++ b/src/graphics/graphics_object.cpp
@@ -102,6 +102,7 @@ void GraphicsObject::render() {
 
 void GraphicsObject::configureUniforms() {
     m_view->shaderProgram()->setUniformValue(m_shader_locs.renderingPartObject, false);
+    m_view->shaderProgram()->setUniformValue(m_shader_locs.usingInstancedGcode, false);
 }
 
 BaseView* GraphicsObject::view() { return m_view.data(); }
@@ -367,6 +368,8 @@ void GraphicsObject::populateGL(BaseView* view, const std::vector<float>& vertic
     m_shader_locs.uv = m_view->shaderProgram()->attributeLocation(Constants::OpenGL::Shader::kUVName);
     m_shader_locs.usingSolidWireframeMode =
         m_view->shaderProgram()->uniformLocation(Constants::OpenGL::Shader::kUsingSolidWireframeModeName);
+    m_shader_locs.usingInstancedGcode =
+        m_view->shaderProgram()->uniformLocation(Constants::OpenGL::Shader::kUsingInstancedGcodeName);
 
     m_view->makeCurrent();
 

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -37,10 +37,11 @@ constexpr qsizetype kLightweightLineThreshold = 2000000;
 //! @brief Segment count where instanced bead rendering starts avoiding large CPU mesh expansion.
 constexpr qsizetype kInstancedBeadThreshold = 100000;
 
-constexpr uint kInstanceFloatCount = 10;
+constexpr uint kInstanceFloatCount = 13;
 constexpr uint kInstanceStartOffset = 0;
 constexpr uint kInstanceDeltaOffset = 3;
 constexpr uint kInstanceColorOffset = 6;
+constexpr uint kInstanceNormalOffset = 10;
 constexpr uint kInstanceStrideBytes = kInstanceFloatCount * sizeof(float);
 constexpr float kMinimumPickRadius = 0.025f;
 constexpr float kPickTieTolerance = 0.000001f;
@@ -365,10 +366,12 @@ std::pair<uint, uint> GCodeObject::appendInstancedBead(const QSharedPointer<Segm
     const uint instance_index = group->instances.size() / kInstanceFloatCount;
     const QVector3D start = segment->start().toQVector3D();
     const QVector3D delta = displayEnd(segment) - start;
+    const QVector3D display_normal = segment->displayNormal();
     const QColor color = segment->color();
 
     group->instances.insert(group->instances.end(), {start.x(), start.y(), start.z(), delta.x(), delta.y(), delta.z(),
-                                                     color.redF(), color.greenF(), color.blueF(), color.alphaF()});
+                                                     color.redF(), color.greenF(), color.blueF(), color.alphaF(),
+                                                     display_normal.x(), display_normal.y(), display_normal.z()});
 
     return std::make_pair(group_index, instance_index);
 }
@@ -415,6 +418,11 @@ void GCodeObject::populateInstancedBeadsGL() {
         this->view()->glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
                                             reinterpret_cast<const void*>(kInstanceColorOffset * sizeof(float)));
         this->view()->glVertexAttribDivisor(6, 1);
+
+        this->view()->glEnableVertexAttribArray(7);
+        this->view()->glVertexAttribPointer(7, 3, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
+                                            reinterpret_cast<const void*>(kInstanceNormalOffset * sizeof(float)));
+        this->view()->glVertexAttribDivisor(7, 1);
 
         group->vao->release();
         group->template_vbo.release();
@@ -751,6 +759,9 @@ void GCodeObject::drawInstancedBeadRun(uint group_index, uint first_instance, ui
     this->view()->glVertexAttribPointer(
         6, 4, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
         reinterpret_cast<const void*>(first_instance_bytes + (kInstanceColorOffset * sizeof(float))));
+    this->view()->glVertexAttribPointer(
+        7, 3, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
+        reinterpret_cast<const void*>(first_instance_bytes + (kInstanceNormalOffset * sizeof(float))));
 
     this->view()->glDrawArraysInstanced(GL_TRIANGLES, 0, group->template_vertex_count, instance_count);
 

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -2,6 +2,11 @@
 
 #include <GL/gl.h>
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -18,13 +23,24 @@
 #include "geometry/segments/line.h"
 #include "graphics/base_view.h"
 #include "graphics/graphics_object.h"
+#include "managers/settings/settings_manager.h"
+#include "utilities/constants.h"
 #include "utilities/enums.h"
 #include "widgets/gcode_info_control.h"
 
 namespace ORNL {
 namespace {
-//! @brief Segment count where full bead mesh visualization is likely to exceed practical GL buffer sizes.
-constexpr qsizetype kLightweightLineThreshold = 1000000;
+//! @brief Segment count where full-build bead rendering should fall back to overview lines.
+constexpr qsizetype kLightweightLineThreshold = 2000000;
+
+//! @brief Segment count where instanced bead rendering starts avoiding large CPU mesh expansion.
+constexpr qsizetype kInstancedBeadThreshold = 100000;
+
+constexpr uint kInstanceFloatCount = 10;
+constexpr uint kInstanceStartOffset = 0;
+constexpr uint kInstanceDeltaOffset = 3;
+constexpr uint kInstanceColorOffset = 6;
+constexpr uint kInstanceStrideBytes = kInstanceFloatCount * sizeof(float);
 
 //! @brief Counts display segments before GL buffer construction so oversized gcode can use a lighter path.
 qsizetype countSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
@@ -35,17 +51,135 @@ qsizetype countSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gco
     return count;
 }
 
+bool allSegmentsAreLines(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
+    for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
+        for (const QSharedPointer<SegmentBase>& segment : layer) {
+            if (dynamic_cast<LineSegment*>(segment.data()) == nullptr)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+QVector3D displayEnd(const QSharedPointer<SegmentBase>& segment) {
+    QVector3D end = segment->end().toQVector3D();
+    if (dynamic_cast<LineSegment*>(segment.data()) != nullptr) {
+        end += segment->start().toQVector3D();
+    }
+
+    return end;
+}
+
+void appendInstancedTemplateTriangle(const QVector3D& v0, const QVector3D& v1, const QVector3D& v2,
+                                     std::vector<float>& vertices, std::vector<float>& normals) {
+    vertices.insert(vertices.end(), {v0.x(), v0.y(), v0.z(), v1.x(), v1.y(), v1.z(), v2.x(), v2.y(), v2.z()});
+
+    QVector3D normal = QVector3D::crossProduct(v1 - v0, v2 - v0).normalized();
+    for (int i = 0; i < 3; ++i) {
+        normals.insert(normals.end(), {normal.x(), normal.y(), normal.z()});
+    }
+}
+
+void createInstancedBeadTemplate(float width, float height, std::vector<float>& vertices,
+                                 std::vector<float>& normals) {
+    width = std::max(width, std::numeric_limits<float>::epsilon());
+    height = std::max(height, std::numeric_limits<float>::epsilon());
+
+    float radius;
+    unsigned int quads_per_side;
+    if (height > width) {
+        radius = std::sqrt((width / 2.0f) * (width / 2.0f) + (height / 2.0f) * (height / 2.0f));
+        quads_per_side = 1;
+    }
+    else {
+        radius = width / 2.0f;
+        quads_per_side = 6;
+    }
+
+    const unsigned int vertices_per_arc = quads_per_side + 1;
+    const unsigned int vertices_per_side = 2 * vertices_per_arc;
+    const float theta_start = -std::asin((height / 2.0f) / radius);
+    const float theta_end = -theta_start;
+    const float theta_increment = (theta_end - theta_start) / quads_per_side;
+
+    std::vector<QVector3D> top_vertices(2 * vertices_per_arc);
+    std::vector<QVector3D> bottom_vertices(2 * vertices_per_arc);
+
+    for (unsigned int i = 0; i < vertices_per_arc; ++i) {
+        const float theta = theta_start + i * theta_increment;
+        const float x = radius * std::cos(theta);
+        const float y = radius * std::sin(theta);
+
+        top_vertices[i] = QVector3D(x, y, 1.0f);
+        bottom_vertices[i] = QVector3D(x, y, 0.0f);
+        top_vertices[i + vertices_per_arc] = QVector3D(-x, -y, 1.0f);
+        bottom_vertices[i + vertices_per_arc] = QVector3D(-x, -y, 0.0f);
+    }
+
+    const QVector3D top_center(0.0f, 0.0f, 1.0f);
+    const QVector3D bottom_center(0.0f, 0.0f, 0.0f);
+
+    for (unsigned int i = 0; i < vertices_per_side; ++i) {
+        const unsigned int j = (i + 1) % vertices_per_side;
+        appendInstancedTemplateTriangle(top_center, top_vertices[j], top_vertices[i], vertices, normals);
+        appendInstancedTemplateTriangle(top_vertices[i], bottom_vertices[j], bottom_vertices[i], vertices, normals);
+        appendInstancedTemplateTriangle(top_vertices[i], top_vertices[j], bottom_vertices[j], vertices, normals);
+        appendInstancedTemplateTriangle(bottom_center, bottom_vertices[i], bottom_vertices[j], vertices, normals);
+    }
+}
+
+void appendBoundingVertices(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode, std::vector<float>& vertices,
+                            std::vector<float>& normals, std::vector<float>& colors) {
+    QVector3D min(Constants::Limits::Maximums::kMaxFloat, Constants::Limits::Maximums::kMaxFloat,
+                  Constants::Limits::Maximums::kMaxFloat);
+    QVector3D max(Constants::Limits::Minimums::kMinFloat, Constants::Limits::Minimums::kMinFloat,
+                  Constants::Limits::Minimums::kMinFloat);
+
+    float max_half_bead = 0.0f;
+    for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
+        for (const QSharedPointer<SegmentBase>& segment : layer) {
+            const QVector3D start = segment->start().toQVector3D();
+            const QVector3D end = displayEnd(segment);
+
+            min.setX(std::min({min.x(), start.x(), end.x()}));
+            min.setY(std::min({min.y(), start.y(), end.y()}));
+            min.setZ(std::min({min.z(), start.z(), end.z()}));
+            max.setX(std::max({max.x(), start.x(), end.x()}));
+            max.setY(std::max({max.y(), start.y(), end.y()}));
+            max.setZ(std::max({max.z(), start.z(), end.z()}));
+
+            max_half_bead = std::max(max_half_bead, std::max(segment->displayWidth(), segment->displayHeight()) / 2.0f);
+        }
+    }
+
+    min -= QVector3D(max_half_bead, max_half_bead, max_half_bead);
+    max += QVector3D(max_half_bead, max_half_bead, max_half_bead);
+
+    const std::array<QVector3D, 8> corners = {QVector3D(min.x(), min.y(), min.z()),
+                                             QVector3D(min.x(), max.y(), min.z()),
+                                             QVector3D(max.x(), max.y(), min.z()),
+                                             QVector3D(max.x(), min.y(), min.z()),
+                                             QVector3D(min.x(), min.y(), max.z()),
+                                             QVector3D(min.x(), max.y(), max.z()),
+                                             QVector3D(max.x(), max.y(), max.z()),
+                                             QVector3D(max.x(), min.y(), max.z())};
+
+    vertices.reserve(corners.size() * 3);
+    normals.reserve(corners.size() * 3);
+    colors.reserve(corners.size() * 4);
+    for (const QVector3D& corner : corners) {
+        vertices.insert(vertices.end(), {corner.x(), corner.y(), corner.z()});
+        normals.insert(normals.end(), {0.0f, 0.0f, 0.0f});
+        colors.insert(colors.end(), {0.0f, 0.0f, 0.0f, 0.0f});
+    }
+}
+
 //! @brief Appends a single GL_LINES segment using the parser's display-space line representation.
 void appendLightweightLine(const QSharedPointer<SegmentBase>& segment, std::vector<float>& vertices,
                            std::vector<float>& normals, std::vector<float>& colors) {
     QVector3D start = segment->start().toQVector3D();
-    QVector3D end = segment->end().toQVector3D();
-
-    // GCodeLoader stores parsed G0/G1 line endpoints as displacement vectors
-    // because the standard bead renderer builds cylinders from start+direction.
-    if (dynamic_cast<LineSegment*>(segment.data()) != nullptr) {
-        end += start;
-    }
+    QVector3D end = displayEnd(segment);
 
     vertices.push_back(start.x());
     vertices.push_back(start.y());
@@ -81,7 +215,11 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
     m_segment_info_control->setGCode(gcode);
 
     const qsizetype segment_count = countSegments(gcode);
-    m_lightweight_lines = segment_count > kLightweightLineThreshold;
+    const bool can_instance_beads = allSegmentsAreLines(gcode);
+    m_instanced_beads =
+        can_instance_beads && segment_count > kInstancedBeadThreshold && segment_count <= kLightweightLineThreshold;
+    m_lightweight_lines =
+        segment_count > kLightweightLineThreshold || (!can_instance_beads && segment_count > kInstancedBeadThreshold);
     if (m_lightweight_lines) {
         vertices.reserve(segment_count * 2 * 3);
         normals.reserve(segment_count * 2 * 3);
@@ -101,16 +239,24 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
             seg_meta->type = segment->displayType();
             seg_meta->original_color = segment->color();
             seg_meta->current_color = segment->color();
-            seg_meta->offset = vertices.size() / 3;
 
             if (m_lightweight_lines) {
+                seg_meta->offset = vertices.size() / 3;
                 appendLightweightLine(segment, vertices, normals, colors);
+                seg_meta->length = (vertices.size() / 3) - seg_meta->offset;
+            }
+            else if (m_instanced_beads) {
+                const auto [group_index, instance_index] = appendInstancedBead(segment);
+                seg_meta->instance_group = group_index;
+                seg_meta->instance_offset = instance_index;
+                seg_meta->offset = instance_index;
+                seg_meta->length = 1;
             }
             else {
+                seg_meta->offset = vertices.size() / 3;
                 segment->createGraphic(vertices, normals, colors);
+                seg_meta->length = (vertices.size() / 3) - seg_meta->offset;
             }
-
-            seg_meta->length = (vertices.size() / 3) - seg_meta->offset;
 
             if (static_cast<bool>(seg_meta->type & m_hidden_type))
                 seg_meta->hidden = true;
@@ -127,7 +273,115 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
     m_low_segment = 0;
     m_high_segment = visibleSegmentCount();
 
-    this->populateGL(view, vertices, normals, colors, m_lightweight_lines ? GL_LINES : GL_TRIANGLES);
+    if (m_instanced_beads) {
+        appendBoundingVertices(gcode, vertices, normals, colors);
+        this->populateGL(view, vertices, normals, colors, GL_POINTS);
+        this->populateInstancedBeadsGL();
+    }
+    else {
+        this->populateGL(view, vertices, normals, colors, m_lightweight_lines ? GL_LINES : GL_TRIANGLES);
+    }
+}
+
+void GCodeObject::configureUniforms() {
+    GraphicsObject::configureUniforms();
+
+    if (m_instanced_beads) {
+        QVector3D stacking_axis = {GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorX),
+                                   GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorY),
+                                   GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorZ)};
+        if (stacking_axis.lengthSquared() < std::numeric_limits<float>::epsilon()) {
+            stacking_axis = QVector3D(0.0f, 0.0f, 1.0f);
+        }
+
+        this->view()->shaderProgram()->setUniformValue(m_shader_locs.usingInstancedGcode, true);
+        this->view()->shaderProgram()->setUniformValue(m_shader_locs.stackingAxis, stacking_axis.normalized());
+    }
+}
+
+std::pair<uint, uint> GCodeObject::appendInstancedBead(const QSharedPointer<SegmentBase>& segment) {
+    const float width = segment->displayWidth();
+    const float height = segment->displayHeight();
+
+    uint group_index = 0;
+    for (; group_index < m_instanced_bead_groups.size(); ++group_index) {
+        const QSharedPointer<InstancedBeadGroup>& group = m_instanced_bead_groups[group_index];
+        if (std::abs(group->width - width) < 0.000001f && std::abs(group->height - height) < 0.000001f) {
+            break;
+        }
+    }
+
+    if (group_index == m_instanced_bead_groups.size()) {
+        QSharedPointer<InstancedBeadGroup> group = QSharedPointer<InstancedBeadGroup>::create();
+        group->width = width;
+        group->height = height;
+        createInstancedBeadTemplate(width, height, group->template_vertices, group->template_normals);
+        group->template_vertex_count = group->template_vertices.size() / 3;
+        m_instanced_bead_groups.push_back(group);
+    }
+
+    QSharedPointer<InstancedBeadGroup>& group = m_instanced_bead_groups[group_index];
+    const uint instance_index = group->instances.size() / kInstanceFloatCount;
+    const QVector3D start = segment->start().toQVector3D();
+    const QVector3D delta = displayEnd(segment) - start;
+    const QColor color = segment->color();
+
+    group->instances.insert(group->instances.end(), {start.x(), start.y(), start.z(), delta.x(), delta.y(), delta.z(),
+                                                     color.redF(), color.greenF(), color.blueF(), color.alphaF()});
+
+    return std::make_pair(group_index, instance_index);
+}
+
+void GCodeObject::populateInstancedBeadsGL() {
+    this->view()->makeCurrent();
+    this->view()->shaderProgram()->bind();
+
+    for (QSharedPointer<InstancedBeadGroup>& group : m_instanced_bead_groups) {
+        group->vao = QSharedPointer<QOpenGLVertexArrayObject>::create();
+        group->vao->create();
+        group->vao->bind();
+
+        group->template_vbo.create();
+        group->template_vbo.setUsagePattern(QOpenGLBuffer::StaticDraw);
+        group->template_vbo.bind();
+        group->template_vbo.allocate(group->template_vertices.data(), group->template_vertices.size() * sizeof(float));
+        this->view()->glEnableVertexAttribArray(0);
+        this->view()->glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+        group->template_nbo.create();
+        group->template_nbo.setUsagePattern(QOpenGLBuffer::StaticDraw);
+        group->template_nbo.bind();
+        group->template_nbo.allocate(group->template_normals.data(), group->template_normals.size() * sizeof(float));
+        this->view()->glEnableVertexAttribArray(1);
+        this->view()->glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+        group->instance_vbo.create();
+        group->instance_vbo.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+        group->instance_vbo.bind();
+        group->instance_vbo.allocate(group->instances.data(), group->instances.size() * sizeof(float));
+
+        this->view()->glEnableVertexAttribArray(4);
+        this->view()->glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
+                                            reinterpret_cast<const void*>(kInstanceStartOffset * sizeof(float)));
+        this->view()->glVertexAttribDivisor(4, 1);
+
+        this->view()->glEnableVertexAttribArray(5);
+        this->view()->glVertexAttribPointer(5, 3, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
+                                            reinterpret_cast<const void*>(kInstanceDeltaOffset * sizeof(float)));
+        this->view()->glVertexAttribDivisor(5, 1);
+
+        this->view()->glEnableVertexAttribArray(6);
+        this->view()->glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
+                                            reinterpret_cast<const void*>(kInstanceColorOffset * sizeof(float)));
+        this->view()->glVertexAttribDivisor(6, 1);
+
+        group->vao->release();
+        group->template_vbo.release();
+        group->template_nbo.release();
+        group->instance_vbo.release();
+    }
+
+    this->view()->shaderProgram()->release();
 }
 
 void GCodeObject::hideSegmentType(SegmentDisplayType type, bool hide) {
@@ -277,7 +531,7 @@ bool GCodeObject::isCurrentlySelected(int line_num) { return m_selected_segments
 const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriangles() {
     QVector<std::pair<uint, std::vector<Triangle>>> ret;
 
-    if (m_lightweight_lines) {
+    if (m_lightweight_lines || m_instanced_beads) {
         return ret;
     }
 
@@ -313,6 +567,11 @@ const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriang
 }
 
 void GCodeObject::draw() {
+    if (m_instanced_beads) {
+        drawInstancedBeads();
+        return;
+    }
+
     for (uint i = m_low_layer; i <= m_high_layer; i++) {
         uint run_offset = 0;
         uint run_length = 0;
@@ -344,7 +603,78 @@ void GCodeObject::draw() {
     }
 }
 
+void GCodeObject::drawInstancedBeads() {
+    constexpr uint invalid_group = std::numeric_limits<uint>::max();
+
+    for (uint i = m_low_layer; i <= m_high_layer; i++) {
+        uint run_group = invalid_group;
+        uint run_first_instance = 0;
+        uint run_instance_count = 0;
+
+        auto drawRun = [&]() {
+            if (run_instance_count > 0) {
+                drawInstancedBeadRun(run_group, run_first_instance, run_instance_count);
+                run_instance_count = 0;
+                run_group = invalid_group;
+            }
+        };
+
+        for (const auto& segment : m_segments[i]) {
+            if (segment->hidden) {
+                drawRun();
+                continue;
+            }
+
+            if (run_instance_count > 0 && run_group == segment->instance_group &&
+                run_first_instance + run_instance_count == segment->instance_offset) {
+                ++run_instance_count;
+            }
+            else {
+                drawRun();
+                run_group = segment->instance_group;
+                run_first_instance = segment->instance_offset;
+                run_instance_count = 1;
+            }
+        }
+
+        drawRun();
+    }
+}
+
+void GCodeObject::drawInstancedBeadRun(uint group_index, uint first_instance, uint instance_count) {
+    if (group_index >= m_instanced_bead_groups.size() || instance_count == 0) {
+        return;
+    }
+
+    const QSharedPointer<InstancedBeadGroup>& group = m_instanced_bead_groups[group_index];
+    const std::uintptr_t first_instance_bytes =
+        static_cast<std::uintptr_t>(first_instance) * static_cast<std::uintptr_t>(kInstanceStrideBytes);
+
+    group->vao->bind();
+    group->instance_vbo.bind();
+
+    this->view()->glVertexAttribPointer(
+        4, 3, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
+        reinterpret_cast<const void*>(first_instance_bytes + (kInstanceStartOffset * sizeof(float))));
+    this->view()->glVertexAttribPointer(
+        5, 3, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
+        reinterpret_cast<const void*>(first_instance_bytes + (kInstanceDeltaOffset * sizeof(float))));
+    this->view()->glVertexAttribPointer(
+        6, 4, GL_FLOAT, GL_FALSE, kInstanceStrideBytes,
+        reinterpret_cast<const void*>(first_instance_bytes + (kInstanceColorOffset * sizeof(float))));
+
+    this->view()->glDrawArraysInstanced(GL_TRIANGLES, 0, group->template_vertex_count, instance_count);
+
+    group->instance_vbo.release();
+    group->vao->release();
+}
+
 void GCodeObject::paintSegment(QSharedPointer<GCodeObject::SegmentDisplayMeta> seg_meta, QColor color) {
+    if (m_instanced_beads) {
+        paintInstancedBead(seg_meta, color);
+        return;
+    }
+
     std::vector<float> new_colors;
     new_colors.resize(seg_meta->length * 4, 0.0f);
 
@@ -356,5 +686,26 @@ void GCodeObject::paintSegment(QSharedPointer<GCodeObject::SegmentDisplayMeta> s
     }
 
     this->updateColors(new_colors, seg_meta->offset * 4);
+}
+
+void GCodeObject::paintInstancedBead(QSharedPointer<GCodeObject::SegmentDisplayMeta> seg_meta, QColor color) {
+    if (seg_meta->instance_group >= m_instanced_bead_groups.size()) {
+        return;
+    }
+
+    QSharedPointer<InstancedBeadGroup>& group = m_instanced_bead_groups[seg_meta->instance_group];
+    const uint color_offset = (seg_meta->instance_offset * kInstanceFloatCount) + kInstanceColorOffset;
+    if (color_offset + 3 >= group->instances.size()) {
+        return;
+    }
+
+    group->instances[color_offset + 0] = color.redF();
+    group->instances[color_offset + 1] = color.greenF();
+    group->instances[color_offset + 2] = color.blueF();
+    group->instances[color_offset + 3] = color.alphaF();
+
+    group->instance_vbo.bind();
+    group->instance_vbo.write(color_offset * sizeof(float), group->instances.data() + color_offset, 4 * sizeof(float));
+    group->instance_vbo.release();
 }
 } // namespace ORNL

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -47,6 +47,8 @@ constexpr float kMinimumPickRadius = 0.025f;
 constexpr float kPickTieTolerance = 0.000001f;
 constexpr float kTravelPickRadiusMultiplier = 2.0f;
 constexpr float kTravelPickScoreBias = 0.75f;
+constexpr float kPickGeometryEpsilon = 0.000001f;
+constexpr float kPickDepthTieRadiusMultiplier = 2.0f;
 
 //! @brief Counts display segments before GL buffer construction so oversized gcode can use a lighter path.
 qsizetype countSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
@@ -133,6 +135,140 @@ void createInstancedBeadTemplate(float width, float height, std::vector<float>& 
         appendInstancedTemplateTriangle(top_vertices[i], top_vertices[j], bottom_vertices[j], vertices, normals);
         appendInstancedTemplateTriangle(bottom_center, bottom_vertices[i], bottom_vertices[j], vertices, normals);
     }
+}
+
+void createInstancedPrismTemplate(float width, float height, std::vector<float>& vertices,
+                                  std::vector<float>& normals) {
+    const float half_side =
+        std::max({width, height, std::numeric_limits<float>::epsilon()}) / 2.0f;
+
+    const std::array<QVector3D, 8> v = {
+        QVector3D(-half_side, -half_side, 0.0f), QVector3D(half_side, -half_side, 0.0f),
+        QVector3D(half_side, half_side, 0.0f),   QVector3D(-half_side, half_side, 0.0f),
+        QVector3D(-half_side, -half_side, 1.0f), QVector3D(half_side, -half_side, 1.0f),
+        QVector3D(half_side, half_side, 1.0f),   QVector3D(-half_side, half_side, 1.0f)};
+
+    // The gcode segment frame mirrors the local prism X axis. Wind prism faces
+    // opposite the local box convention so transformed faces remain outward.
+    appendInstancedTemplateTriangle(v[0], v[2], v[3], vertices, normals);
+    appendInstancedTemplateTriangle(v[0], v[1], v[2], vertices, normals);
+    appendInstancedTemplateTriangle(v[4], v[6], v[5], vertices, normals);
+    appendInstancedTemplateTriangle(v[4], v[7], v[6], vertices, normals);
+    appendInstancedTemplateTriangle(v[0], v[7], v[4], vertices, normals);
+    appendInstancedTemplateTriangle(v[0], v[3], v[7], vertices, normals);
+    appendInstancedTemplateTriangle(v[1], v[6], v[2], vertices, normals);
+    appendInstancedTemplateTriangle(v[1], v[5], v[6], vertices, normals);
+    appendInstancedTemplateTriangle(v[3], v[6], v[7], vertices, normals);
+    appendInstancedTemplateTriangle(v[3], v[2], v[6], vertices, normals);
+    appendInstancedTemplateTriangle(v[0], v[5], v[1], vertices, normals);
+    appendInstancedTemplateTriangle(v[0], v[4], v[5], vertices, normals);
+}
+
+bool renderAsPrism(SegmentDisplayType type) {
+    return type == SegmentDisplayType::kTravel;
+}
+
+QVector3D transformVector(const QMatrix4x4& transform, const QVector3D& vector) {
+    return (transform * QVector4D(vector, 0.0f)).toVector3D();
+}
+
+QVector3D fallbackNormalForTangent(const QVector3D& tangent) {
+    const QVector3D normalized_tangent = tangent.normalized();
+    if (std::abs(QVector3D::dotProduct(normalized_tangent, QVector3D(0.0f, 0.0f, 1.0f))) < 0.9f) {
+        return QVector3D(0.0f, 0.0f, 1.0f);
+    }
+    return QVector3D(1.0f, 0.0f, 0.0f);
+}
+
+QVector3D segmentDisplayNormal(const QVector3D& tangent, const QVector3D& display_normal) {
+    QVector3D normal = display_normal;
+    if (normal.lengthSquared() < kPickGeometryEpsilon) {
+        normal = {GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorX),
+                  GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorY),
+                  GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorZ)};
+    }
+
+    if (normal.lengthSquared() < kPickGeometryEpsilon ||
+        QVector3D::crossProduct(tangent, normal).lengthSquared() < kPickGeometryEpsilon) {
+        normal = fallbackNormalForTangent(tangent);
+    }
+
+    return normal.normalized();
+}
+
+bool rayObbEntryDistance(const QVector3D& ray_start, const QVector3D& ray_dir, const QVector3D& center,
+                         const std::array<QVector3D, 3>& axes, const std::array<float, 3>& half_extents,
+                         float& entry_distance) {
+    float min_distance = 0.0f;
+    float max_distance = std::numeric_limits<float>::infinity();
+    const QVector3D origin_offset = ray_start - center;
+
+    for (uint i = 0; i < axes.size(); ++i) {
+        const float origin_projection = QVector3D::dotProduct(origin_offset, axes[i]);
+        const float direction_projection = QVector3D::dotProduct(ray_dir, axes[i]);
+
+        if (std::abs(direction_projection) < kPickGeometryEpsilon) {
+            if (std::abs(origin_projection) > half_extents[i]) {
+                return false;
+            }
+            continue;
+        }
+
+        float near_distance = (-half_extents[i] - origin_projection) / direction_projection;
+        float far_distance = (half_extents[i] - origin_projection) / direction_projection;
+        if (near_distance > far_distance) {
+            std::swap(near_distance, far_distance);
+        }
+
+        min_distance = std::max(min_distance, near_distance);
+        max_distance = std::min(max_distance, far_distance);
+
+        if (min_distance > max_distance || max_distance < 0.0f) {
+            return false;
+        }
+    }
+
+    entry_distance = min_distance;
+    return true;
+}
+
+bool travelPrismEntryDistance(const QVector3D& pick_start, const QVector3D& pick_end, const QVector3D& pick_normal,
+                              float pick_radius, const QMatrix4x4& transform, const QVector3D& ray_start,
+                              const QVector3D& ray_dir, float& entry_distance) {
+    const QVector3D object_delta = pick_end - pick_start;
+    const float object_length = object_delta.length();
+    if (object_length < kPickGeometryEpsilon) {
+        return false;
+    }
+
+    const QVector3D object_tangent = object_delta / object_length;
+    QVector3D object_normal = segmentDisplayNormal(object_tangent, pick_normal);
+    QVector3D object_binormal = QVector3D::crossProduct(object_tangent, object_normal);
+    if (object_binormal.lengthSquared() < kPickGeometryEpsilon) {
+        object_normal = fallbackNormalForTangent(object_tangent);
+        object_binormal = QVector3D::crossProduct(object_tangent, object_normal);
+    }
+    object_binormal.normalize();
+    object_normal = QVector3D::crossProduct(object_binormal, object_tangent).normalized();
+
+    std::array<QVector3D, 3> axes = {transformVector(transform, object_binormal),
+                                    transformVector(transform, object_normal),
+                                    transformVector(transform, object_tangent)};
+    std::array<float, 3> half_extents = {pick_radius, pick_radius, object_length / 2.0f};
+
+    for (uint i = 0; i < axes.size(); ++i) {
+        const float axis_length = axes[i].length();
+        if (axis_length < kPickGeometryEpsilon) {
+            return false;
+        }
+
+        axes[i] /= axis_length;
+        half_extents[i] *= axis_length;
+    }
+
+    const QVector3D object_center = pick_start + (object_delta * 0.5f);
+    const QVector3D center = transform * object_center;
+    return rayObbEntryDistance(ray_start, ray_dir, center, axes, half_extents, entry_distance);
 }
 
 void appendBoundingVertices(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode, std::vector<float>& vertices,
@@ -242,6 +378,36 @@ float closestRaySegmentDistance(const QVector3D& ray_start, const QVector3D& ray
     const QVector3D closest_segment = seg_start + (segment * segment_t);
     return (closest_ray - closest_segment).length();
 }
+
+float approximateSurfaceEntryDistance(float ray_distance, float segment_distance, float pick_radius) {
+    const float half_chord =
+        std::sqrt(std::max(0.0f, (pick_radius * pick_radius) - (segment_distance * segment_distance)));
+    return std::max(0.0f, ray_distance - half_chord);
+}
+
+bool isBetterPick(float entry_distance, float pick_score, float depth_tolerance, float best_entry_distance,
+                  float best_pick_score, float best_depth_tolerance) {
+    if (!std::isfinite(best_entry_distance)) {
+        return true;
+    }
+
+    const float combined_depth_tolerance = std::max({kPickTieTolerance, depth_tolerance, best_depth_tolerance});
+    if (entry_distance + combined_depth_tolerance < best_entry_distance) {
+        return true;
+    }
+
+    if (std::abs(entry_distance - best_entry_distance) <= combined_depth_tolerance) {
+        if (pick_score + kPickTieTolerance < best_pick_score) {
+            return true;
+        }
+
+        if (std::abs(pick_score - best_pick_score) <= kPickTieTolerance && entry_distance < best_entry_distance) {
+            return true;
+        }
+    }
+
+    return false;
+}
 } // namespace
 
 GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentBase>>> gcode,
@@ -280,6 +446,7 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
             seg_meta->current_color = segment->color();
             seg_meta->pick_start = segment->start().toQVector3D();
             seg_meta->pick_end = displayEnd(segment);
+            seg_meta->pick_normal = segment->displayNormal();
             seg_meta->pick_radius = std::max(segment->displayWidth(), segment->displayHeight()) / 2.0f;
 
             if (m_lightweight_lines) {
@@ -344,11 +511,13 @@ void GCodeObject::configureUniforms() {
 std::pair<uint, uint> GCodeObject::appendInstancedBead(const QSharedPointer<SegmentBase>& segment) {
     const float width = segment->displayWidth();
     const float height = segment->displayHeight();
+    const bool prism = renderAsPrism(segment->displayType());
 
     uint group_index = 0;
     for (; group_index < m_instanced_bead_groups.size(); ++group_index) {
         const QSharedPointer<InstancedBeadGroup>& group = m_instanced_bead_groups[group_index];
-        if (std::abs(group->width - width) < 0.000001f && std::abs(group->height - height) < 0.000001f) {
+        if (group->prism == prism && std::abs(group->width - width) < 0.000001f &&
+            std::abs(group->height - height) < 0.000001f) {
             break;
         }
     }
@@ -357,7 +526,13 @@ std::pair<uint, uint> GCodeObject::appendInstancedBead(const QSharedPointer<Segm
         QSharedPointer<InstancedBeadGroup> group = QSharedPointer<InstancedBeadGroup>::create();
         group->width = width;
         group->height = height;
-        createInstancedBeadTemplate(width, height, group->template_vertices, group->template_normals);
+        group->prism = prism;
+        if (prism) {
+            createInstancedPrismTemplate(width, height, group->template_vertices, group->template_normals);
+        }
+        else {
+            createInstancedBeadTemplate(width, height, group->template_vertices, group->template_normals);
+        }
         group->template_vertex_count = group->template_vertices.size() / 3;
         m_instanced_bead_groups.push_back(group);
     }
@@ -626,8 +801,9 @@ uint GCodeObject::pickSegment(const QMatrix4x4& projection, const QMatrix4x4& vi
         std::max({transform.column(0).toVector3D().length(), transform.column(1).toVector3D().length(),
                   transform.column(2).toVector3D().length(), 1.0f});
 
+    float best_entry_distance = std::numeric_limits<float>::infinity();
     float best_pick_score = std::numeric_limits<float>::infinity();
-    float best_ray_distance = std::numeric_limits<float>::infinity();
+    float best_depth_tolerance = 0.0f;
     uint picked_line = 0;
 
     for (uint i = m_low_layer; i <= m_high_layer; ++i) {
@@ -635,26 +811,51 @@ uint GCodeObject::pickSegment(const QMatrix4x4& projection, const QMatrix4x4& vi
             if (segment->hidden)
                 continue;
 
+            float entry_distance = std::numeric_limits<float>::infinity();
+            float pick_score = std::numeric_limits<float>::infinity();
+            float depth_tolerance = 0.0f;
+            bool hit = false;
+
             const QVector3D start = transform * segment->pick_start;
             const QVector3D end = transform * segment->pick_end;
+            const float world_pick_radius = std::max(segment->pick_radius * radius_scale, kMinimumPickRadius);
 
-            float ray_distance = std::numeric_limits<float>::infinity();
-            const float segment_distance = closestRaySegmentDistance(ray_start, ray_dir, start, end, ray_distance);
-            float pick_radius = std::max(segment->pick_radius * radius_scale, kMinimumPickRadius);
             if (segment->type == SegmentDisplayType::kTravel) {
-                pick_radius *= kTravelPickRadiusMultiplier;
+                hit = travelPrismEntryDistance(segment->pick_start, segment->pick_end, segment->pick_normal,
+                                               segment->pick_radius, transform, ray_start, ray_dir, entry_distance);
+                if (hit) {
+                    float ray_distance = std::numeric_limits<float>::infinity();
+                    const float segment_distance = closestRaySegmentDistance(ray_start, ray_dir, start, end,
+                                                                             ray_distance);
+                    pick_score = (segment_distance / world_pick_radius) * kTravelPickScoreBias;
+                    depth_tolerance = world_pick_radius * kPickDepthTieRadiusMultiplier;
+                }
             }
 
-            float pick_score = segment_distance / pick_radius;
-            if (segment->type == SegmentDisplayType::kTravel) {
-                pick_score *= kTravelPickScoreBias;
+            if (!hit) {
+                float ray_distance = std::numeric_limits<float>::infinity();
+                const float segment_distance = closestRaySegmentDistance(ray_start, ray_dir, start, end, ray_distance);
+                float pick_radius = world_pick_radius;
+                if (segment->type == SegmentDisplayType::kTravel) {
+                    pick_radius *= kTravelPickRadiusMultiplier;
+                }
+
+                if (segment_distance <= pick_radius) {
+                    hit = true;
+                    entry_distance = approximateSurfaceEntryDistance(ray_distance, segment_distance, pick_radius);
+                    pick_score = segment_distance / pick_radius;
+                    if (segment->type == SegmentDisplayType::kTravel) {
+                        pick_score *= kTravelPickScoreBias;
+                    }
+                    depth_tolerance = pick_radius * kPickDepthTieRadiusMultiplier;
+                }
             }
 
-            if (segment_distance <= pick_radius && (pick_score + kPickTieTolerance < best_pick_score ||
-                                                   (std::abs(pick_score - best_pick_score) <= kPickTieTolerance &&
-                                                    ray_distance < best_ray_distance))) {
+            if (hit && isBetterPick(entry_distance, pick_score, depth_tolerance, best_entry_distance, best_pick_score,
+                                    best_depth_tolerance)) {
+                best_entry_distance = entry_distance;
                 best_pick_score = pick_score;
-                best_ray_distance = ray_distance;
+                best_depth_tolerance = depth_tolerance;
                 picked_line = segment->line;
             }
         }

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -314,12 +314,33 @@ const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriang
 
 void GCodeObject::draw() {
     for (uint i = m_low_layer; i <= m_high_layer; i++) {
-        for (const auto& segment : m_segments[i]) {
-            if (segment->hidden)
-                continue;
+        uint run_offset = 0;
+        uint run_length = 0;
 
-            this->view()->glDrawArrays(this->renderMode(), segment->offset, segment->length);
+        auto drawRun = [&]() {
+            if (run_length > 0) {
+                this->view()->glDrawArrays(this->renderMode(), run_offset, run_length);
+                run_length = 0;
+            }
+        };
+
+        for (const auto& segment : m_segments[i]) {
+            if (segment->hidden) {
+                drawRun();
+                continue;
+            }
+
+            if (run_length > 0 && run_offset + run_length == segment->offset) {
+                run_length += segment->length;
+            }
+            else {
+                drawRun();
+                run_offset = segment->offset;
+                run_length = segment->length;
+            }
         }
+
+        drawRun();
     }
 }
 

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -23,6 +23,7 @@
 #include "geometry/segments/line.h"
 #include "graphics/base_view.h"
 #include "graphics/graphics_object.h"
+#include "graphics/support/part_picker.h"
 #include "managers/settings/settings_manager.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
@@ -41,6 +42,10 @@ constexpr uint kInstanceStartOffset = 0;
 constexpr uint kInstanceDeltaOffset = 3;
 constexpr uint kInstanceColorOffset = 6;
 constexpr uint kInstanceStrideBytes = kInstanceFloatCount * sizeof(float);
+constexpr float kMinimumPickRadius = 0.025f;
+constexpr float kPickTieTolerance = 0.000001f;
+constexpr float kTravelPickRadiusMultiplier = 2.0f;
+constexpr float kTravelPickScoreBias = 0.75f;
 
 //! @brief Counts display segments before GL buffer construction so oversized gcode can use a lighter path.
 qsizetype countSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
@@ -203,6 +208,39 @@ void appendLightweightLine(const QSharedPointer<SegmentBase>& segment, std::vect
         colors.push_back(segment->color().alphaF());
     }
 }
+
+float closestRaySegmentDistance(const QVector3D& ray_start, const QVector3D& ray_dir, const QVector3D& seg_start,
+                                const QVector3D& seg_end, float& ray_distance) {
+    const QVector3D segment = seg_end - seg_start;
+    const QVector3D ray_to_segment = ray_start - seg_start;
+    const float segment_length_squared = segment.lengthSquared();
+
+    if (segment_length_squared < std::numeric_limits<float>::epsilon()) {
+        ray_distance = std::max(0.0f, QVector3D::dotProduct(seg_start - ray_start, ray_dir));
+        return ((ray_start + (ray_dir * ray_distance)) - seg_start).length();
+    }
+
+    const float ray_segment_dot = QVector3D::dotProduct(ray_dir, segment);
+    const float segment_offset_dot = QVector3D::dotProduct(segment, ray_to_segment);
+    const float ray_offset_dot = QVector3D::dotProduct(ray_dir, ray_to_segment);
+    const float denominator = segment_length_squared - (ray_segment_dot * ray_segment_dot);
+
+    float segment_t = 0.0f;
+    if (std::abs(denominator) > std::numeric_limits<float>::epsilon()) {
+        segment_t = (segment_offset_dot - (ray_segment_dot * ray_offset_dot)) / denominator;
+        segment_t = std::clamp(segment_t, 0.0f, 1.0f);
+    }
+
+    ray_distance = QVector3D::dotProduct((seg_start + (segment * segment_t)) - ray_start, ray_dir);
+    if (ray_distance < 0.0f) {
+        ray_distance = 0.0f;
+        segment_t = std::clamp(-segment_offset_dot / segment_length_squared, 0.0f, 1.0f);
+    }
+
+    const QVector3D closest_ray = ray_start + (ray_dir * ray_distance);
+    const QVector3D closest_segment = seg_start + (segment * segment_t);
+    return (closest_ray - closest_segment).length();
+}
 } // namespace
 
 GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentBase>>> gcode,
@@ -239,6 +277,9 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
             seg_meta->type = segment->displayType();
             seg_meta->original_color = segment->color();
             seg_meta->current_color = segment->color();
+            seg_meta->pick_start = segment->start().toQVector3D();
+            seg_meta->pick_end = displayEnd(segment);
+            seg_meta->pick_radius = std::max(segment->displayWidth(), segment->displayHeight()) / 2.0f;
 
             if (m_lightweight_lines) {
                 seg_meta->offset = vertices.size() / 3;
@@ -564,6 +605,54 @@ const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriang
     }
 
     return ret;
+}
+
+uint GCodeObject::pickSegment(const QMatrix4x4& projection, const QMatrix4x4& view, const QPointF& mouse_ndc_pos,
+                              bool ortho) {
+    QVector3D ray_start;
+    QVector3D ray_dir;
+    std::tie(ray_start, ray_dir) = PartPicker::getDirectionAndStart(projection, mouse_ndc_pos, view, ortho);
+
+    const QMatrix4x4 transform = this->transformation();
+    const float radius_scale =
+        std::max({transform.column(0).toVector3D().length(), transform.column(1).toVector3D().length(),
+                  transform.column(2).toVector3D().length(), 1.0f});
+
+    float best_pick_score = std::numeric_limits<float>::infinity();
+    float best_ray_distance = std::numeric_limits<float>::infinity();
+    uint picked_line = 0;
+
+    for (uint i = m_low_layer; i <= m_high_layer; ++i) {
+        for (const QSharedPointer<SegmentDisplayMeta>& segment : m_segments[i]) {
+            if (segment->hidden)
+                continue;
+
+            const QVector3D start = transform * segment->pick_start;
+            const QVector3D end = transform * segment->pick_end;
+
+            float ray_distance = std::numeric_limits<float>::infinity();
+            const float segment_distance = closestRaySegmentDistance(ray_start, ray_dir, start, end, ray_distance);
+            float pick_radius = std::max(segment->pick_radius * radius_scale, kMinimumPickRadius);
+            if (segment->type == SegmentDisplayType::kTravel) {
+                pick_radius *= kTravelPickRadiusMultiplier;
+            }
+
+            float pick_score = segment_distance / pick_radius;
+            if (segment->type == SegmentDisplayType::kTravel) {
+                pick_score *= kTravelPickScoreBias;
+            }
+
+            if (segment_distance <= pick_radius && (pick_score + kPickTieTolerance < best_pick_score ||
+                                                   (std::abs(pick_score - best_pick_score) <= kPickTieTolerance &&
+                                                    ray_distance < best_ray_distance))) {
+                best_pick_score = pick_score;
+                best_ray_distance = ray_distance;
+                picked_line = segment->line;
+            }
+        }
+    }
+
+    return picked_line;
 }
 
 void GCodeObject::draw() {

--- a/src/graphics/objects/part_object.cpp
+++ b/src/graphics/objects/part_object.cpp
@@ -146,6 +146,7 @@ void PartObject::draw() {
     }
 }
 void PartObject::configureUniforms() {
+    GraphicsObject::configureUniforms();
     view()->shaderProgram()->setUniformValue(m_shader_locs.renderingPartObject, true);
 }
 

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -3,6 +3,7 @@
 
 #include <math.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <limits>
@@ -894,6 +895,47 @@ void ShapeFactory::createGcodeCylinder(const float& width, const float& length, 
         appendTriangle(bottom_center, bottom_vertices[i], bottom_vertices[j], color, vertices, colors,
                        normals); // Bottom triangle
     }
+}
+
+void ShapeFactory::createGcodePrism(const float& width, const float& length, const float& height,
+                                    const QVector3D& start, const QVector3D& end, const QColor& color,
+                                    std::vector<float>& vertices, std::vector<float>& colors,
+                                    std::vector<float>& normals) {
+    createGcodePrism(width, length, height, start, end, QVector3D(), color, vertices, colors, normals);
+}
+
+void ShapeFactory::createGcodePrism(const float& width, const float& length, const float& height,
+                                    const QVector3D& start, const QVector3D& end,
+                                    const QVector3D& display_normal, const QColor& color,
+                                    std::vector<float>& vertices, std::vector<float>& colors,
+                                    std::vector<float>& normals) {
+    const QMatrix4x4 transform = computeGcodeCylinderTransform(start, end, display_normal);
+    const float half_side =
+        std::max({width, height, std::numeric_limits<float>::epsilon()}) / 2.0f;
+
+    const QVector3D v0 = transform * QVector3D(-half_side, -half_side, 0.0f);
+    const QVector3D v1 = transform * QVector3D(half_side, -half_side, 0.0f);
+    const QVector3D v2 = transform * QVector3D(half_side, half_side, 0.0f);
+    const QVector3D v3 = transform * QVector3D(-half_side, half_side, 0.0f);
+    const QVector3D v4 = transform * QVector3D(-half_side, -half_side, length);
+    const QVector3D v5 = transform * QVector3D(half_side, -half_side, length);
+    const QVector3D v6 = transform * QVector3D(half_side, half_side, length);
+    const QVector3D v7 = transform * QVector3D(-half_side, half_side, length);
+
+    // The gcode segment frame mirrors the local prism X axis. Wind prism faces
+    // opposite the local box convention so transformed faces remain outward.
+    appendTriangle(v0, v2, v3, color, vertices, colors, normals);
+    appendTriangle(v0, v1, v2, color, vertices, colors, normals);
+    appendTriangle(v4, v6, v5, color, vertices, colors, normals);
+    appendTriangle(v4, v7, v6, color, vertices, colors, normals);
+    appendTriangle(v0, v7, v4, color, vertices, colors, normals);
+    appendTriangle(v0, v3, v7, color, vertices, colors, normals);
+    appendTriangle(v1, v6, v2, color, vertices, colors, normals);
+    appendTriangle(v1, v5, v6, color, vertices, colors, normals);
+    appendTriangle(v3, v6, v7, color, vertices, colors, normals);
+    appendTriangle(v3, v2, v6, color, vertices, colors, normals);
+    appendTriangle(v0, v5, v1, color, vertices, colors, normals);
+    appendTriangle(v0, v4, v5, color, vertices, colors, normals);
 }
 
 void ShapeFactory::createCone(float radius, float height, const QMatrix4x4& transform, const QColor& color,

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -21,6 +21,16 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
+namespace {
+QVector3D fallbackNormalForTangent(const QVector3D& tangent) {
+    const QVector3D normalized_tangent = tangent.normalized();
+    if (std::abs(QVector3D::dotProduct(normalized_tangent, QVector3D(0.0f, 0.0f, 1.0f))) < 0.9f) {
+        return QVector3D(0.0f, 0.0f, 1.0f);
+    }
+    return QVector3D(1.0f, 0.0f, 0.0f);
+}
+} // namespace
+
 void ShapeFactory::createRectangle(float length, float width, float height, const QMatrix4x4& transform,
                                    const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
                                    std::vector<float>& normals) {
@@ -815,8 +825,16 @@ void ShapeFactory::createGcodeCylinder(const float& width, const float& length, 
                                        const QVector3D& start, const QVector3D& end, const QColor& color,
                                        std::vector<float>& vertices, std::vector<float>& colors,
                                        std::vector<float>& normals) {
+    createGcodeCylinder(width, length, height, start, end, QVector3D(), color, vertices, colors, normals);
+}
+
+void ShapeFactory::createGcodeCylinder(const float& width, const float& length, const float& height,
+                                       const QVector3D& start, const QVector3D& end,
+                                       const QVector3D& display_normal, const QColor& color,
+                                       std::vector<float>& vertices, std::vector<float>& colors,
+                                       std::vector<float>& normals) {
     // Compute the transformation matrix for the clipped cylinder
-    QMatrix4x4 transform = computeGcodeCylinderTransform(start, end);
+    QMatrix4x4 transform = computeGcodeCylinderTransform(start, end, display_normal);
 
     // Radius of the clipped cylinder and number of quads per side
     float radius;
@@ -1293,24 +1311,38 @@ void ShapeFactory::createBuildVolumeCylinder(float radius, float height, float x
 }
 
 QMatrix4x4 ShapeFactory::computeGcodeCylinderTransform(const QVector3D& start, const QVector3D& end) {
+    return computeGcodeCylinderTransform(start, end, QVector3D());
+}
+
+QMatrix4x4 ShapeFactory::computeGcodeCylinderTransform(const QVector3D& start, const QVector3D& end,
+                                                       const QVector3D& display_normal) {
     // Convert the start position and displacement to a transform matrix we can use in the standard method
     QMatrix4x4 transform;
     transform.translate(start);
 
     // Retrieve the tangent (forward) vector from start to end
-    QVector3D tangent = end.normalized();
+    QVector3D tangent = end;
+    if (tangent.lengthSquared() < std::numeric_limits<float>::epsilon()) {
+        tangent = QVector3D(0.0f, 0.0f, 1.0f);
+    }
+    else {
+        tangent.normalize();
+    }
 
     // Retrieve the normal (up) vector from the global settings
-    QVector3D normal = {GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorX),
-                        GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorY),
-                        GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorZ)};
+    QVector3D normal = display_normal;
+    if (normal.lengthSquared() < std::numeric_limits<float>::epsilon()) {
+        normal = {GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorX),
+                  GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorY),
+                  GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorZ)};
+    }
     normal.normalize();
 
     // Compute the right vector
     QVector3D binormal = QVector3D::crossProduct(tangent, normal);
     if (binormal.lengthSquared() < std::numeric_limits<float>::epsilon()) {
-        // Up and forward are parallel or anti-parallel; choose a different up vector
-        normal = QVector3D(1, 0, 0);
+        // Up and forward are parallel or anti-parallel; choose a different up vector.
+        normal = fallbackNormalForTangent(tangent);
         binormal = QVector3D::crossProduct(tangent, normal);
     }
     binormal.normalize();

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -76,6 +76,11 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
         m_gcode_object->hideSegmentType(m_state.hidden_type, true);
 
         m_printer->adoptChild(m_gcode_object);
+
+        uint segment_count = m_gcode_object->visibleSegmentCount();
+        this->setMouseTracking(segment_count <= 10000);
+        if (segment_count > 0)
+            emit maxSegmentChanged(segment_count - 1);
     }
 
     // Clear out old ghosted parts
@@ -265,6 +270,9 @@ uint GCodeView::pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeOb
     uint picked_seg = 0;
 
     auto tris = gog->segmentTriangles();
+    if (tris.isEmpty()) {
+        return gog->pickSegment(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, m_state.ortho);
+    }
 
     for (auto& tri : tris) {
         float dist = PartPicker::pickDistance(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, tri.second,

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -1,5 +1,6 @@
 #include "threading/gcode_loader.h"
 
+#include <cmath>
 #include <limits>
 #include <tuple>
 
@@ -57,6 +58,19 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
+namespace {
+double shortestAngleDeltaDegrees(double start_degrees, double end_degrees) {
+    double delta = end_degrees - start_degrees;
+    while (delta > 180.0) {
+        delta -= 360.0;
+    }
+    while (delta < -180.0) {
+        delta += 360.0;
+    }
+    return delta;
+}
+} // namespace
+
 GCodeLoader::GCodeLoader(QString filename, bool alterFile)
     : m_filename(filename), m_adjust_file(alterFile), m_should_cancel(false) {
     m_sb = GSM->getGlobal();
@@ -282,6 +296,7 @@ void GCodeLoader::run() {
             m_origin = QVector3D(m_x_offset, m_y_offset, 0.0f);
             m_table_offset = 0.0f;
             m_prev_table_offset = 0.0f;
+            parseRadialVisualizationHints();
 
             // reserve more memory than the hash will need to guarantee no reallocation
             QHash<QString, QTextCharFormat> fontColors;
@@ -579,6 +594,33 @@ void GCodeLoader::setParser(QStringList& originalLines, QStringList& lines) {
     }
 }
 
+void GCodeLoader::parseRadialVisualizationHints() {
+    m_has_last_radial_c = false;
+    m_last_radial_c_degrees = 0.0;
+    m_radial_c_axis_offset_degrees = GSM->getGlobal()->setting<Angle>(PRS::MachineSetup::kAxisC).to(degree);
+
+    if (m_selected_meta.m_syntax_id != GcodeSyntax::kRadial3Plus2) {
+        return;
+    }
+
+    const QRegularExpression c_axis_offset_pattern(
+        R"(C\s+AXIS\s+OFFSET:\s*([-+]?(?:\d+(?:\.\d*)?|\.\d+)))", QRegularExpression::CaseInsensitiveOption);
+
+    for (const QString& line : m_original_lines) {
+        const QRegularExpressionMatch match = c_axis_offset_pattern.match(line);
+        if (!match.hasMatch()) {
+            continue;
+        }
+
+        bool parsed = false;
+        const double offset = match.captured(1).toDouble(&parsed);
+        if (parsed) {
+            m_radial_c_axis_offset_degrees = offset;
+        }
+        return;
+    }
+}
+
 QColor GCodeLoader::determineFontColor(const QString& comment) {
 
     if (m_prestart.indexIn(comment) != -1) {
@@ -658,6 +700,25 @@ QColor GCodeLoader::determineFontColor(const QString& comment) {
     }
 
     return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kUnknown);
+}
+
+QVector3D GCodeLoader::radialDisplayNormal(const QMap<char, double>& parameters) {
+    if (m_selected_meta.m_syntax_id != GcodeSyntax::kRadial3Plus2 || !parameters.contains('C')) {
+        return QVector3D();
+    }
+
+    const double current_c_degrees = parameters['C'];
+    double segment_c_degrees = current_c_degrees;
+    if (m_has_last_radial_c) {
+        segment_c_degrees =
+            m_last_radial_c_degrees + (shortestAngleDeltaDegrees(m_last_radial_c_degrees, current_c_degrees) / 2.0);
+    }
+
+    m_last_radial_c_degrees = current_c_degrees;
+    m_has_last_radial_c = true;
+
+    const double radians = qDegreesToRadians(segment_c_degrees - m_radial_c_axis_offset_degrees);
+    return QVector3D(std::cos(radians), std::sin(radians), 0.0f).normalized();
 }
 
 void GCodeLoader::setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, const QColor& color,
@@ -833,6 +894,7 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
     }
 
     QVector<QSharedPointer<SegmentBase>> generated_segments;
+    const QVector3D display_normal = radialDisplayNormal(parameters);
 
     if (extruder_on || is_travel) {
         QSharedPointer<SegmentBase> segment;
@@ -896,6 +958,10 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
             else { // G0, G1, or anything else is drawn as a line
                 // Create line segment
                 segment = QSharedPointer<LineSegment>::create(m_start_pos, end_pos - m_start_pos);
+            }
+
+            if (!segment.isNull() && display_normal.lengthSquared() > std::numeric_limits<float>::epsilon()) {
+                segment->setDisplayNormal(display_normal);
             }
 
             // Set the segment's display info

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -1025,6 +1025,7 @@ const char* Constants::OpenGL::Shader::kStackingAxisName = "stackingAxis";
 const char* Constants::OpenGL::Shader::kOverhangAngleName = "overhangAngle";
 const char* Constants::OpenGL::Shader::kOverhangModeName = "usingOverhangMode";
 const char* Constants::OpenGL::Shader::kRenderingPartObjectName = "renderingPartObject";
+const char* Constants::OpenGL::Shader::kUsingInstancedGcodeName = "usingInstancedGcode";
 //================================================================================
 // Slicer 1 Keys - used for gcode processing (all caps)
 //================================================================================


### PR DESCRIPTION
## Summary
- Restore versioned Windows installer artifact names by using the Nix derivation name.
- Add the GitHub Actions run number to each generated installer `.exe` name.

## Root Cause
The Windows CI job hardcoded `ornlslicer-installer.exe`, so repeated GitHub Actions runs produced installers with the same name.

## Impact
Installer artifacts are now distinguishable across runs, for example `ornlslicer-x86_64-w64-mingw32-2.0.0-run-<run_number>-installer.exe`.

Closes #133.

## Validation
- `git diff --check`
- YAML parse of `.github/workflows/ci.yml`
- `nix eval --raw .#windows.ornl.ornlslicer.name`