### PR TITLE
refactor: improve G-code visualization, progress, and shape generation

### DIFF
--- a/include/graphics/objects/gcode_object.h
+++ b/include/graphics/objects/gcode_object.h
@@ -7,8 +7,11 @@
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlist.h>
+#include <qopenglbuffer.h>
+#include <qopenglvertexarrayobject.h>
 #include <qsharedpointer.h>
 #include <qtypes.h>
+#include <qvectornd.h>
 
 #include "geometry/segment_base.h"
 #include "graphics/graphics_object.h"
@@ -32,6 +35,9 @@ class GCodeObject : public GraphicsObject {
     //! \param segmentInfoControl: Segment / Bead info display control
     GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentBase>>> gcode,
                 QSharedPointer<GCodeInfoControl> segmentInfoControl);
+
+    //! \brief Destructor.
+    ~GCodeObject();
 
     //! \brief Hides/Show all segments matching a type.
     //! \param type: Type to hide/show.
@@ -84,17 +90,26 @@ class GCodeObject : public GraphicsObject {
     //! \return Pairs of (layer number, Triangles) for each segment.
     const QVector<std::pair<uint, std::vector<Triangle>>> segmentTriangles();
 
+    //! \brief Line primitives that compose lightweight-rendered segments.
+    //! \return Pairs of (line number, segment endpoints) for each line segment.
+    const QVector<std::pair<uint, std::pair<QVector3D, QVector3D>>> segmentLines();
+
   protected:
     //! \brief Overridden draw call to allow segment hiding.
     void draw();
 
   private:
+    //! \brief Render buffer that contains a segment's vertices.
+    enum class SegmentRenderBuffer { kPrimary, kTravelLine };
+
     //! \brief Segment metadata.
     struct SegmentDisplayMeta {
         //! \brief Segment location in GL buffer.
         uint offset = 0;
         //! \brief Segment length in GL buffer.
         uint length = 0;
+        //! \brief Buffer containing this segment's geometry.
+        SegmentRenderBuffer buffer = SegmentRenderBuffer::kPrimary;
 
         //! \brief If this segment is hidden.
         bool hidden = false;
@@ -110,11 +125,21 @@ class GCodeObject : public GraphicsObject {
         uint line;
 
         bool operator==(const SegmentDisplayMeta& rhs) const {
-            return offset == rhs.offset && length == rhs.length && hidden == rhs.hidden && type == rhs.type &&
-                   original_color == rhs.original_color && current_color == rhs.current_color && layer == rhs.layer &&
-                   line == rhs.line;
+            return offset == rhs.offset && length == rhs.length && buffer == rhs.buffer && hidden == rhs.hidden &&
+                   type == rhs.type && original_color == rhs.original_color && current_color == rhs.current_color &&
+                   layer == rhs.layer && line == rhs.line;
         }
     };
+
+    //! \brief Initializes the secondary GL line buffer used by travel segments.
+    void populateTravelLineGL(BaseView* view, const std::vector<float>& vertices, const std::vector<float>& normals,
+                              const std::vector<float>& colors);
+
+    //! \brief Draws all visible runs for the requested buffer.
+    void drawBufferRuns(SegmentRenderBuffer buffer, ushort render_mode);
+
+    //! \brief Updates the travel line color buffer with new float data.
+    void updateTravelLineColors(std::vector<float>& colors, uint whence);
 
     //! \brief Paints a segment different color.
     //! \param seg_meta: Segment to paint.
@@ -123,6 +148,22 @@ class GCodeObject : public GraphicsObject {
 
     //! \brief True when very large gcode is rendered as lightweight GL lines instead of bead meshes.
     bool m_lightweight_lines = false;
+
+    //! \brief Render mode used by the primary GraphicsObject buffer.
+    ushort m_primary_render_mode = GL_TRIANGLES;
+
+    //! \brief Travel line buffer geometry.
+    std::vector<float> m_travel_line_vertices;
+    std::vector<float> m_travel_line_normals;
+    std::vector<float> m_travel_line_colors;
+    std::vector<float> m_travel_line_uv;
+
+    //! \brief Travel line OpenGL buffers.
+    QSharedPointer<QOpenGLVertexArrayObject> m_travel_line_vao;
+    QOpenGLBuffer m_travel_line_vbo;
+    QOpenGLBuffer m_travel_line_cbo;
+    QOpenGLBuffer m_travel_line_nbo;
+    QOpenGLBuffer m_travel_line_tbo;
 
     //! \brief Segment metadata container.
     QVector<QVector<QSharedPointer<SegmentDisplayMeta>>> m_segments;

--- a/include/graphics/support/shape_factory.h
+++ b/include/graphics/support/shape_factory.h
@@ -106,10 +106,12 @@ class ShapeFactory final {
      *  @param vertices Destination xyz vertex buffer to append to.
      *  @param colors Destination rgba color buffer to append to.
      *  @param normals Destination xyz normal buffer to append to.
+     *  @param quads_per_side Number of quads used to approximate each rounded side of the bead cross-section. Defaults
+     *                         to 4.
      */
     static void appendLinearBead(float width, float length, float height, const QVector3D& start, const QVector3D& end,
                                  const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
-                                 std::vector<float>& normals);
+                                 std::vector<float>& normals, unsigned int quads_per_side = 4);
 
     /*! \brief Appends a circular-arc bead triangle mesh.
      *

--- a/include/graphics/support/shape_factory.h
+++ b/include/graphics/support/shape_factory.h
@@ -4,14 +4,19 @@
 
 #include <QColor>
 #include <QMatrix4x4>
-#include <qvectornd.h>
+#include <QVector3D>
 
 #include "geometry/point.h"
 
 namespace ORNL {
-//! \brief "Class" for creating various geometries. Input vectors are appended to so shapes can be built additively.
-class ShapeFactory {
+//! \brief Utility for appending generated geometry to OpenGL buffer vectors.
+//!
+//! All creation functions append to the supplied vectors so callers can build combined meshes without intermediate
+//! allocations.
+class ShapeFactory final {
   public:
+    ShapeFactory() = delete;
+
     /*! \brief Append the data for a rectangular prism to input vectors
      *
      *  @param length Total X dimension
@@ -66,10 +71,9 @@ class ShapeFactory {
      *  @param colors Vertex colors of the clipped cylinder
      *  @param normals Normal vectors of the clipped cylinder
      */
-    static void createGcodeCylinder(const float& width, const float& length, const float& height,
-                                    const QVector3D& start, const QVector3D& end, const QColor& color,
-                                    std::vector<float>& vertices, std::vector<float>& colors,
-                                    std::vector<float>& normals);
+    static void createGcodeCylinder(float width, float length, float height, const QVector3D& start,
+                                    const QVector3D& end, const QColor& color, std::vector<float>& vertices,
+                                    std::vector<float>& colors, std::vector<float>& normals);
 
     /*!
      * \brief appends the data for a arc cylinder to input vectors
@@ -77,15 +81,15 @@ class ShapeFactory {
      * @param cylinder_height how thick of a cylinder to draw
      * @param start the start point of the cylinder
      * @param center the center point of the arc
-     * @param angle the angle of the arc
-     * @param transform the transformation matrix to place the arc at the correct point
+     * @param end the end point of the cylinder
+     * @param is_ccw true when the arc is counter-clockwise
      * @param color the color to draw the arc as
      * @param vertices Vector of vertices to append the new vertices to
      * @param colors Vector of colors to append the new colors to
      * @param normals Vector of normals to append the new normals to
      */
-    static void createArcCylinder(const float cylinder_height, const Point& start, const Point& center,
-                                  const Point& end, bool is_ccw, const QColor& color, std::vector<float>& vertices,
+    static void createArcCylinder(float cylinder_height, const Point& start, const Point& center, const Point& end,
+                                  bool is_ccw, const QColor& color, std::vector<float>& vertices,
                                   std::vector<float>& colors, std::vector<float>& normals);
 
     /*!
@@ -100,7 +104,7 @@ class ShapeFactory {
      * @param colors Vector of colors to append the new colors to
      * @param normals Vector of normals to append the new normals to
      */
-    static void createSplineCylinder(const float cylinder_height, const Point& start, const Point& control_a,
+    static void createSplineCylinder(float cylinder_height, const Point& start, const Point& control_a,
                                      const Point& control_b, const Point& end, const QColor& color,
                                      std::vector<float>& vertices, std::vector<float>& colors,
                                      std::vector<float>& normals);
@@ -145,10 +149,10 @@ class ShapeFactory {
      *  @param vertices Vector of vertices to append the new vertices to
      *  @param colors Vector of colors to append the new colors to
      */
-    static void createBuildVolumeRectangle(const QVector3D& min, const QVector3D& max, const float& x_grid_dist,
-                                           const float& x_grid_offset, const float& y_grid_dist,
-                                           const float& y_grid_offset, const QColor& color,
-                                           std::vector<float>& vertices, std::vector<float>& colors);
+    static void createBuildVolumeRectangle(const QVector3D& min, const QVector3D& max, float x_grid_dist,
+                                           float x_grid_offset, float y_grid_dist, float y_grid_offset,
+                                           const QColor& color, std::vector<float>& vertices,
+                                           std::vector<float>& colors);
 
     /*! \brief Create cylinder for build volume representation
      *
@@ -178,7 +182,7 @@ class ShapeFactory {
      * @param cylinder_height how thick of a cylinder to draw
      * @param start the start point of the cylinder
      * @param center the center point of the arc
-     * @param angle the angle of the arc
+     * @param end the end point of the cylinder
      * @param transform the transformation matrix to place the arc at the correct point
      * @param color the color to draw the arc as
      * @param vertices Vector of vertices to append the new vertices to
@@ -194,7 +198,7 @@ class ShapeFactory {
      * @param cylinder_height how thick of a cylinder to draw
      * @param start the start point of the cylinder
      * @param center the center point of the arc
-     * @param angle the angle of the arc
+     * @param end the end point of the cylinder
      * @param transform the transformation matrix to place the arc at the correct point
      * @param color the color to draw the arc as
      * @param vertices Vector of vertices to append the new vertices to
@@ -204,16 +208,5 @@ class ShapeFactory {
     static void createArcCylinderCCW(float cylinder_height, const Point& start, const Point& center, const Point& end,
                                      const QMatrix4x4& transform, const QColor& color, std::vector<float>& vertices,
                                      std::vector<float>& colors, std::vector<float>& normals);
-
-    //! adds three vectors to array and computes normal/ colors
-    //! \param v0 the first vertex
-    //! \param v1 the second vertex
-    //! \param v2 the third vertex
-    //! \param color the color to draw as
-    //! \param vertices Vector of vertices to append the new vertices to
-    //! \param colors Vector of colors to append the new colors to
-    //! \param normals Vector of normals to append the new normals to
-    static void appendTriangle(const QVector3D& v0, const QVector3D& v1, const QVector3D& v2, const QColor& color,
-                               std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals);
 };
-} // Namespace ORNL
+} // namespace ORNL

--- a/include/graphics/support/shape_factory.h
+++ b/include/graphics/support/shape_factory.h
@@ -17,196 +17,234 @@ class ShapeFactory final {
   public:
     ShapeFactory() = delete;
 
-    /*! \brief Append the data for a rectangular prism to input vectors
-     *
-     *  @param length Total X dimension
-     *  @param width Total Y dimension
-     *  @param height Total Z dimension
-     *  @param transform Matrix to apply to each vertex
-     *  @param color Color of prism
-     *  @param vertices Vector of vertices to append the new vertices to
-     *  @param colors Vector of colors to append the new colors to
-     *  @param normals Vector of normals to append the new normals to
-     */
-    static void createRectangle(float length, float width, float height, const QMatrix4x4& transform,
-                                const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
-                                std::vector<float>& normals);
+    //! \name Closed Triangle Meshes
+    //! @{
 
-    /*! \brief Append the data for a cylinder to input vectors
+    /*! \brief Appends a transformed rectangular-prism triangle mesh.
      *
-     *  @param radius Radius of cylinder
-     *  @param height Height of cylinder
-     *  @param transform Matrix to apply to each vertex
-     *  @param color Color of cylinder
-     *  @param vertices Vector of vertices to append the new vertices to
-     *  @param colors Vector of colors to append the new colors to
-     *  @param normals Vector of normals to append the new normals to
+     *  The prism is centered at the local origin before \p transform is applied.
+     *  Output is suitable for GL_TRIANGLES.
+     *
+     *  @param length Local X dimension.
+     *  @param width Local Y dimension.
+     *  @param height Local Z dimension.
+     *  @param transform Matrix applied to every generated vertex.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     *  @param normals Destination xyz normal buffer to append to.
      */
-    static void createCylinder(float radius, float height, const QMatrix4x4& transform, const QColor& color,
+    static void appendBox(float length, float width, float height, const QMatrix4x4& transform, const QColor& color,
+                          std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals);
+
+    /*! \brief Appends a transformed capped-cylinder triangle mesh.
+     *
+     *  The local cylinder runs from z=0 to z=\p height before \p transform is applied.
+     *  Output is suitable for GL_TRIANGLES.
+     *
+     *  @param radius Local cylinder radius.
+     *  @param height Local cylinder height.
+     *  @param transform Matrix applied to every generated vertex.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     *  @param normals Destination xyz normal buffer to append to.
+     */
+    static void appendCylinder(float radius, float height, const QMatrix4x4& transform, const QColor& color,
                                std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals);
 
-    /*! \brief Append the data for a sphere to input vectors
+    /*! \brief Appends a transformed UV-sphere triangle mesh.
      *
-     *  @param radius: Radius of sphere
-     *  @param sectorCount: Number of horizontal sectors that make up sphere
-     *  @param stackCount: Number of vertical sectors that make up sphere
-     *  @param transform: Matrix to apply to each vertex
-     *  @param color: Color of sphere
-     *  @param vertices: Vector of vertices to append the new vertices to
-     *  @param colors: Vector of colors to append the new colors to
-     *  @param normals: Vector of normals to append the new normals to
+     *  Output is suitable for GL_TRIANGLES.
+     *
+     *  @param radius Local sphere radius.
+     *  @param sector_count Number of longitudinal sectors.
+     *  @param stack_count Number of latitudinal stacks.
+     *  @param transform Matrix applied to every generated vertex.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     *  @param normals Destination xyz normal buffer to append to.
      */
-    static void createSphere(float radius, int sectorCount, int stackCount, const QMatrix4x4& transform,
+    static void appendSphere(float radius, int sector_count, int stack_count, const QMatrix4x4& transform,
                              const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
                              std::vector<float>& normals);
 
-    /*! \brief Append the data for a clipped cylinder to the input vector
-     *  @param width: Width of the clipped cylinder
-     *  @param length: Length of the clipped cylinder
-     *  @param height: Height of the clipped cylinder
-     *  @param start: Start point of the gcode segment
-     *  @param end: End point of the gcode segment
-     *  @param color: Color of the clipped cylinder
-     *  @param vertices Vertices of the clipped cylinder
-     *  @param colors Vertex colors of the clipped cylinder
-     *  @param normals Normal vectors of the clipped cylinder
-     */
-    static void createGcodeCylinder(float width, float length, float height, const QVector3D& start,
-                                    const QVector3D& end, const QColor& color, std::vector<float>& vertices,
-                                    std::vector<float>& colors, std::vector<float>& normals);
-
-    /*!
-     * \brief appends the data for a arc cylinder to input vectors
-     * \note this is an overload that automatically computes the transform
-     * @param cylinder_height how thick of a cylinder to draw
-     * @param start the start point of the cylinder
-     * @param center the center point of the arc
-     * @param end the end point of the cylinder
-     * @param is_ccw true when the arc is counter-clockwise
-     * @param color the color to draw the arc as
-     * @param vertices Vector of vertices to append the new vertices to
-     * @param colors Vector of colors to append the new colors to
-     * @param normals Vector of normals to append the new normals to
-     */
-    static void createArcCylinder(float cylinder_height, const Point& start, const Point& center, const Point& end,
-                                  bool is_ccw, const QColor& color, std::vector<float>& vertices,
-                                  std::vector<float>& colors, std::vector<float>& normals);
-
-    /*!
-     * \brief appends the data for a spline cylinder for input values
-     * @param cylinder_height how thick of a cylinder to draw
-     * @param start the start point of the cylinder
-     * @param control_a the first control point
-     * @param control_b the second control point
-     * @param end the end point of the spline
-     * @param color the color to draw the arc as
-     * @param vertices Vector of vertices to append the new vertices to
-     * @param colors Vector of colors to append the new colors to
-     * @param normals Vector of normals to append the new normals to
-     */
-    static void createSplineCylinder(float cylinder_height, const Point& start, const Point& control_a,
-                                     const Point& control_b, const Point& end, const QColor& color,
-                                     std::vector<float>& vertices, std::vector<float>& colors,
-                                     std::vector<float>& normals);
-
-    /*! \brief Append the data for a cone to input vectors
+    /*! \brief Appends a transformed capped-cone triangle mesh.
      *
-     *  @param radius Radius of base of cone
-     *  @param height Height from base to tip
-     *  @param transform Matrix to apply to each vertex
-     *  @param color Color of cone
-     *  @param vertices Vector of vertices to append the new vertices to
-     *  @param colors Vector of colors to append the new colors to
-     *  @param normals Vector of normals to append the new normals to
+     *  The local cone base is on z=0 and its tip is at z=\p height before \p transform is applied.
+     *  Output is suitable for GL_TRIANGLES.
+     *
+     *  @param radius Local base radius.
+     *  @param height Local height from base to tip.
+     *  @param transform Matrix applied to every generated vertex.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     *  @param normals Destination xyz normal buffer to append to.
      */
-    static void createCone(float radius, float height, const QMatrix4x4& transform, const QColor& color,
+    static void appendCone(float radius, float height, const QMatrix4x4& transform, const QColor& color,
                            std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals);
 
-    /*! \brief Create rectangle for use as a plane.
-     *
-     *  Constructs a wire frame rectangular prism build volume representation
-     *  @param length: length of plane
-     *  @param width: length of plane
-     *  @param x_grid_dist: Distance between grid lines in x direction
-     *  @param y_grid_dist: Distance between grid lines in y direction
-     *  @param color Color of resulting volume
-     *  @param vertices Vector of vertices to append the new vertices to
-     *  @param colors Vector of colors to append the new colors to
-     */
-    static void createGridPlane(float length, float width, float x_grid_dist, float y_grid_dist, const QColor& color,
-                                std::vector<float>& vertices, std::vector<float>& colors);
+    //! @}
 
-    /*! \brief Create rectangle for build volume representation
-     *
-     *  Constructs a wire frame rectangular prism build volume representation
-     *  @param min Min value of rectangle
-     *  @param max Max value of rectangle
-     *  @param x_grid_dist: Distance between grid lines in x direction
-     *  @param x_grid_offset: Distance to offset the first grid line from the minimum X
-     *  @param y_grid_dist: Distance between grid lines in y direction
-     *  @param y_grid_offset: Distance to offset the first grid line from the minimum Y
-     *  @param color Color of resulting volume
-     *  @param vertices Vector of vertices to append the new vertices to
-     *  @param colors Vector of colors to append the new colors to
-     */
-    static void createBuildVolumeRectangle(const QVector3D& min, const QVector3D& max, float x_grid_dist,
-                                           float x_grid_offset, float y_grid_dist, float y_grid_offset,
-                                           const QColor& color, std::vector<float>& vertices,
-                                           std::vector<float>& colors);
+    //! \name Toolpath Bead Meshes
+    //! @{
 
-    /*! \brief Create cylinder for build volume representation
+    /*! \brief Appends a straight squished-bead triangle mesh between two points.
      *
-     *  Constructs a wire frame cylindrical build volume representation
-     *  @param radius Radius of circle for top/bottom of cylinder
-     *  @param height Height of cylinder
-     *  @param x_grid_dist: Distance between grid lines in x direction
-     *  @param y_grid_dist: Distance between grid lines in y direction
-     *  @param color Color of resulting volume
-     *  @param vertices Vector of vertices to append the new vertices to
-     *  @param colors Vector of colors to append the new colors to
+     *  This is the filled G-code line bead representation, not a round cylinder. The cross-section is clipped/squished
+     *  from \p width and \p height, capped at \p start and \p end, and oriented using the current slicing vector.
+     *  Output is suitable for GL_TRIANGLES.
+     *
+     *  @param width Display bead width across the path.
+     *  @param length Display bead length along the path.
+     *  @param height Display bead height.
+     *  @param start Segment start point.
+     *  @param end Segment end point.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     *  @param normals Destination xyz normal buffer to append to.
      */
-    static void createBuildVolumeCylinder(float radius, float height, float x_grid_dist, float y_grid_dist,
+    static void appendLinearBead(float width, float length, float height, const QVector3D& start, const QVector3D& end,
+                                 const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
+                                 std::vector<float>& normals);
+
+    /*! \brief Appends a circular-arc bead triangle mesh.
+     *
+     *  The bead follows the XY arc defined by \p start, \p center, \p end, and \p is_ccw. Z is linearly interpolated
+     *  from start to end. Output is suitable for GL_TRIANGLES.
+     *
+     *  @param bead_diameter Diameter of the circular bead cross-section.
+     *  @param start Arc start point.
+     *  @param center Arc center point.
+     *  @param end Arc end point.
+     *  @param is_ccw True when the arc travels counter-clockwise.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     *  @param normals Destination xyz normal buffer to append to.
+     */
+    static void appendArcBead(float bead_diameter, const Point& start, const Point& center, const Point& end,
+                              bool is_ccw, const QColor& color, std::vector<float>& vertices,
+                              std::vector<float>& colors, std::vector<float>& normals);
+
+    /*! \brief Appends a cubic Bezier bead triangle mesh.
+     *
+     *  The bead follows the cubic Bezier curve defined by start, two controls, and end. Output is suitable for
+     *  GL_TRIANGLES.
+     *
+     *  @param bead_diameter Diameter of the circular bead cross-section.
+     *  @param start Curve start point.
+     *  @param control_a First Bezier control point.
+     *  @param control_b Second Bezier control point.
+     *  @param end Curve end point.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     *  @param normals Destination xyz normal buffer to append to.
+     */
+    static void appendSplineBead(float bead_diameter, const Point& start, const Point& control_a,
+                                 const Point& control_b, const Point& end, const QColor& color,
+                                 std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals);
+
+    //! @}
+
+    //! \name Line Geometry
+    //! @{
+
+    /*! \brief Appends XY grid lines for a rectangular plane centered at the origin.
+     *
+     *  Output is suitable for GL_LINES.
+     *
+     *  @param length Plane length in X.
+     *  @param width Plane width in Y.
+     *  @param x_grid_dist Distance between grid lines parallel to Y.
+     *  @param y_grid_dist Distance between grid lines parallel to X.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     */
+    static void appendGridPlaneLines(float length, float width, float x_grid_dist, float y_grid_dist,
+                                     const QColor& color, std::vector<float>& vertices, std::vector<float>& colors);
+
+    /*! \brief Appends wireframe and floor-grid lines for a rectangular build volume.
+     *
+     *  Output is suitable for GL_LINES.
+     *
+     *  @param min Minimum build-volume corner.
+     *  @param max Maximum build-volume corner.
+     *  @param x_grid_dist Distance between floor grid lines parallel to Y.
+     *  @param x_grid_offset X offset for the first floor grid line.
+     *  @param y_grid_dist Distance between floor grid lines parallel to X.
+     *  @param y_grid_offset Y offset for the first floor grid line.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     */
+    static void appendBuildVolumeBoxLines(const QVector3D& min, const QVector3D& max, float x_grid_dist,
+                                          float x_grid_offset, float y_grid_dist, float y_grid_offset,
                                           const QColor& color, std::vector<float>& vertices,
                                           std::vector<float>& colors);
 
+    /*! \brief Appends wireframe and floor-grid lines for a cylindrical build volume.
+     *
+     *  Output is suitable for GL_LINES.
+     *
+     *  @param radius Build-volume radius.
+     *  @param height Build-volume height.
+     *  @param x_grid_dist Distance between floor grid lines parallel to Y.
+     *  @param y_grid_dist Distance between floor grid lines parallel to X.
+     *  @param color RGBA color applied to every generated vertex.
+     *  @param vertices Destination xyz vertex buffer to append to.
+     *  @param colors Destination rgba color buffer to append to.
+     */
+    static void appendBuildVolumeCylinderLines(float radius, float height, float x_grid_dist, float y_grid_dist,
+                                               const QColor& color, std::vector<float>& vertices,
+                                               std::vector<float>& colors);
+
+    //! @}
+
   private:
-    /*! \brief Helper function to compute the transformation matrix for a gcode cylinder
-     *  @param start Start point of the gcode segment
-     *  @param end End point of the gcode segment
-     *  @return Transformation matrix to place the cylinder at the correct point and orientation
+    /*! \brief Computes the transform that places a local +Z bead mesh between two endpoints.
+     *  @param start Segment start point.
+     *  @param end Segment end point.
+     *  @return Transform that translates to \p start and rotates local +Z toward \p end.
      */
-    static QMatrix4x4 computeGcodeCylinderTransform(const QVector3D& start, const QVector3D& end);
+    static QMatrix4x4 computeLinearBeadTransform(const QVector3D& start, const QVector3D& end);
 
     /*!
-     * \brief appends the data for a clockwise (G2) arc cylinder to input vectors
-     * @param cylinder_height how thick of a cylinder to draw
-     * @param start the start point of the cylinder
-     * @param center the center point of the arc
-     * @param end the end point of the cylinder
-     * @param transform the transformation matrix to place the arc at the correct point
-     * @param color the color to draw the arc as
-     * @param vertices Vector of vertices to append the new vertices to
-     * @param colors Vector of colors to append the new colors to
-     * @param normals Vector of normals to append the new normals to
+     * \brief Appends a clockwise circular-arc bead using a precomputed placement transform.
+     * @param bead_diameter Diameter of the circular bead cross-section.
+     * @param start Arc start point.
+     * @param center Arc center point.
+     * @param end Arc end point.
+     * @param transform Matrix placing the local arc frame in world coordinates.
+     * @param color RGBA color applied to every generated vertex.
+     * @param vertices Destination xyz vertex buffer to append to.
+     * @param colors Destination rgba color buffer to append to.
+     * @param normals Destination xyz normal buffer to append to.
      */
-    static void createArcCylinder(float cylinder_height, const Point& start, const Point& center, const Point& end,
-                                  const QMatrix4x4& transform, const QColor& color, std::vector<float>& vertices,
-                                  std::vector<float>& colors, std::vector<float>& normals);
+    static void appendArcBeadClockwise(float bead_diameter, const Point& start, const Point& center, const Point& end,
+                                       const QMatrix4x4& transform, const QColor& color, std::vector<float>& vertices,
+                                       std::vector<float>& colors, std::vector<float>& normals);
 
     /*!
-     * \brief appends the data for a counter-clockwise (G3) arc cylinder to input vectors
-     * @param cylinder_height how thick of a cylinder to draw
-     * @param start the start point of the cylinder
-     * @param center the center point of the arc
-     * @param end the end point of the cylinder
-     * @param transform the transformation matrix to place the arc at the correct point
-     * @param color the color to draw the arc as
-     * @param vertices Vector of vertices to append the new vertices to
-     * @param colors Vector of colors to append the new colors to
-     * @param normals Vector of normals to append the new normals to
+     * \brief Appends a counter-clockwise circular-arc bead using a precomputed placement transform.
+     * @param bead_diameter Diameter of the circular bead cross-section.
+     * @param start Arc start point.
+     * @param center Arc center point.
+     * @param end Arc end point.
+     * @param transform Matrix placing the local arc frame in world coordinates.
+     * @param color RGBA color applied to every generated vertex.
+     * @param vertices Destination xyz vertex buffer to append to.
+     * @param colors Destination rgba color buffer to append to.
+     * @param normals Destination xyz normal buffer to append to.
      */
-    static void createArcCylinderCCW(float cylinder_height, const Point& start, const Point& center, const Point& end,
-                                     const QMatrix4x4& transform, const QColor& color, std::vector<float>& vertices,
-                                     std::vector<float>& colors, std::vector<float>& normals);
+    static void appendArcBeadCounterClockwise(float bead_diameter, const Point& start, const Point& center,
+                                              const Point& end, const QMatrix4x4& transform, const QColor& color,
+                                              std::vector<float>& vertices, std::vector<float>& colors,
+                                              std::vector<float>& normals);
 };
 } // namespace ORNL

--- a/include/graphics/support/shape_factory.h
+++ b/include/graphics/support/shape_factory.h
@@ -9,7 +9,7 @@
 #include "geometry/point.h"
 
 namespace ORNL {
-//! \brief Utility for appending generated geometry to OpenGL buffer vectors.
+//! @brief Utility for appending generated geometry to OpenGL buffer vectors.
 //!
 //! All creation functions append to the supplied vectors so callers can build combined meshes without intermediate
 //! allocations.
@@ -17,12 +17,12 @@ class ShapeFactory final {
   public:
     ShapeFactory() = delete;
 
-    //! \name Closed Triangle Meshes
+    //! @name Closed Triangle Meshes
     //! @{
 
-    /*! \brief Appends a transformed rectangular-prism triangle mesh.
+    /*! @brief Appends a transformed rectangular-prism triangle mesh.
      *
-     *  The prism is centered at the local origin before \p transform is applied.
+     *  The prism is centered at the local origin before @p transform is applied.
      *  Output is suitable for GL_TRIANGLES.
      *
      *  @param length Local X dimension.
@@ -37,9 +37,9 @@ class ShapeFactory final {
     static void appendBox(float length, float width, float height, const QMatrix4x4& transform, const QColor& color,
                           std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals);
 
-    /*! \brief Appends a transformed capped-cylinder triangle mesh.
+    /*! @brief Appends a transformed capped-cylinder triangle mesh.
      *
-     *  The local cylinder runs from z=0 to z=\p height before \p transform is applied.
+     *  The local cylinder runs from z=0 to z=@p height before @p transform is applied.
      *  Output is suitable for GL_TRIANGLES.
      *
      *  @param radius Local cylinder radius.
@@ -53,7 +53,7 @@ class ShapeFactory final {
     static void appendCylinder(float radius, float height, const QMatrix4x4& transform, const QColor& color,
                                std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals);
 
-    /*! \brief Appends a transformed UV-sphere triangle mesh.
+    /*! @brief Appends a transformed UV-sphere triangle mesh.
      *
      *  Output is suitable for GL_TRIANGLES.
      *
@@ -70,9 +70,9 @@ class ShapeFactory final {
                              const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
                              std::vector<float>& normals);
 
-    /*! \brief Appends a transformed capped-cone triangle mesh.
+    /*! @brief Appends a transformed capped-cone triangle mesh.
      *
-     *  The local cone base is on z=0 and its tip is at z=\p height before \p transform is applied.
+     *  The local cone base is on z=0 and its tip is at z=@p height before @p transform is applied.
      *  Output is suitable for GL_TRIANGLES.
      *
      *  @param radius Local base radius.
@@ -88,13 +88,13 @@ class ShapeFactory final {
 
     //! @}
 
-    //! \name Toolpath Bead Meshes
+    //! @name Toolpath Bead Meshes
     //! @{
 
-    /*! \brief Appends a straight squished-bead triangle mesh between two points.
+    /*! @brief Appends a straight squished-bead triangle mesh between two points.
      *
      *  This is the filled G-code line bead representation, not a round cylinder. The cross-section is clipped/squished
-     *  from \p width and \p height, capped at \p start and \p end, and oriented using the current slicing vector.
+     *  from @p width and @p height, capped at @p start and @p end, and oriented using the current slicing vector.
      *  Output is suitable for GL_TRIANGLES.
      *
      *  @param width Display bead width across the path.
@@ -113,9 +113,9 @@ class ShapeFactory final {
                                  const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
                                  std::vector<float>& normals, unsigned int quads_per_side = 4);
 
-    /*! \brief Appends a circular-arc bead triangle mesh.
+    /*! @brief Appends a circular-arc bead triangle mesh.
      *
-     *  The bead follows the XY arc defined by \p start, \p center, \p end, and \p is_ccw. Z is linearly interpolated
+     *  The bead follows the XY arc defined by @p start, @p center, @p end, and @p is_ccw. Z is linearly interpolated
      *  from start to end. Output is suitable for GL_TRIANGLES.
      *
      *  @param bead_diameter Diameter of the circular bead cross-section.
@@ -132,7 +132,7 @@ class ShapeFactory final {
                               bool is_ccw, const QColor& color, std::vector<float>& vertices,
                               std::vector<float>& colors, std::vector<float>& normals);
 
-    /*! \brief Appends a cubic Bezier bead triangle mesh.
+    /*! @brief Appends a cubic Bezier bead triangle mesh.
      *
      *  The bead follows the cubic Bezier curve defined by start, two controls, and end. Output is suitable for
      *  GL_TRIANGLES.
@@ -153,10 +153,10 @@ class ShapeFactory final {
 
     //! @}
 
-    //! \name Line Geometry
+    //! @name Line Geometry
     //! @{
 
-    /*! \brief Appends XY grid lines for a rectangular plane centered at the origin.
+    /*! @brief Appends XY grid lines for a rectangular plane centered at the origin.
      *
      *  Output is suitable for GL_LINES.
      *
@@ -171,7 +171,7 @@ class ShapeFactory final {
     static void appendGridPlaneLines(float length, float width, float x_grid_dist, float y_grid_dist,
                                      const QColor& color, std::vector<float>& vertices, std::vector<float>& colors);
 
-    /*! \brief Appends wireframe and floor-grid lines for a rectangular build volume.
+    /*! @brief Appends wireframe and floor-grid lines for a rectangular build volume.
      *
      *  Output is suitable for GL_LINES.
      *
@@ -190,7 +190,7 @@ class ShapeFactory final {
                                           const QColor& color, std::vector<float>& vertices,
                                           std::vector<float>& colors);
 
-    /*! \brief Appends wireframe and floor-grid lines for a cylindrical build volume.
+    /*! @brief Appends wireframe and floor-grid lines for a cylindrical build volume.
      *
      *  Output is suitable for GL_LINES.
      *
@@ -209,10 +209,10 @@ class ShapeFactory final {
     //! @}
 
   private:
-    /*! \brief Computes the transform that places a local +Z bead mesh between two endpoints.
+    /*! @brief Computes the transform that places a local +Z bead mesh between two endpoints.
      *  @param start Segment start point.
      *  @param end Segment end point.
-     *  @return Transform that translates to \p start and rotates local +Z toward \p end.
+     *  @return Transform that translates to @p start and rotates local +Z toward @p end.
      */
     static QMatrix4x4 computeLinearBeadTransform(const QVector3D& start, const QVector3D& end);
 };

--- a/include/graphics/support/shape_factory.h
+++ b/include/graphics/support/shape_factory.h
@@ -213,38 +213,5 @@ class ShapeFactory final {
      *  @return Transform that translates to \p start and rotates local +Z toward \p end.
      */
     static QMatrix4x4 computeLinearBeadTransform(const QVector3D& start, const QVector3D& end);
-
-    /*!
-     * \brief Appends a clockwise circular-arc bead using a precomputed placement transform.
-     * @param bead_diameter Diameter of the circular bead cross-section.
-     * @param start Arc start point.
-     * @param center Arc center point.
-     * @param end Arc end point.
-     * @param transform Matrix placing the local arc frame in world coordinates.
-     * @param color RGBA color applied to every generated vertex.
-     * @param vertices Destination xyz vertex buffer to append to.
-     * @param colors Destination rgba color buffer to append to.
-     * @param normals Destination xyz normal buffer to append to.
-     */
-    static void appendArcBeadClockwise(float bead_diameter, const Point& start, const Point& center, const Point& end,
-                                       const QMatrix4x4& transform, const QColor& color, std::vector<float>& vertices,
-                                       std::vector<float>& colors, std::vector<float>& normals);
-
-    /*!
-     * \brief Appends a counter-clockwise circular-arc bead using a precomputed placement transform.
-     * @param bead_diameter Diameter of the circular bead cross-section.
-     * @param start Arc start point.
-     * @param center Arc center point.
-     * @param end Arc end point.
-     * @param transform Matrix placing the local arc frame in world coordinates.
-     * @param color RGBA color applied to every generated vertex.
-     * @param vertices Destination xyz vertex buffer to append to.
-     * @param colors Destination rgba color buffer to append to.
-     * @param normals Destination xyz normal buffer to append to.
-     */
-    static void appendArcBeadCounterClockwise(float bead_diameter, const Point& start, const Point& center,
-                                              const Point& end, const QMatrix4x4& transform, const QColor& color,
-                                              std::vector<float>& vertices, std::vector<float>& colors,
-                                              std::vector<float>& normals);
 };
 } // namespace ORNL

--- a/include/graphics/view/gcode_view.h
+++ b/include/graphics/view/gcode_view.h
@@ -129,6 +129,9 @@ class GCodeView : public BaseView {
     void handleWheelBackward(QPointF mouse_ndc_pos, float delta) override;
 
   private:
+    //! \brief Enables hover tracking only when the visible segment count is small enough for interactive picking.
+    void updateHoverTracking();
+
     //! \brief Picks a segment based on the mouse position.
     //! \param mouse_ndc_pos: Mouse normalized location.
     //! \param gog: GCode object to search through.

--- a/include/threading/gcode_loader.h
+++ b/include/threading/gcode_loader.h
@@ -101,17 +101,23 @@ class GCodeLoader : public QThread {
     //! \return color based on comment keywords
     QColor determineFontColor(const QString& comment);
 
+    //! \brief determine display type based on comment keywords
+    //! \param comment: Comment to parse
+    //! \return semantic display type used for visibility and selection behavior
+    SegmentDisplayType determineSegmentDisplayType(const QString& comment);
+
     //! \brief Set the segment display information based on the region type defined in the comment.
     //! \param segment: Segment to set display info for.
+    //! \param type: Segment visibility/display classification.
     //! \param color: Color to set for the segment.
     //! \param comment: Comment to parse for the segment type.
     //! \param start_pos: The start position of the segment.
     //! \param end_pos: The end position of the segment.
     //! \param line_num: The line number of the segment.
     //! \param layer_num: The layer number of the segment.
-    void setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, const QColor& color, const QString& comment,
-                               const QVector3D& start_pos, const QVector3D& end_pos, const int& line_num,
-                               const int& layer_num);
+    void setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, SegmentDisplayType type, const QColor& color,
+                               const QString& comment, const QVector3D& start_pos, const QVector3D& end_pos,
+                               const int& line_num, const int& layer_num);
 
     //! \brief Set the segment meta information. This is the information that is displayed when the user selects
     //! a segment in the UI.
@@ -136,13 +142,13 @@ class GCodeLoader : public QThread {
     //! \param parameters: Parameters of gcodecommand end (x, y, z, w, i, j, p, q)
     //! \param extruder_on: whether the extruder is on
     //! \param extruder_speed: double value read from gcode
-    //! \param is_travel: if this line is a travel, ignores extruder status
+    //! \param include_non_extruding_moves: if true, generates visual segments when the extruder is off
     //! \param optional_parameters: Parameters of gcodecommand for start (x, y, z, w)
     //! \return List of generated visual segments.
     QVector<QSharedPointer<SegmentBase>>
     generateVisualSegment(int line_num, int layer_num, const QColor& color, int command_id,
                           const QMap<char, double>& parameters, bool extruder_on, double extruder_speed,
-                          bool is_travel, const QString comment,
+                          bool include_non_extruding_moves, const QString comment,
                           const QMap<char, double>& optional_parameters = QMap<char, double>());
 
     //! \brief Filename.

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -1037,6 +1037,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
     }
     setXPos(temp_x);
     setYPos(temp_y);
+    setZPos(temp_z);
 }
 
 void CommonParser::G3Handler(QVector<QString> params) {

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -264,6 +264,7 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
     QString newCurrentLine, zOffsetString;
     double currentZOffset = sb->setting<Distance>(PRS::Dimensions::kZOffset).to(m_distance_unit);
     bool no_error;
+    int last_status_percent = -1;
 
     // parse each line
     for (; m_current_line <= m_current_end_line; ++m_current_line) {
@@ -406,8 +407,12 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
                 m_layer_start_lines.push_back(m_current_line + 1);
             }
 
-            emit statusUpdate(StatusUpdateStepType::kGcodeParsing,
-                              qRound((double)(m_current_line + 1) / (double)(m_current_end_line + 1) * 100));
+            const int status_percent =
+                qRound((double)(m_current_line + 1) / (double)(m_current_end_line + 1) * 100);
+            if (status_percent != last_status_percent) {
+                emit statusUpdate(StatusUpdateStepType::kGcodeParsing, status_percent);
+                last_status_percent = status_percent;
+            }
         }
 
         if (m_should_cancel)

--- a/src/gcode/writers/five_axis_marlin_writer.cpp
+++ b/src/gcode/writers/five_axis_marlin_writer.cpp
@@ -11,6 +11,7 @@
 #include "gcode/gcode_meta.h"
 #include "gcode/writers/writer_base.h"
 #include "geometry/point.h"
+#include "geometry/segments/arc.h"
 #include "units/unit.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
@@ -548,7 +549,7 @@ QString FiveAxisMarlinWriter::writeArc(const Point& start_point, const Point& en
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance length = angle() * center_point.distance(start_point);
+        Distance length = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
         Distance width = params->setting<Distance>(SS::kWidth);
         Distance height = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);

--- a/src/gcode/writers/haas_metric_no_comments_writer.cpp
+++ b/src/gcode/writers/haas_metric_no_comments_writer.cpp
@@ -231,8 +231,6 @@ QString HaasMetricNoCommentsWriter::writeArc(const Point& start_point, const Poi
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
-    rv += ((ccw) ? m_G3 : m_G2);
-
     // Turn on the extruder if it isn't already on
     if (!m_extruder_on && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm);

--- a/src/gcode/writers/kraussmaffei_writer.cpp
+++ b/src/gcode/writers/kraussmaffei_writer.cpp
@@ -11,6 +11,7 @@
 #include "gcode/gcode_meta.h"
 #include "gcode/writers/writer_base.h"
 #include "geometry/point.h"
+#include "geometry/segments/arc.h"
 #include "units/unit.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
@@ -416,7 +417,7 @@ QString KraussMaffeiWriter::writeArc(const Point& start_point, const Point& end_
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance length = angle() * center_point.distance(start_point);
+        Distance length = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
         Distance width = params->setting<Distance>(SS::kWidth);
         Distance height = params->setting<Distance>(SS::kHeight);
         Volume segment_extrusion_amount = length * width * height;

--- a/src/gcode/writers/mach4_writer.cpp
+++ b/src/gcode/writers/mach4_writer.cpp
@@ -11,6 +11,7 @@
 #include "gcode/gcode_meta.h"
 #include "gcode/writers/writer_base.h"
 #include "geometry/point.h"
+#include "geometry/segments/arc.h"
 #include "units/unit.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
@@ -460,7 +461,7 @@ QString Mach4Writer::writeArc(const Point& start_point, const Point& end_point, 
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance length = angle() * center_point.distance(start_point);
+        Distance length = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
         Distance width = params->setting<Distance>(SS::kWidth);
         Distance height = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);

--- a/src/gcode/writers/marlin_writer.cpp
+++ b/src/gcode/writers/marlin_writer.cpp
@@ -11,6 +11,7 @@
 #include "gcode/gcode_meta.h"
 #include "gcode/writers/writer_base.h"
 #include "geometry/point.h"
+#include "geometry/segments/arc.h"
 #include "units/unit.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
@@ -547,7 +548,7 @@ QString MarlinWriter::writeArc(const Point& start_point, const Point& end_point,
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance length = angle() * center_point.distance(start_point);
+        Distance length = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
         Distance width = params->setting<Distance>(SS::kWidth);
         Distance height = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);

--- a/src/gcode/writers/reprap_writer.cpp
+++ b/src/gcode/writers/reprap_writer.cpp
@@ -410,7 +410,7 @@ QString RepRapWriter::writeArc(const Point& start_point, const Point& end_point,
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance segment_length = ArcSegment(start_point, end_point, center_point, ccw).length();
+        Distance segment_length = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
         Distance width = params->setting<Distance>(SS::kWidth);
         Distance height = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);

--- a/src/geometry/path_modifier.cpp
+++ b/src/geometry/path_modifier.cpp
@@ -663,7 +663,7 @@ void PathModifierGenerator::GenerateSpiralLift(Path& path, Distance spiralWidth,
         Point spiral_end_point(startPoint.x() + spiralWidth + spiralHeight * qCos(355.0 * M_PI / 180),
                                startPoint.y() + spiralWidth + spiralHeight * qSin(355.0 * M_PI / 180),
                                startPoint.z() + spiralHeight);
-        Point center_point(startPoint.x(), startPoint.y());
+        Point center_point(startPoint.x(), startPoint.y(), startPoint.z());
 
         writeSegment(path, startPoint, spiral_start_point, path.back()->getSb()->setting<Distance>(SS::kWidth),
                      spiralHeight, spiralLiftVelocity, path.back()->getSb()->setting<Acceleration>(SS::kAccel), .0f,

--- a/src/geometry/path_modifier.cpp
+++ b/src/geometry/path_modifier.cpp
@@ -659,9 +659,11 @@ void PathModifierGenerator::GenerateSpiralLift(Path& path, Distance spiralWidth,
     Point startPoint = path.back()->end();
 
     if (supportsG3) {
+        const Angle spiral_angle = 355.0f * degree;
+        const Angle end_angle = (360.0f * degree) - spiral_angle;
         Point spiral_start_point(startPoint.x() + spiralWidth, startPoint.y(), startPoint.z());
-        Point spiral_end_point(startPoint.x() + spiralWidth + spiralHeight * qCos(355.0 * M_PI / 180),
-                               startPoint.y() + spiralWidth + spiralHeight * qSin(355.0 * M_PI / 180),
+        Point spiral_end_point(startPoint.x() + spiralWidth * qCos(end_angle()),
+                               startPoint.y() + spiralWidth * qSin(end_angle()),
                                startPoint.z() + spiralHeight);
         Point center_point(startPoint.x(), startPoint.y(), startPoint.z());
 
@@ -670,7 +672,7 @@ void PathModifierGenerator::GenerateSpiralLift(Path& path, Distance spiralWidth,
                      path.back()->getSb()->setting<RegionType>(SS::kRegionType), PathModifiers::kSpiralLift,
                      path.back()->getSb()->setting<int>(SS::kMaterialNumber));
 
-        writeArcSegment(path, spiral_start_point, spiral_end_point, center_point, 355, false,
+        writeArcSegment(path, spiral_start_point, spiral_end_point, center_point, spiral_angle, false,
                         path.back()->getSb()->setting<Distance>(SS::kWidth),
                         path.back()->getSb()->setting<Distance>(SS::kHeight), spiralLiftVelocity,
                         path.back()->getSb()->setting<Acceleration>(SS::kAccel), .0f,

--- a/src/geometry/segments/arc.cpp
+++ b/src/geometry/segments/arc.cpp
@@ -52,8 +52,7 @@ ArcSegment::ArcSegment(Point start, Point end, Point center, bool ccw)
 }
 
 void ArcSegment::createGraphic(std::vector<float>& vertices, std::vector<float>& normals, std::vector<float>& colors) {
-    ShapeFactory::createArcCylinder(m_display_width, m_start, m_center, m_end, m_ccw, m_color, vertices, colors,
-                                    normals);
+    ShapeFactory::appendArcBead(m_display_width, m_start, m_center, m_end, m_ccw, m_color, vertices, colors, normals);
 }
 
 QSharedPointer<SegmentBase> ArcSegment::clone() const { return QSharedPointer<ArcSegment>::create(*this); }

--- a/src/geometry/segments/arc.cpp
+++ b/src/geometry/segments/arc.cpp
@@ -2,6 +2,7 @@
 
 #include <math.h>
 
+#include <cmath>
 #include <limits>
 #include <vector>
 
@@ -83,7 +84,12 @@ float ArcSegment::getMinZ() {
         return m_end.z();
 }
 
-Distance ArcSegment::length() { return m_angle() * m_center.distance(m_start); }
+Distance ArcSegment::length() {
+    const double planar_radius = std::hypot(m_start.x() - m_center.x(), m_start.y() - m_center.y());
+    const double planar_length = m_angle() * planar_radius;
+    const double z_delta = m_end.z() - m_start.z();
+    return Distance(std::hypot(planar_length, z_delta));
+}
 
 Point ArcSegment::CalculateCenter(const Point& start, const Point& middle, const Point& end) {
     const double ax = start.x() - end.x();

--- a/src/geometry/segments/arc.cpp
+++ b/src/geometry/segments/arc.cpp
@@ -2,7 +2,6 @@
 
 #include <math.h>
 
-#include <cassert>
 #include <vector>
 
 #include <qhashfunctions.h>
@@ -12,6 +11,7 @@
 #include <qsharedpointer.h>
 #include <qvectornd.h>
 
+#include "exceptions/exceptions.h"
 #include "gcode/writers/writer_base.h"
 #include "geometry/point.h"
 #include "geometry/segment_base.h"
@@ -29,8 +29,9 @@ ArcSegment::ArcSegment(Point start, Point end, Point center, Angle angle, bool c
 
 ArcSegment::ArcSegment(Point start, Point middle, Point end) : SegmentBase(start, end) {
     switch (MathUtils::orientation(start, middle, end)) {
-        case 0:            // These points are co-linear and an arc is not valid so throw an error
-            assert(false); // This function should never reach this point
+        case 0:
+            throw IllegalArgumentException(
+                "Cannot construct an ArcSegment from collinear start, middle, and end points");
         case 1:            // Clockwise
             m_ccw = false;
             break;

--- a/src/geometry/segments/arc.cpp
+++ b/src/geometry/segments/arc.cpp
@@ -2,6 +2,7 @@
 
 #include <math.h>
 
+#include <limits>
 #include <vector>
 
 #include <qhashfunctions.h>
@@ -85,39 +86,22 @@ float ArcSegment::getMinZ() {
 Distance ArcSegment::length() { return m_angle() * m_center.distance(m_start); }
 
 Point ArcSegment::CalculateCenter(const Point& start, const Point& middle, const Point& end) {
-    // Find the perpendicular bisector of start -> middle and end -> middle
-    Point mid_start_middle = start;
-    Point mid_end_middle = end;
-    mid_start_middle.moveTowards(middle, start.distance(middle) / 2.0f);
-    mid_end_middle.moveTowards(middle, end.distance(middle) / 2.0f);
+    const double ax = start.x() - end.x();
+    const double ay = start.y() - end.y();
+    const double bx = middle.x() - end.x();
+    const double by = middle.y() - end.y();
+    const double determinant = 2.0 * ((ax * by) - (ay * bx));
+    const double scale = qMax(1.0, qMax(qMax(qAbs(ax), qAbs(ay)), qMax(qAbs(bx), qAbs(by))));
+    const double determinant_tolerance = std::numeric_limits<double>::epsilon() * scale * scale * 16.0;
 
-    double slope_start_middle = 0.0;
-    double slope_end_middle = 0.0;
-    double x = 0.0;
-    double y = 0.0;
+    if (qFuzzyIsNull(determinant) || qAbs(determinant) <= determinant_tolerance) {
+        throw IllegalArgumentException("Cannot calculate an arc center from collinear or near-collinear points");
+    }
 
-    if (!qFuzzyCompare(middle.x(), start.x()) &&
-        !qFuzzyCompare(end.x(), middle.x())) // If neither of the lines are vertical
-    {
-        slope_start_middle = (middle.y() - start.y()) / (middle.x() - start.x());
-        slope_end_middle = (middle.y() - end.y()) / (middle.x() - end.x());
-        x = (((slope_start_middle * slope_end_middle) * (start.y() - end.y())) +
-             (slope_end_middle * (start.x() + middle.x())) - (slope_start_middle * (middle.x() + end.x()))) /
-            (2 * (slope_end_middle - slope_start_middle));
-        y = (-1 / slope_start_middle) * (x - ((start.x() + middle.x()) / 2)) + ((start.y() + middle.y()) / 2);
-    }
-    else if (qFuzzyCompare(middle.x(), start.x()) &&
-             !qFuzzyCompare(end.x(), middle.x())) // The start- > middle line is vertical
-    {
-        slope_end_middle = (end.y() - middle.y()) / (end.x() - middle.x());
-        y = (middle.y() + start.y()) / 2;
-        x = (y - ((end.y() + middle.y()) / 2)) * (slope_end_middle / -1) + ((end.x() + middle.x()) / 2);
-    }
-    else if (!qFuzzyCompare(middle.x(), start.x()) && qFuzzyCompare(end.x(), middle.x())) {
-        slope_start_middle = (middle.y() - start.y()) / (middle.x() - start.x());
-        y = (middle.y() + end.y()) / 2;
-        x = (y - ((start.y() + middle.y()) / 2)) * (slope_start_middle / -1) + ((start.x() + middle.x()) / 2);
-    } // else Both are vertical, therefore co-linear
+    const double start_offset_squared = (ax * ax) + (ay * ay);
+    const double middle_offset_squared = (bx * bx) + (by * by);
+    const double x = end.x() + ((by * start_offset_squared) - (ay * middle_offset_squared)) / determinant;
+    const double y = end.y() + ((ax * middle_offset_squared) - (bx * start_offset_squared)) / determinant;
 
     return Point(x, y, ((end.z() - start.z()) / 2) + start.z());
 }

--- a/src/geometry/segments/bezier.cpp
+++ b/src/geometry/segments/bezier.cpp
@@ -24,8 +24,8 @@ BezierSegment::BezierSegment(const Point& start, const Point& control_a, const P
 
 void BezierSegment::createGraphic(std::vector<float>& vertices, std::vector<float>& normals,
                                   std::vector<float>& colors) {
-    ShapeFactory::createSplineCylinder(m_display_width, m_start, m_control_a, m_control_b, m_end, m_color, vertices,
-                                       colors, normals);
+    ShapeFactory::appendSplineBead(m_display_width, m_start, m_control_a, m_control_b, m_end, m_color, vertices, colors,
+                                   normals);
 }
 
 Point BezierSegment::getPointAlong(double t) {

--- a/src/geometry/segments/line.cpp
+++ b/src/geometry/segments/line.cpp
@@ -16,8 +16,8 @@ LineSegment::LineSegment(Point start, Point end) : SegmentBase(start, end) {
 }
 
 void LineSegment::createGraphic(std::vector<float>& vertices, std::vector<float>& normals, std::vector<float>& colors) {
-    ShapeFactory::createGcodeCylinder(m_display_width, m_display_length, m_display_height, m_start.toQVector3D(),
-                                      m_end.toQVector3D(), m_color, vertices, colors, normals);
+    ShapeFactory::appendLinearBead(m_display_width, m_display_length, m_display_height, m_start.toQVector3D(),
+                                   m_end.toQVector3D(), m_color, vertices, colors, normals);
 }
 
 QSharedPointer<SegmentBase> LineSegment::clone() const { return QSharedPointer<LineSegment>::create(*this); }

--- a/src/graphics/objects/arrow_object.cpp
+++ b/src/graphics/objects/arrow_object.cpp
@@ -102,7 +102,7 @@ void ArrowObject::initArrow(BaseView* view) {
     cone_tfm.rotate(90, 0, 1, 0);
 
     std::vector<float> tmp_norm;
-    ShapeFactory::createCone(.3, 1, cone_tfm, QColor(), m_head_vertices, colors, tmp_norm);
+    ShapeFactory::appendCone(.3, 1, cone_tfm, QColor(), m_head_vertices, colors, tmp_norm);
 
     // Concat the two vectors and populate
     vertices = m_tail_vertices;

--- a/src/graphics/objects/axes_object.cpp
+++ b/src/graphics/objects/axes_object.cpp
@@ -63,15 +63,15 @@ AxesObject::AxesObject(ORNL::BaseView* view, float axis_length) {
     std::vector<float> axesColors;
     std::vector<float> axesNormals;
     for (int i = 0; i < 3; ++i) {
-        ShapeFactory::createCylinder(radius, height, axesCylinderTransforms[i], axesColorList[i], axesVertices,
+        ShapeFactory::appendCylinder(radius, height, axesCylinderTransforms[i], axesColorList[i], axesVertices,
                                      axesColors, axesNormals);
-        ShapeFactory::createCone(radius * 1.5, height / 3.0, axesConeTransforms[i], axesColorList[i], axesVertices,
+        ShapeFactory::appendCone(radius * 1.5, height / 3.0, axesConeTransforms[i], axesColorList[i], axesVertices,
                                  axesColors, axesNormals);
     }
 
     QMatrix4x4 joint_tfm;
     joint_tfm.translate(-QVector3D(radius, radius, 0) * 3 / 4);
-    ShapeFactory::createSphere(radius * 2, 30, 30, joint_tfm, Constants::Colors::kBlack, axesVertices, axesColors,
+    ShapeFactory::appendSphere(radius * 2, 30, 30, joint_tfm, Constants::Colors::kBlack, axesVertices, axesColors,
                                axesNormals);
 
     this->populateGL(view, axesVertices, axesNormals, axesColors);

--- a/src/graphics/objects/cube_object.cpp
+++ b/src/graphics/objects/cube_object.cpp
@@ -73,7 +73,7 @@ CubeObject::CubeObject(BaseView* view, float length, float width, float height, 
           // Back
           0.75, 0.666, 1, 0.666, 0.75, 0.333, 1, 0.666, 1, 0.333, 0.75, 0.333};
 
-    ShapeFactory::createRectangle(m_length, m_width, m_height, QMatrix4x4(), color, vertices, colors, normals);
+    ShapeFactory::appendBox(m_length, m_width, m_height, QMatrix4x4(), color, vertices, colors, normals);
 
     this->populateGL(view, vertices, normals, colors, render_mode, uv, result);
 }

--- a/src/graphics/objects/cylinder_object.cpp
+++ b/src/graphics/objects/cylinder_object.cpp
@@ -24,7 +24,7 @@ CylinderObject::CylinderObject(BaseView* view, float outer_radius, float inner_r
     std::vector<float> normals;
     std::vector<float> colors;
 
-    ShapeFactory::createCylinder(m_outer_radius, m_height, QMatrix4x4(), color, vertices, colors, normals);
+    ShapeFactory::appendCylinder(m_outer_radius, m_height, QMatrix4x4(), color, vertices, colors, normals);
 
     this->populateGL(view, vertices, normals, colors);
 }

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -19,6 +19,8 @@
 #include <qvectornd.h>
 
 #include "geometry/segment_base.h"
+#include "geometry/segments/arc.h"
+#include "geometry/segments/bezier.h"
 #include "graphics/base_view.h"
 #include "graphics/graphics_object.h"
 #include "utilities/enums.h"
@@ -28,6 +30,13 @@ namespace ORNL {
 namespace {
 //! @brief Segment count where full bead mesh visualization is likely to exceed practical GL buffer sizes.
 constexpr qsizetype kLightweightLineThreshold = 1000000;
+
+//! @brief Estimated mesh vertices where true-width bead rendering becomes too expensive for interactive loading.
+constexpr qsizetype kLightweightMeshVertexThreshold = 5000000;
+
+//! @brief Vertex counts emitted by ShapeFactory for each full bead mesh segment type.
+constexpr qsizetype kLinearBeadVertexCount = 120;
+constexpr qsizetype kCurvedBeadVertexCount = 9120;
 
 //! @brief Counts display segments before GL buffer construction so oversized gcode can use a lighter path.
 qsizetype countSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
@@ -49,6 +58,32 @@ bool hasMeshSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode)
     }
 
     return false;
+}
+
+//! @brief Estimates vertices required if printable segments are expanded to true-width bead meshes.
+qsizetype estimateMeshVertexCount(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
+    qsizetype count = 0;
+    for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
+        for (const QSharedPointer<SegmentBase>& segment : layer) {
+            if (static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) {
+                continue;
+            }
+
+            if (dynamic_cast<ArcSegment*>(segment.data()) != nullptr ||
+                dynamic_cast<BezierSegment*>(segment.data()) != nullptr) {
+                count += kCurvedBeadVertexCount;
+            }
+            else {
+                count += kLinearBeadVertexCount;
+            }
+
+            if (count > kLightweightMeshVertexThreshold) {
+                return count;
+            }
+        }
+    }
+
+    return count;
 }
 
 //! @brief Appends a single GL_LINES segment using the parser's display-space line representation.
@@ -94,7 +129,9 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
     m_segment_info_control->setGCode(gcode);
 
     const qsizetype segment_count = countSegments(gcode);
-    m_lightweight_lines = segment_count > kLightweightLineThreshold;
+    const qsizetype mesh_vertex_count = estimateMeshVertexCount(gcode);
+    m_lightweight_lines =
+        segment_count > kLightweightLineThreshold || mesh_vertex_count > kLightweightMeshVertexThreshold;
     m_primary_render_mode = (m_lightweight_lines || !hasMeshSegments(gcode)) ? GL_LINES : GL_TRIANGLES;
 
     if (m_lightweight_lines) {

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -15,7 +15,6 @@
 #include <qvectornd.h>
 
 #include "geometry/segment_base.h"
-#include "geometry/segments/line.h"
 #include "graphics/base_view.h"
 #include "graphics/graphics_object.h"
 #include "utilities/enums.h"
@@ -40,12 +39,6 @@ void appendLightweightLine(const QSharedPointer<SegmentBase>& segment, std::vect
                            std::vector<float>& normals, std::vector<float>& colors) {
     QVector3D start = segment->start().toQVector3D();
     QVector3D end = segment->end().toQVector3D();
-
-    // GCodeLoader stores parsed G0/G1 line endpoints as displacement vectors
-    // because the standard bead renderer builds cylinders from start+direction.
-    if (dynamic_cast<LineSegment*>(segment.data()) != nullptr) {
-        end += start;
-    }
 
     vertices.push_back(start.x());
     vertices.push_back(start.y());

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -2,14 +2,18 @@
 
 #include <GL/gl.h>
 
+#include <cstring>
 #include <utility>
 #include <vector>
 
+#include <QOpenGLShaderProgram>
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qmatrix4x4.h>
 #include <qnamespace.h>
+#include <qopenglbuffer.h>
+#include <qopenglvertexarrayobject.h>
 #include <qsharedpointer.h>
 #include <qtypes.h>
 #include <qvectornd.h>
@@ -32,6 +36,19 @@ qsizetype countSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gco
         count += layer.size();
     }
     return count;
+}
+
+//! @brief Returns true when any segment needs bead mesh geometry in normal rendering.
+bool hasMeshSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
+    for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
+        for (const QSharedPointer<SegmentBase>& segment : layer) {
+            if (!static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 //! @brief Appends a single GL_LINES segment using the parser's display-space line representation.
@@ -66,19 +83,24 @@ void appendLightweightLine(const QSharedPointer<SegmentBase>& segment, std::vect
 
 GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentBase>>> gcode,
                          QSharedPointer<GCodeInfoControl> segmentInfoControl) {
-    std::vector<float> vertices;
-    std::vector<float> normals;
-    std::vector<float> colors;
+    std::vector<float> primary_vertices;
+    std::vector<float> primary_normals;
+    std::vector<float> primary_colors;
+    std::vector<float> travel_line_vertices;
+    std::vector<float> travel_line_normals;
+    std::vector<float> travel_line_colors;
 
     m_segment_info_control = segmentInfoControl;
     m_segment_info_control->setGCode(gcode);
 
     const qsizetype segment_count = countSegments(gcode);
     m_lightweight_lines = segment_count > kLightweightLineThreshold;
+    m_primary_render_mode = (m_lightweight_lines || !hasMeshSegments(gcode)) ? GL_LINES : GL_TRIANGLES;
+
     if (m_lightweight_lines) {
-        vertices.reserve(segment_count * 2 * 3);
-        normals.reserve(segment_count * 2 * 3);
-        colors.reserve(segment_count * 2 * 4);
+        primary_vertices.reserve(segment_count * 2 * 3);
+        primary_normals.reserve(segment_count * 2 * 3);
+        primary_colors.reserve(segment_count * 2 * 4);
     }
 
     m_segments.reserve(gcode.size());
@@ -94,16 +116,27 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
             seg_meta->type = segment->displayType();
             seg_meta->original_color = segment->color();
             seg_meta->current_color = segment->color();
-            seg_meta->offset = vertices.size() / 3;
 
-            if (m_lightweight_lines) {
-                appendLightweightLine(segment, vertices, normals, colors);
+            const bool render_as_line =
+                m_lightweight_lines || static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel);
+            const bool use_primary_buffer = m_lightweight_lines || !render_as_line || m_primary_render_mode == GL_LINES;
+            seg_meta->buffer = use_primary_buffer ? SegmentRenderBuffer::kPrimary : SegmentRenderBuffer::kTravelLine;
+
+            if (use_primary_buffer) {
+                seg_meta->offset = primary_vertices.size() / 3;
+                if (render_as_line) {
+                    appendLightweightLine(segment, primary_vertices, primary_normals, primary_colors);
+                }
+                else {
+                    segment->createGraphic(primary_vertices, primary_normals, primary_colors);
+                }
+                seg_meta->length = (primary_vertices.size() / 3) - seg_meta->offset;
             }
             else {
-                segment->createGraphic(vertices, normals, colors);
+                seg_meta->offset = travel_line_vertices.size() / 3;
+                appendLightweightLine(segment, travel_line_vertices, travel_line_normals, travel_line_colors);
+                seg_meta->length = (travel_line_vertices.size() / 3) - seg_meta->offset;
             }
-
-            seg_meta->length = (vertices.size() / 3) - seg_meta->offset;
 
             if (static_cast<bool>(seg_meta->type & m_hidden_type))
                 seg_meta->hidden = true;
@@ -120,7 +153,79 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
     m_low_segment = 0;
     m_high_segment = visibleSegmentCount();
 
-    this->populateGL(view, vertices, normals, colors, m_lightweight_lines ? GL_LINES : GL_TRIANGLES);
+    this->populateGL(view, primary_vertices, primary_normals, primary_colors, m_primary_render_mode);
+    this->populateTravelLineGL(view, travel_line_vertices, travel_line_normals, travel_line_colors);
+}
+
+GCodeObject::~GCodeObject() {
+    if (m_view.isNull() || m_view->context() == nullptr)
+        return;
+
+    m_view->makeCurrent();
+
+    if (!m_travel_line_vao.isNull()) {
+        m_travel_line_vao->destroy();
+    }
+
+    m_travel_line_vbo.destroy();
+    m_travel_line_nbo.destroy();
+    m_travel_line_cbo.destroy();
+    m_travel_line_tbo.destroy();
+}
+
+void GCodeObject::populateTravelLineGL(BaseView* view, const std::vector<float>& vertices,
+                                       const std::vector<float>& normals, const std::vector<float>& colors) {
+    if (vertices.empty()) {
+        return;
+    }
+
+    m_travel_line_vertices = vertices;
+    m_travel_line_normals = normals;
+    m_travel_line_colors = colors;
+    m_travel_line_uv.resize((m_travel_line_vertices.size() / 3) * 2, 0.0f);
+
+    view->makeCurrent();
+    view->shaderProgram()->bind();
+
+    m_travel_line_vao = QSharedPointer<QOpenGLVertexArrayObject>::create();
+    m_travel_line_vao->create();
+    m_travel_line_vao->bind();
+
+    m_travel_line_vbo.create();
+    m_travel_line_vbo.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+    m_travel_line_vbo.bind();
+    m_travel_line_vbo.allocate(m_travel_line_vertices.data(), m_travel_line_vertices.size() * sizeof(float));
+    view->shaderProgram()->enableAttributeArray(m_shader_locs.vertice);
+    view->shaderProgram()->setAttributeBuffer(m_shader_locs.vertice, GL_FLOAT, 0, 3);
+
+    m_travel_line_nbo.create();
+    m_travel_line_nbo.setUsagePattern(QOpenGLBuffer::StaticDraw);
+    m_travel_line_nbo.bind();
+    m_travel_line_nbo.allocate(m_travel_line_normals.data(), m_travel_line_normals.size() * sizeof(float));
+    view->shaderProgram()->enableAttributeArray(m_shader_locs.normal);
+    view->shaderProgram()->setAttributeBuffer(m_shader_locs.normal, GL_FLOAT, 0, 3);
+
+    m_travel_line_cbo.create();
+    m_travel_line_cbo.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+    m_travel_line_cbo.bind();
+    m_travel_line_cbo.allocate(m_travel_line_colors.data(), m_travel_line_colors.size() * sizeof(float));
+    view->shaderProgram()->enableAttributeArray(m_shader_locs.color);
+    view->shaderProgram()->setAttributeBuffer(m_shader_locs.color, GL_FLOAT, 0, 4);
+
+    m_travel_line_tbo.create();
+    m_travel_line_tbo.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+    m_travel_line_tbo.bind();
+    m_travel_line_tbo.allocate(m_travel_line_uv.data(), m_travel_line_uv.size() * sizeof(float));
+    view->shaderProgram()->enableAttributeArray(m_shader_locs.uv);
+    view->shaderProgram()->setAttributeBuffer(m_shader_locs.uv, GL_FLOAT, 0, 2);
+
+    m_travel_line_vao->release();
+    m_travel_line_vbo.release();
+    m_travel_line_nbo.release();
+    m_travel_line_cbo.release();
+    m_travel_line_tbo.release();
+
+    view->shaderProgram()->release();
 }
 
 void GCodeObject::hideSegmentType(SegmentDisplayType type, bool hide) {
@@ -270,7 +375,7 @@ bool GCodeObject::isCurrentlySelected(int line_num) { return m_selected_segments
 const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriangles() {
     QVector<std::pair<uint, std::vector<Triangle>>> ret;
 
-    if (m_lightweight_lines) {
+    if (m_primary_render_mode != GL_TRIANGLES) {
         return ret;
     }
 
@@ -279,7 +384,7 @@ const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriang
 
     for (uint i = m_low_layer; i <= m_high_layer; i++) {
         for (QSharedPointer<SegmentDisplayMeta> seg : m_segments[i]) {
-            if (seg->hidden)
+            if (seg->hidden || seg->buffer != SegmentRenderBuffer::kPrimary)
                 continue;
             // For each segment, get its triangles.
             std::vector<Triangle> seg_tri;
@@ -305,20 +410,47 @@ const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriang
     return ret;
 }
 
-void GCodeObject::draw() {
+const QVector<std::pair<uint, std::pair<QVector3D, QVector3D>>> GCodeObject::segmentLines() {
+    QVector<std::pair<uint, std::pair<QVector3D, QVector3D>>> ret;
+    QMatrix4x4 transform = this->transformation();
+
+    for (uint i = m_low_layer; i <= m_high_layer; i++) {
+        for (QSharedPointer<SegmentDisplayMeta> seg : m_segments[i]) {
+            if (seg->hidden)
+                continue;
+            if (seg->buffer == SegmentRenderBuffer::kPrimary && m_primary_render_mode != GL_LINES)
+                continue;
+
+            const std::vector<float>& vert =
+                seg->buffer == SegmentRenderBuffer::kTravelLine ? m_travel_line_vertices : this->vertices();
+            uint seg_start = seg->offset * 3;
+            uint seg_end = (seg->offset + seg->length) * 3;
+
+            for (uint i = seg_start; i + 5 < seg_end; i += 6) {
+                QVector3D start = transform * QVector3D(vert[i + 0], vert[i + 1], vert[i + 2]);
+                QVector3D end = transform * QVector3D(vert[i + 3], vert[i + 4], vert[i + 5]);
+                ret.push_back(std::make_pair(seg->line, std::make_pair(start, end)));
+            }
+        }
+    }
+
+    return ret;
+}
+
+void GCodeObject::drawBufferRuns(SegmentRenderBuffer buffer, ushort render_mode) {
     for (uint i = m_low_layer; i <= m_high_layer; i++) {
         uint run_offset = 0;
         uint run_length = 0;
 
         auto drawRun = [&]() {
             if (run_length > 0) {
-                this->view()->glDrawArrays(this->renderMode(), run_offset, run_length);
+                this->view()->glDrawArrays(render_mode, run_offset, run_length);
                 run_length = 0;
             }
         };
 
         for (const auto& segment : m_segments[i]) {
-            if (segment->hidden) {
+            if (segment->hidden || segment->buffer != buffer) {
                 drawRun();
                 continue;
             }
@@ -337,6 +469,42 @@ void GCodeObject::draw() {
     }
 }
 
+void GCodeObject::draw() {
+    drawBufferRuns(SegmentRenderBuffer::kPrimary, m_primary_render_mode);
+
+    if (m_travel_line_vao.isNull()) {
+        return;
+    }
+
+    this->vao()->release();
+    m_travel_line_vao->bind();
+    drawBufferRuns(SegmentRenderBuffer::kTravelLine, GL_LINES);
+    m_travel_line_vao->release();
+    this->vao()->bind();
+}
+
+void GCodeObject::updateTravelLineColors(std::vector<float>& colors, uint whence) {
+    if (m_travel_line_vao.isNull()) {
+        return;
+    }
+
+    m_travel_line_cbo.bind();
+
+    const uint end_count = colors.size() + whence;
+    if (end_count > m_travel_line_colors.size()) {
+        m_travel_line_colors.resize(end_count);
+
+        m_travel_line_cbo.allocate(end_count);
+        m_travel_line_cbo.write(0, m_travel_line_colors.data(), (whence + 1) * sizeof(float));
+    }
+
+    memcpy(m_travel_line_colors.data() + whence, colors.data(), colors.size() * sizeof(float));
+
+    m_travel_line_cbo.write(whence * sizeof(float), m_travel_line_colors.data() + whence,
+                            colors.size() * sizeof(float));
+    m_travel_line_cbo.release();
+}
+
 void GCodeObject::paintSegment(QSharedPointer<GCodeObject::SegmentDisplayMeta> seg_meta, QColor color) {
     std::vector<float> new_colors;
     new_colors.resize(seg_meta->length * 4, 0.0f);
@@ -348,6 +516,11 @@ void GCodeObject::paintSegment(QSharedPointer<GCodeObject::SegmentDisplayMeta> s
         new_colors[(4 * i) + 3] = color.alphaF();
     }
 
-    this->updateColors(new_colors, seg_meta->offset * 4);
+    if (seg_meta->buffer == SegmentRenderBuffer::kTravelLine) {
+        updateTravelLineColors(new_colors, seg_meta->offset * 4);
+    }
+    else {
+        this->updateColors(new_colors, seg_meta->offset * 4);
+    }
 }
 } // namespace ORNL

--- a/src/graphics/objects/grid_object.cpp
+++ b/src/graphics/objects/grid_object.cpp
@@ -23,13 +23,13 @@ GridObject::GridObject(BaseView* view, float length, float width, float x_grid, 
     std::vector<float> vertices;
     std::vector<float> colors;
 
-    ShapeFactory::createGridPlane(m_length, m_width, m_x_grid, m_y_grid, m_color, vertices, colors);
+    ShapeFactory::appendGridPlaneLines(m_length, m_width, m_x_grid, m_y_grid, m_color, vertices, colors);
 
     std::vector<float> tmp_norm;
     this->populateGL(view, vertices, tmp_norm, colors, GL_LINES);
 
     // Get collision box - Only need vertices.
-    ShapeFactory::createRectangle(length, width, 0.1, QMatrix4x4(), m_color, m_collision_vertices, colors, tmp_norm);
+    ShapeFactory::appendBox(length, width, 0.1, QMatrix4x4(), m_color, m_collision_vertices, colors, tmp_norm);
 }
 
 void GridObject::updateDimensions(float length, float width, float x_grid, float y_grid) {
@@ -42,15 +42,14 @@ void GridObject::updateDimensions(float length, float width, float x_grid, float
     std::vector<float> vertices;
     std::vector<float> colors;
 
-    ShapeFactory::createGridPlane(m_length, m_width, m_x_grid, m_y_grid, m_color, vertices, colors);
+    ShapeFactory::appendGridPlaneLines(m_length, m_width, m_x_grid, m_y_grid, m_color, vertices, colors);
 
     this->replaceVertices(vertices);
     this->replaceColors(colors);
 
     std::vector<float> tmp_norm;
     m_collision_vertices.clear();
-    ShapeFactory::createRectangle(m_length, m_width, 0.1, QMatrix4x4(), m_color, m_collision_vertices, colors,
-                                  tmp_norm);
+    ShapeFactory::appendBox(m_length, m_width, 0.1, QMatrix4x4(), m_color, m_collision_vertices, colors, tmp_norm);
 }
 
 std::vector<Triangle> GridObject::triangles() {

--- a/src/graphics/objects/printer/cartesian_printer_object.cpp
+++ b/src/graphics/objects/printer/cartesian_printer_object.cpp
@@ -30,8 +30,8 @@ CartesianPrinterObject::CartesianPrinterObject(BaseView* view, QSharedPointer<Se
     std::vector<float> vertices;
     std::vector<float> colors;
 
-    ShapeFactory::createBuildVolumeRectangle(m_min, m_max, m_x_grid, m_x_grid_offset, m_y_grid, m_y_grid_offset,
-                                             Constants::Colors::kBlack, vertices, colors);
+    ShapeFactory::appendBuildVolumeBoxLines(m_min, m_max, m_x_grid, m_x_grid_offset, m_y_grid, m_y_grid_offset,
+                                            Constants::Colors::kBlack, vertices, colors);
 
     std::vector<float> tmp_norm;
     this->populateGL(view, vertices, tmp_norm, colors, GL_LINES);
@@ -148,8 +148,8 @@ void CartesianPrinterObject::updateGeometry() {
     std::vector<float> vertices;
     std::vector<float> colors;
 
-    ShapeFactory::createBuildVolumeRectangle(m_min, m_max, m_x_grid, m_x_grid_offset, m_y_grid, m_y_grid_offset,
-                                             Constants::Colors::kBlack, vertices, colors);
+    ShapeFactory::appendBuildVolumeBoxLines(m_min, m_max, m_x_grid, m_x_grid_offset, m_y_grid, m_y_grid_offset,
+                                            Constants::Colors::kBlack, vertices, colors);
 
     this->replaceVertices(vertices);
     this->replaceColors(colors);

--- a/src/graphics/objects/printer/cylindrical_printer_object.cpp
+++ b/src/graphics/objects/printer/cylindrical_printer_object.cpp
@@ -29,8 +29,8 @@ CylindricalPrinterObject::CylindricalPrinterObject(BaseView* view, QSharedPointe
     std::vector<float> vertices;
     std::vector<float> colors;
 
-    ShapeFactory::createBuildVolumeCylinder(m_radius, m_height, m_x_grid, m_y_grid, Constants::Colors::kBlack, vertices,
-                                            colors);
+    ShapeFactory::appendBuildVolumeCylinderLines(m_radius, m_height, m_x_grid, m_y_grid, Constants::Colors::kBlack,
+                                                 vertices, colors);
 
     std::vector<float> tmp_norm;
     this->populateGL(view, vertices, tmp_norm, colors, GL_LINES);
@@ -141,8 +141,8 @@ void CylindricalPrinterObject::updateGeometry() {
     std::vector<float> vertices;
     std::vector<float> colors;
 
-    ShapeFactory::createBuildVolumeCylinder(m_radius, m_height, m_x_grid, m_y_grid, Constants::Colors::kBlack, vertices,
-                                            colors);
+    ShapeFactory::appendBuildVolumeCylinderLines(m_radius, m_height, m_x_grid, m_y_grid, Constants::Colors::kBlack,
+                                                 vertices, colors);
 
     this->replaceVertices(vertices);
     this->replaceColors(colors);

--- a/src/graphics/objects/sphere_object.cpp
+++ b/src/graphics/objects/sphere_object.cpp
@@ -17,7 +17,7 @@ SphereObject::SphereObject(BaseView* view, float radius, QColor color, ushort re
     std::vector<float> normals;
     std::vector<float> colors;
 
-    ShapeFactory::createSphere(m_radius, 25, 25, QMatrix4x4(), color, vertices, colors, normals);
+    ShapeFactory::appendSphere(m_radius, 25, 25, QMatrix4x4(), color, vertices, colors, normals);
 
     this->populateGL(view, vertices, normals, colors, render_mode);
 }

--- a/src/graphics/objects/text_object.cpp
+++ b/src/graphics/objects/text_object.cpp
@@ -45,8 +45,8 @@ TextObject::TextObject(ORNL::BaseView* view, QString str, float scale, bool bill
     painter.end();
     // result.invertPixels();
 
-    ShapeFactory::createRectangle(scale * str.length(), scale, 0.1, QMatrix4x4(), Constants::Colors::kWhite, vertices,
-                                  colors, normals);
+    ShapeFactory::appendBox(scale * str.length(), scale, 0.1, QMatrix4x4(), Constants::Colors::kWhite, vertices, colors,
+                            normals);
 
     uv = {// Bottom face
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -1,240 +1,282 @@
-
 #include "graphics/support/shape_factory.h"
 
-#include <math.h>
-
+#include <algorithm>
 #include <array>
 #include <cmath>
-#include <limits>
+#include <cstddef>
 #include <vector>
 
 #include <QMatrix4x4>
-#include <QtMath>
-#include <qcolor.h>
-#include <qvectornd.h>
+#include <QVector2D>
+#include <QVector4D>
 
-#include "geometry/point.h"
 #include "geometry/segments/bezier.h"
 #include "managers/settings/settings_manager.h"
-#include "units/unit.h"
-#include "utilities/constants.h"
 #include "utilities/mathutils.h"
 
 namespace ORNL {
+namespace {
+constexpr float kPi = 3.14159265358979323846f;
+constexpr float kTwoPi = 2.0f * kPi;
+constexpr float kVectorEpsilon = 1.0e-6f;
+constexpr float kVectorEpsilonSquared = kVectorEpsilon * kVectorEpsilon;
+
+constexpr int kCylinderSegments = 50;
+constexpr int kConeSlices = 50;
+constexpr int kSphereMinSectorCount = 3;
+constexpr int kSphereMinStackCount = 2;
+constexpr int kTubeCrossSectionResolution = 20;
+constexpr int kCurveSegments = 75;
+constexpr int kBuildVolumeCylinderSegments = 100;
+constexpr int kBuildVolumeVerticalLines = 6;
+
+struct Rgba {
+    float r;
+    float g;
+    float b;
+    float a;
+
+    explicit Rgba(const QColor& color)
+        : r(static_cast<float>(color.redF())), g(static_cast<float>(color.greenF())),
+          b(static_cast<float>(color.blueF())), a(static_cast<float>(color.alphaF())) {}
+};
+
+void reserveAdditional(std::vector<float>& values, std::size_t count) { values.reserve(values.size() + count); }
+
+void reserveTriangleMesh(std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals,
+                         std::size_t triangle_count) {
+    const std::size_t vertex_count = triangle_count * 3;
+    reserveAdditional(vertices, vertex_count * 3);
+    reserveAdditional(normals, vertex_count * 3);
+    reserveAdditional(colors, vertex_count * 4);
+}
+
+void reserveLineMesh(std::vector<float>& vertices, std::vector<float>& colors, std::size_t line_count) {
+    const std::size_t vertex_count = line_count * 2;
+    reserveAdditional(vertices, vertex_count * 3);
+    reserveAdditional(colors, vertex_count * 4);
+}
+
+void appendVertex(std::vector<float>& vertices, const QVector3D& vertex) {
+    vertices.push_back(vertex.x());
+    vertices.push_back(vertex.y());
+    vertices.push_back(vertex.z());
+}
+
+void appendVector(std::vector<float>& values, const QVector3D& vector) {
+    values.push_back(vector.x());
+    values.push_back(vector.y());
+    values.push_back(vector.z());
+}
+
+void appendColor(std::vector<float>& colors, const Rgba& rgba) {
+    colors.push_back(rgba.r);
+    colors.push_back(rgba.g);
+    colors.push_back(rgba.b);
+    colors.push_back(rgba.a);
+}
+
+QVector3D faceNormal(const QVector3D& v0, const QVector3D& v1, const QVector3D& v2) {
+    QVector3D normal = QVector3D::crossProduct(v1 - v0, v2 - v0);
+    if (normal.lengthSquared() > kVectorEpsilonSquared) {
+        normal.normalize();
+    }
+    return normal;
+}
+
+void appendTriangleData(const QVector3D& v0, const QVector3D& v1, const QVector3D& v2, const Rgba& rgba,
+                        std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals) {
+    const QVector3D normal = faceNormal(v0, v1, v2);
+
+    appendVertex(vertices, v0);
+    appendVertex(vertices, v1);
+    appendVertex(vertices, v2);
+
+    for (int i = 0; i < 3; ++i) {
+        appendVector(normals, normal);
+        appendColor(colors, rgba);
+    }
+}
+
+void appendLine(const QVector3D& start, const QVector3D& end, const Rgba& rgba, std::vector<float>& vertices,
+                std::vector<float>& colors) {
+    appendVertex(vertices, start);
+    appendVertex(vertices, end);
+    appendColor(colors, rgba);
+    appendColor(colors, rgba);
+}
+
+std::size_t countLoopValues(float value, float limit, float step) {
+    if (!std::isfinite(value) || !std::isfinite(limit) || !std::isfinite(step) || step <= 0.0f) {
+        return 0;
+    }
+
+    std::size_t count = 0;
+    while (value < limit) {
+        ++count;
+        value += step;
+    }
+    return count;
+}
+
+const std::array<QVector2D, kTubeCrossSectionResolution>& circleTable() {
+    static const std::array<QVector2D, kTubeCrossSectionResolution> table = [] {
+        std::array<QVector2D, kTubeCrossSectionResolution> values;
+        const float step = kTwoPi / static_cast<float>(kTubeCrossSectionResolution);
+
+        for (int i = 0; i < kTubeCrossSectionResolution; ++i) {
+            const float theta = static_cast<float>(i) * step;
+            values[i] = QVector2D(std::cos(theta), std::sin(theta));
+        }
+
+        return values;
+    }();
+
+    return table;
+}
+
+float arcSweepAngle(const Point& start, const Point& center, const Point& end, bool counterclockwise) {
+    if (MathUtils::orientation(start, center, end) == 0) {
+        return (start == end) ? kTwoPi : kPi;
+    }
+
+    const float start_angle = std::atan2(center.x() - start.x(), center.y() - start.y());
+    const float end_angle = std::atan2(center.x() - end.x(), center.y() - end.y());
+
+    float angle = counterclockwise ? start_angle - end_angle : end_angle - start_angle;
+    if (angle < 0.0f) {
+        angle += kTwoPi;
+    }
+
+    return angle;
+}
+
+void createArcCylinderMesh(float cylinder_height, const Point& start, const Point& center, const Point& end,
+                           const QMatrix4x4& transform, bool counterclockwise, const QColor& color,
+                           std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals) {
+    const float major_radius = std::hypot(start.x() - center.x(), start.y() - center.y());
+    const float minor_radius = cylinder_height / 2.0f;
+    if (major_radius <= kVectorEpsilon || minor_radius <= kVectorEpsilon) {
+        return;
+    }
+
+    const float angle = arcSweepAngle(start, center, end, counterclockwise);
+    const float phi_increment = angle / static_cast<float>(kCurveSegments);
+    const float height_increment = (end.z() - start.z()) / static_cast<float>(kCurveSegments);
+    const auto& circle = circleTable();
+    const Rgba rgba(color);
+
+    reserveTriangleMesh(vertices, colors, normals,
+                        kTubeCrossSectionResolution * (2 + (2 * static_cast<std::size_t>(kCurveSegments))));
+
+    std::array<std::array<QVector3D, kTubeCrossSectionResolution>, kCurveSegments + 1> tube_vertices;
+
+    float phi = counterclockwise ? 0.0f : kTwoPi;
+    float height = 0.0f;
+    for (auto& ring_vertices : tube_vertices) {
+        const float cos_phi = std::cos(phi);
+        const float sin_phi = std::sin(phi);
+
+        for (int i = 0; i < kTubeCrossSectionResolution; ++i) {
+            const float local_radius = major_radius + (minor_radius * circle[i].x());
+            ring_vertices[i] = transform * QVector3D(cos_phi * local_radius, sin_phi * local_radius,
+                                                     (circle[i].y() * minor_radius) + height);
+        }
+
+        height += height_increment;
+        phi += counterclockwise ? phi_increment : -phi_increment;
+    }
+
+    const QVector3D start_center = transform * QVector3D(major_radius, 0.0f, 0.0f);
+    const float end_phi = counterclockwise ? angle : -angle;
+    const QVector3D end_center =
+        transform * QVector3D(major_radius * std::cos(end_phi), major_radius * std::sin(end_phi), end.z() - start.z());
+
+    for (int i = 0; i < kTubeCrossSectionResolution; ++i) {
+        const int next = (i + 1) % kTubeCrossSectionResolution;
+        if (counterclockwise) {
+            appendTriangleData(start_center, tube_vertices[0][i], tube_vertices[0][next], rgba, vertices, colors,
+                               normals);
+        }
+        else {
+            appendTriangleData(tube_vertices[0][next], tube_vertices[0][i], start_center, rgba, vertices, colors,
+                               normals);
+        }
+    }
+
+    for (int slice_index = 0; slice_index < kCurveSegments; ++slice_index) {
+        const int next_slice = slice_index + 1;
+        for (int vertex_index = 0; vertex_index < kTubeCrossSectionResolution; ++vertex_index) {
+            const int next_vertex = (vertex_index + 1) % kTubeCrossSectionResolution;
+
+            if (counterclockwise) {
+                appendTriangleData(tube_vertices[slice_index][vertex_index], tube_vertices[next_slice][vertex_index],
+                                   tube_vertices[slice_index][next_vertex], rgba, vertices, colors, normals);
+                appendTriangleData(tube_vertices[next_slice][next_vertex], tube_vertices[slice_index][next_vertex],
+                                   tube_vertices[next_slice][vertex_index], rgba, vertices, colors, normals);
+            }
+            else {
+                appendTriangleData(tube_vertices[slice_index][next_vertex], tube_vertices[next_slice][vertex_index],
+                                   tube_vertices[slice_index][vertex_index], rgba, vertices, colors, normals);
+                appendTriangleData(tube_vertices[next_slice][vertex_index], tube_vertices[slice_index][next_vertex],
+                                   tube_vertices[next_slice][next_vertex], rgba, vertices, colors, normals);
+            }
+        }
+    }
+
+    for (int i = 0; i < kTubeCrossSectionResolution; ++i) {
+        const int next = (i + 1) % kTubeCrossSectionResolution;
+        if (counterclockwise) {
+            appendTriangleData(tube_vertices[kCurveSegments][next], tube_vertices[kCurveSegments][i], end_center, rgba,
+                               vertices, colors, normals);
+        }
+        else {
+            appendTriangleData(end_center, tube_vertices[kCurveSegments][i], tube_vertices[kCurveSegments][next], rgba,
+                               vertices, colors, normals);
+        }
+    }
+}
+} // namespace
+
 void ShapeFactory::createRectangle(float length, float width, float height, const QMatrix4x4& transform,
                                    const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
                                    std::vector<float>& normals) {
-    QVector3D vertex0, vertex1, vertex2, vertex3, vertex4, vertex5, vertex6, vertex7;
+    const float half_length = length / 2.0f;
+    const float half_width = width / 2.0f;
+    const float half_height = height / 2.0f;
 
-    // Divide everything by 2 since we want to center the rectangle on the origin
-    length /= 2.0f;
-    width /= 2.0f;
-    height /= 2.0f;
+    const std::array<QVector3D, 8> corner_vertices = {
+        transform * QVector3D(-half_length, -half_width, half_height),  // back  left  top
+        transform * QVector3D(half_length, -half_width, half_height),   // back  right top
+        transform * QVector3D(half_length, half_width, half_height),    // front right top
+        transform * QVector3D(-half_length, half_width, half_height),   // front left  top
+        transform * QVector3D(-half_length, -half_width, -half_height), // back  left  bottom
+        transform * QVector3D(half_length, -half_width, -half_height),  // back  right bottom
+        transform * QVector3D(half_length, half_width, -half_height),   // front right bottom
+        transform * QVector3D(-half_length, half_width, -half_height),  // front left  bottom
+    };
 
-    // Create the eight vertices
-    vertex0 = transform * QVector3D(-length, -width, height); // back  left  top
+    static constexpr std::array<std::array<int, 3>, 12> kTriangles = {
+        std::array<int, 3> {7, 6, 4},
+        {6, 5, 4},
+        {0, 1, 3},
+        {1, 2, 3},
+        {0, 3, 4},
+        {3, 7, 4},
+        {3, 2, 7},
+        {2, 6, 7},
+        {2, 1, 6},
+        {1, 5, 6},
+        {1, 0, 5},
+        {0, 4, 5},
+    };
 
-    vertex1 = transform * QVector3D(length, -width, height); // back  right top
+    const Rgba rgba(color);
+    reserveTriangleMesh(vertices, colors, normals, kTriangles.size());
 
-    vertex2 = transform * QVector3D(length, width, height); // front right top
-
-    vertex3 = transform * QVector3D(-length, width, height); // front left  top
-
-    vertex4 = transform * QVector3D(-length, -width, -height); // back  left  bottom
-
-    vertex5 = transform * QVector3D(length, -width, -height); // back  right bottom
-
-    vertex6 = transform * QVector3D(length, width, -height); // front right bottom
-
-    vertex7 = transform * QVector3D(-length, width, -height); // front left  bottom
-
-    // Create the necessary 12 (2 for each face) triangles from the vertices
-
-    // Bottom face
-    vertices.push_back(vertex7.x());
-    vertices.push_back(vertex7.y());
-    vertices.push_back(vertex7.z());
-    vertices.push_back(vertex6.x());
-    vertices.push_back(vertex6.y());
-    vertices.push_back(vertex6.z());
-    vertices.push_back(vertex4.x());
-    vertices.push_back(vertex4.y());
-    vertices.push_back(vertex4.z());
-
-    vertices.push_back(vertex6.x());
-    vertices.push_back(vertex6.y());
-    vertices.push_back(vertex6.z());
-    vertices.push_back(vertex5.x());
-    vertices.push_back(vertex5.y());
-    vertices.push_back(vertex5.z());
-    vertices.push_back(vertex4.x());
-    vertices.push_back(vertex4.y());
-    vertices.push_back(vertex4.z());
-
-    // All vertices for each face have the same normal and color
-    for (int i = 0; i < 6; i++) {
-        normals.push_back(0.0f);
-        normals.push_back(0.0f);
-        normals.push_back(-1.0f);
-        colors.push_back(color.redF());
-        colors.push_back(color.greenF());
-        colors.push_back(color.blueF());
-        colors.push_back(color.alphaF());
-    }
-
-    // Top face
-    vertices.push_back(vertex0.x());
-    vertices.push_back(vertex0.y());
-    vertices.push_back(vertex0.z());
-    vertices.push_back(vertex1.x());
-    vertices.push_back(vertex1.y());
-    vertices.push_back(vertex1.z());
-    vertices.push_back(vertex3.x());
-    vertices.push_back(vertex3.y());
-    vertices.push_back(vertex3.z());
-
-    vertices.push_back(vertex1.x());
-    vertices.push_back(vertex1.y());
-    vertices.push_back(vertex1.z());
-    vertices.push_back(vertex2.x());
-    vertices.push_back(vertex2.y());
-    vertices.push_back(vertex2.z());
-    vertices.push_back(vertex3.x());
-    vertices.push_back(vertex3.y());
-    vertices.push_back(vertex3.z());
-
-    for (int i = 0; i < 6; i++) {
-        normals.push_back(0.0f);
-        normals.push_back(0.0f);
-        normals.push_back(1.0f);
-        colors.push_back(color.redF());
-        colors.push_back(color.greenF());
-        colors.push_back(color.blueF());
-        colors.push_back(color.alphaF());
-    }
-
-    // Left face
-    vertices.push_back(vertex0.x());
-    vertices.push_back(vertex0.y());
-    vertices.push_back(vertex0.z());
-    vertices.push_back(vertex3.x());
-    vertices.push_back(vertex3.y());
-    vertices.push_back(vertex3.z());
-    vertices.push_back(vertex4.x());
-    vertices.push_back(vertex4.y());
-    vertices.push_back(vertex4.z());
-
-    vertices.push_back(vertex3.x());
-    vertices.push_back(vertex3.y());
-    vertices.push_back(vertex3.z());
-    vertices.push_back(vertex7.x());
-    vertices.push_back(vertex7.y());
-    vertices.push_back(vertex7.z());
-    vertices.push_back(vertex4.x());
-    vertices.push_back(vertex4.y());
-    vertices.push_back(vertex4.z());
-
-    for (int i = 0; i < 6; i++) {
-        normals.push_back(-1.0f);
-        normals.push_back(0.0f);
-        normals.push_back(0.0f);
-        colors.push_back(color.redF());
-        colors.push_back(color.greenF());
-        colors.push_back(color.blueF());
-        colors.push_back(color.alphaF());
-    }
-
-    // Front face
-    vertices.push_back(vertex3.x());
-    vertices.push_back(vertex3.y());
-    vertices.push_back(vertex3.z());
-    vertices.push_back(vertex2.x());
-    vertices.push_back(vertex2.y());
-    vertices.push_back(vertex2.z());
-    vertices.push_back(vertex7.x());
-    vertices.push_back(vertex7.y());
-    vertices.push_back(vertex7.z());
-
-    vertices.push_back(vertex2.x());
-    vertices.push_back(vertex2.y());
-    vertices.push_back(vertex2.z());
-    vertices.push_back(vertex6.x());
-    vertices.push_back(vertex6.y());
-    vertices.push_back(vertex6.z());
-    vertices.push_back(vertex7.x());
-    vertices.push_back(vertex7.y());
-    vertices.push_back(vertex7.z());
-
-    for (int i = 0; i < 6; i++) {
-        normals.push_back(0.0f);
-        normals.push_back(1.0f);
-        normals.push_back(0.0f);
-        colors.push_back(color.redF());
-        colors.push_back(color.greenF());
-        colors.push_back(color.blueF());
-        colors.push_back(color.alphaF());
-    }
-
-    // Right face
-    vertices.push_back(vertex2.x());
-    vertices.push_back(vertex2.y());
-    vertices.push_back(vertex2.z());
-    vertices.push_back(vertex1.x());
-    vertices.push_back(vertex1.y());
-    vertices.push_back(vertex1.z());
-    vertices.push_back(vertex6.x());
-    vertices.push_back(vertex6.y());
-    vertices.push_back(vertex6.z());
-
-    vertices.push_back(vertex1.x());
-    vertices.push_back(vertex1.y());
-    vertices.push_back(vertex1.z());
-    vertices.push_back(vertex5.x());
-    vertices.push_back(vertex5.y());
-    vertices.push_back(vertex5.z());
-    vertices.push_back(vertex6.x());
-    vertices.push_back(vertex6.y());
-    vertices.push_back(vertex6.z());
-
-    for (int i = 0; i < 6; i++) {
-        normals.push_back(1.0f);
-        normals.push_back(0.0f);
-        normals.push_back(0.0f);
-        colors.push_back(color.redF());
-        colors.push_back(color.greenF());
-        colors.push_back(color.blueF());
-        colors.push_back(color.alphaF());
-    }
-
-    // Back face
-    vertices.push_back(vertex1.x());
-    vertices.push_back(vertex1.y());
-    vertices.push_back(vertex1.z());
-    vertices.push_back(vertex0.x());
-    vertices.push_back(vertex0.y());
-    vertices.push_back(vertex0.z());
-    vertices.push_back(vertex5.x());
-    vertices.push_back(vertex5.y());
-    vertices.push_back(vertex5.z());
-
-    vertices.push_back(vertex0.x());
-    vertices.push_back(vertex0.y());
-    vertices.push_back(vertex0.z());
-    vertices.push_back(vertex4.x());
-    vertices.push_back(vertex4.y());
-    vertices.push_back(vertex4.z());
-    vertices.push_back(vertex5.x());
-    vertices.push_back(vertex5.y());
-    vertices.push_back(vertex5.z());
-
-    for (int i = 0; i < 6; i++) {
-        normals.push_back(0.0f);
-        normals.push_back(-1.0f);
-        normals.push_back(0.0f);
-        colors.push_back(color.redF());
-        colors.push_back(color.greenF());
-        colors.push_back(color.blueF());
-        colors.push_back(color.alphaF());
+    for (const auto& triangle : kTriangles) {
+        appendTriangleData(corner_vertices[triangle[0]], corner_vertices[triangle[1]], corner_vertices[triangle[2]],
+                           rgba, vertices, colors, normals);
     }
 }
 
@@ -242,1106 +284,449 @@ void ShapeFactory::createArcCylinderCCW(float cylinder_height, const Point& star
                                         const Point& end, const QMatrix4x4& transform, const QColor& color,
                                         std::vector<float>& vertices, std::vector<float>& colors,
                                         std::vector<float>& normals) {
-    const unsigned int cross_sectional_resolution = 20; // number of points that make up a cross-sectional circle
-    const unsigned int arc_segments = 75;               // number of cylindrical segments that comprise an arc
-
-    Angle angle;
-    if (MathUtils::orientation(start, center, end) == 0) {
-        // These are co-linear
-        if (start == end) {
-            // this is a circle
-            angle = 2.0f * M_PI;
-        }
-        else {
-            angle = M_PI;
-        }
-    }
-    else {
-        double a = qAtan2(center.x() - start.x(), center.y() - start.y());
-        double b = qAtan2(center.x() - end.x(), center.y() - end.y());
-
-        angle = Angle(a - b);
-        if (angle < 0) {
-            angle = (2.0f * M_PI) + angle;
-        }
-    }
-
-    float theta = 0; // angle around the cross-sectional circle
-    float theta_increment =
-        2.0f * float(M_PI) /
-        float(cross_sectional_resolution); // the amount to add each iteration through on the cross_sectional circle
-    float phi = 0;                         // angle around the arc
-    float phi_increment = angle() / arc_segments; // the amount to add each iteration though on the arc
-
-    float major_radius = Point(center.x(), center.y(), 0)
-                             .distance(Point(start.x(), start.y(),
-                                             0))(); // the distance from the center of the arc to the start/ end points
-    float minor_radius = cylinder_height / 2.0f;    // the radius the cross-sectional circle
-
-    QVector3D temp_vertices[arc_segments + 1][cross_sectional_resolution];
-
-    auto height = float(0.0);
-    auto height_increment = (end.z() - start.z()) / arc_segments;
-    for (auto& ring_vertices : temp_vertices) {
-        theta = 0;
-        for (auto& vertex : ring_vertices) {
-            vertex = transform * QVector3D(qCos(phi) * (major_radius + (minor_radius * qCos(theta))),
-                                           qSin(phi) * (major_radius + (minor_radius * qCos(theta))),
-                                           (qSin(theta) * minor_radius) + height);
-            theta += theta_increment;
-        }
-        height += height_increment;
-        phi += phi_increment;
-    }
-
-    // Connect first vertex to cap start
-    for (int i = 0; i < cross_sectional_resolution; ++i) {
-        appendTriangle(transform * QVector3D(major_radius, 0, 0), temp_vertices[0][i],
-                       temp_vertices[0][(i + 1) % cross_sectional_resolution], color, vertices, colors, normals);
-    }
-
-    for (int slice_index = 0; slice_index < arc_segments; ++slice_index) {
-        auto next_slice = slice_index + 1;
-        for (int vertex_index = 0; vertex_index < cross_sectional_resolution; ++vertex_index) {
-            auto next_point_index = (vertex_index + 1) % cross_sectional_resolution;
-
-            // Need to build two triangles per side of rectangle
-            appendTriangle(temp_vertices[slice_index][vertex_index], temp_vertices[next_slice][vertex_index],
-                           temp_vertices[slice_index][next_point_index], color, vertices, colors, normals);
-
-            appendTriangle(temp_vertices[next_slice][next_point_index], temp_vertices[slice_index][next_point_index],
-                           temp_vertices[next_slice][vertex_index], color, vertices, colors, normals);
-        }
-    }
-
-    // Cap the end
-    for (int i = 0; i < cross_sectional_resolution; ++i) {
-        appendTriangle(temp_vertices[arc_segments][(i + 1) % cross_sectional_resolution],
-                       temp_vertices[arc_segments][i],
-                       transform * QVector3D(major_radius * qCos(angle()), major_radius * qSin(angle()), height), color,
-                       vertices, colors, normals);
-    }
+    createArcCylinderMesh(cylinder_height, start, center, end, transform, true, color, vertices, colors, normals);
 }
 
 void ShapeFactory::createArcCylinder(float cylinder_height, const Point& start, const Point& center, const Point& end,
                                      const QMatrix4x4& transform, const QColor& color, std::vector<float>& vertices,
                                      std::vector<float>& colors, std::vector<float>& normals) {
-    const unsigned int cross_sectional_resolution = 20; // number of points that make up a cross-sectional circle
-    const unsigned int arc_segments = 75;               // number of cylindrical segments that comprise an arc
-
-    Angle angle;
-    short orientation = MathUtils::orientation(start, center, end);
-    if (orientation == 0) {
-        // These are co-linear
-        if (start == end) {
-            // this is a circle
-            angle = 2.0f * M_PI;
-        }
-        else {
-            angle = M_PI;
-        }
-    }
-    else {
-        double a = qAtan2(center.x() - start.x(), center.y() - start.y());
-        double b = qAtan2(center.x() - end.x(), center.y() - end.y());
-
-        angle = Angle(b - a);
-        if (angle < 0) {
-            angle = (2.0f * M_PI) + angle;
-        }
-    }
-
-    float theta = 0; // angle around the cross-sectional circle
-    float theta_increment =
-        2.0f * float(M_PI) /
-        float(cross_sectional_resolution); // the amount to add each iteration through on the cross_sectional circle
-    float phi = 2.0f * float(M_PI);        // Since this is clockwise, phi will start at 2 * Pi
-    float phi_increment = (angle() / float(arc_segments)); // and decrease by arc_segments number of increments
-
-    float major_radius = Point(center.x(), center.y(), 0)
-                             .distance(Point(start.x(), start.y(),
-                                             0))(); // the distance from the center of the arc to the start/ end points
-    float minor_radius = cylinder_height / 2.0f;    // the radius the cross-sectional circle
-
-    QVector3D temp_vertices[arc_segments + 1][cross_sectional_resolution];
-
-    auto height = float(0.0);
-    auto height_increment = (end.z() - start.z()) / arc_segments;
-    for (auto& ring_vertices : temp_vertices) {
-        theta = 0;
-        for (auto& vertex : ring_vertices) {
-            vertex = transform * QVector3D(qCos(phi) * (major_radius + (minor_radius * qCos(theta))),
-                                           qSin(phi) * (major_radius + (minor_radius * qCos(theta))),
-                                           (qSin(theta) * minor_radius) + height);
-            theta += theta_increment;
-        }
-        height += height_increment;
-        phi -= phi_increment;
-    }
-
-    // Connect first vertex to cap start
-    for (int i = 0; i < cross_sectional_resolution; ++i) {
-        appendTriangle(temp_vertices[0][(i + 1) % cross_sectional_resolution], temp_vertices[0][i],
-                       transform * QVector3D(major_radius, 0, 0), color, vertices, colors, normals);
-    }
-
-    for (int slice_index = 0; slice_index < arc_segments; ++slice_index) {
-        auto next_slice = slice_index + 1;
-        for (int vertex_index = 0; vertex_index < cross_sectional_resolution; ++vertex_index) {
-            auto next_point_index = (vertex_index + 1) % cross_sectional_resolution;
-
-            // Need to build two triangles per side of rectangle
-            appendTriangle(temp_vertices[slice_index][next_point_index], temp_vertices[next_slice][vertex_index],
-                           temp_vertices[slice_index][vertex_index], color, vertices, colors, normals);
-
-            appendTriangle(temp_vertices[next_slice][vertex_index], temp_vertices[slice_index][next_point_index],
-                           temp_vertices[next_slice][next_point_index], color, vertices, colors, normals);
-        }
-    }
-
-    // Cap the end
-    for (int i = 0; i < cross_sectional_resolution; ++i) {
-        appendTriangle(
-            transform * QVector3D(major_radius * qCos(angle() * -1), major_radius * qSin(angle() * -1), height),
-            temp_vertices[arc_segments][i], temp_vertices[arc_segments][(i + 1) % cross_sectional_resolution], color,
-            vertices, colors, normals);
-    }
+    createArcCylinderMesh(cylinder_height, start, center, end, transform, false, color, vertices, colors, normals);
 }
 
-void ShapeFactory::createSplineCylinder(const float diameter, const Point& start, const Point& control_a,
+void ShapeFactory::createSplineCylinder(float diameter, const Point& start, const Point& control_a,
                                         const Point& control_b, const Point& end, const QColor& color,
                                         std::vector<float>& vertices, std::vector<float>& colors,
                                         std::vector<float>& normals) {
-    const unsigned int cross_sectional_resolution = 20; // number of points that make up a cross-sectional circle
-    const unsigned int spline_segments = 75;            // number of cylindrical segments that comprise an spline
+    const float radius = diameter / 2.0f;
+    if (radius <= kVectorEpsilon) {
+        return;
+    }
 
-    float theta = 0; // angle around the cross-sectional circle
-    float theta_increment =
-        2.0f * float(M_PI) /
-        float(cross_sectional_resolution); // the amount to add each iteration through on the cross_sectional circle
+    const auto& circle = circleTable();
+    const Rgba rgba(color);
+    reserveTriangleMesh(vertices, colors, normals,
+                        kTubeCrossSectionResolution * (2 + (2 * static_cast<std::size_t>(kCurveSegments))));
 
-    QVector3D temp_vertices[spline_segments + 1][cross_sectional_resolution];
+    std::array<std::array<QVector3D, kTubeCrossSectionResolution>, kCurveSegments + 1> tube_vertices;
 
-    double t = 0.0;
-    double increment = 1.0 / spline_segments;
     BezierSegment curve(start, control_a, control_b, end);
+    const double increment = 1.0 / static_cast<double>(kCurveSegments);
+    double t = 0.0;
 
-    for (auto& ring_vertices : temp_vertices) {
-        theta = 0;
-        Point center = curve.getPointAlong(t);
-        Point next_center = curve.getPointAlong(t + increment);
+    for (auto& ring_vertices : tube_vertices) {
+        const Point center_point = curve.getPointAlong(t);
+        const Point next_center = curve.getPointAlong(t + increment);
+        const Angle tangent_angle = MathUtils::signedInternalAngle(
+            Point(center_point.x(), center_point.y() + 10.0f, center_point.z()), center_point, next_center);
 
-        for (auto& vertex : ring_vertices) {
-            Point p(center.x() + ((diameter / 2) * qCos(theta)), center.y(),
-                    center.z() + ((diameter / 2) * qSin(theta)));
-            p = p.rotateAround(center, MathUtils::signedInternalAngle(Point(center.x(), center.y() + 10, center.z()),
-                                                                      center, next_center));
-
-            vertex = p.toQVector3D();
-            theta += theta_increment;
+        for (int i = 0; i < kTubeCrossSectionResolution; ++i) {
+            Point point(center_point.x() + (radius * circle[i].x()), center_point.y(),
+                        center_point.z() + (radius * circle[i].y()));
+            point = point.rotateAround(center_point, tangent_angle);
+            ring_vertices[i] = point.toQVector3D();
         }
+
         t += increment;
     }
 
-    // Connect first vertex to cap start
-    for (int i = 0; i < cross_sectional_resolution; ++i) {
-        appendTriangle(curve.getPointAlong(0).toQVector3D(), temp_vertices[0][i],
-                       temp_vertices[0][(i + 1) % cross_sectional_resolution], color, vertices, colors, normals);
+    const QVector3D start_center = curve.getPointAlong(0.0).toQVector3D();
+    const QVector3D end_center = curve.getPointAlong(1.0).toQVector3D();
+
+    for (int i = 0; i < kTubeCrossSectionResolution; ++i) {
+        appendTriangleData(start_center, tube_vertices[0][i], tube_vertices[0][(i + 1) % kTubeCrossSectionResolution],
+                           rgba, vertices, colors, normals);
     }
 
-    for (int slice_index = 0; slice_index < spline_segments; ++slice_index) {
-        auto next_slice = slice_index + 1;
-        for (int vertex_index = 0; vertex_index < cross_sectional_resolution; ++vertex_index) {
-            auto next_point_index = (vertex_index + 1) % cross_sectional_resolution;
+    for (int slice_index = 0; slice_index < kCurveSegments; ++slice_index) {
+        const int next_slice = slice_index + 1;
+        for (int vertex_index = 0; vertex_index < kTubeCrossSectionResolution; ++vertex_index) {
+            const int next_vertex = (vertex_index + 1) % kTubeCrossSectionResolution;
 
-            // Need to build two triangles per side of rectangle
-            appendTriangle(temp_vertices[slice_index][vertex_index], temp_vertices[next_slice][vertex_index],
-                           temp_vertices[slice_index][next_point_index], color, vertices, colors, normals);
-
-            appendTriangle(temp_vertices[next_slice][next_point_index], temp_vertices[slice_index][next_point_index],
-                           temp_vertices[next_slice][vertex_index], color, vertices, colors, normals);
+            appendTriangleData(tube_vertices[slice_index][vertex_index], tube_vertices[next_slice][vertex_index],
+                               tube_vertices[slice_index][next_vertex], rgba, vertices, colors, normals);
+            appendTriangleData(tube_vertices[next_slice][next_vertex], tube_vertices[slice_index][next_vertex],
+                               tube_vertices[next_slice][vertex_index], rgba, vertices, colors, normals);
         }
     }
 
-    // Cap the end
-    for (int i = 0; i < cross_sectional_resolution; ++i) {
-        appendTriangle(temp_vertices[spline_segments][(i + 1) % cross_sectional_resolution],
-                       temp_vertices[spline_segments][i], curve.getPointAlong(1.0).toQVector3D(), color, vertices,
-                       colors, normals);
-    }
-}
-
-void ShapeFactory::appendTriangle(const QVector3D& v0, const QVector3D& v1, const QVector3D& v2, const QColor& color,
-                                  std::vector<float>& vertices, std::vector<float>& colors,
-                                  std::vector<float>& normals) {
-    // Convert color to RGBA format
-    std::array<float, 4> rgba = {static_cast<float>(color.redF()), static_cast<float>(color.greenF()),
-                                 static_cast<float>(color.blueF()), static_cast<float>(color.alphaF())};
-
-    // Add the vertices
-    vertices.insert(vertices.end(), {v0.x(), v0.y(), v0.z(), v1.x(), v1.y(), v1.z(), v2.x(), v2.y(), v2.z()});
-
-    // Compute the normal
-    QVector3D normal = QVector3D::crossProduct(v1 - v0, v2 - v0).normalized();
-
-    // Add the normal and color for each vertex
-    for (int i = 0; i < 3; ++i) {
-        normals.insert(normals.end(), {normal.x(), normal.y(), normal.z()});
-        colors.insert(colors.end(), rgba.begin(), rgba.end());
+    for (int i = 0; i < kTubeCrossSectionResolution; ++i) {
+        appendTriangleData(tube_vertices[kCurveSegments][(i + 1) % kTubeCrossSectionResolution],
+                           tube_vertices[kCurveSegments][i], end_center, rgba, vertices, colors, normals);
     }
 }
 
 void ShapeFactory::createCylinder(float radius, float height, const QMatrix4x4& transform, const QColor& color,
                                   std::vector<float>& vertices, std::vector<float>& colors,
                                   std::vector<float>& normals) {
-    unsigned int segments = 50; // Number of arc segments used to approximate a cylinder
-    float theta = 0.0f;         // Measure of angle at which each segment starts; first theta is just 0
-    float thetaIncrement = 2.0f * float(M_PI) / float(segments);
-    unsigned int center_top, center_bottom, first_top, second_top, first_bottom,
-        second_bottom;                    // Used to correctly place vertices in triangles
-    std::vector<QVector3D> temp_vertices; // store all the raw values of the vertices used to construct the triangles
-
-    /*
-     * The cylinder is drawn segment by segment. Each segment is represented
-     * by four triangles and six points: one triangle from the center of the top circle
-     * to two points on the top circle, then two triangles to make the vertical wall,
-     * then one triangle from the center of the bottom circle to two points on the bottom circle
-     *
-     * The bottom center is at (0,0,0) and the top center is at (0,0,height)
-     */
-
-    // Start with just the top center point
-    temp_vertices.push_back(transform * QVector3D(0.0f, 0.0f, height));
-
-    // Each iteration of this loop will create one vertex on the top circle and
-    // another vertex on the bottom circle
-    for (int i = 0; i < segments; ++i) {
-        temp_vertices.push_back(transform *
-                                QVector3D(radius * float(qCos(theta)), radius * float(qSin(theta)), height));
-        temp_vertices.push_back(transform * QVector3D(radius * float(qCos(theta)), radius * float(qSin(theta)), 0.0f));
-        theta += thetaIncrement;
+    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
+        return;
     }
 
-    // End with just the bottom center point
-    temp_vertices.push_back(transform * QVector3D(0.0f, 0.0f, 0.0f));
+    std::array<QVector3D, kCylinderSegments> top_vertices;
+    std::array<QVector3D, kCylinderSegments> bottom_vertices;
+    const float theta_increment = kTwoPi / static_cast<float>(kCylinderSegments);
 
-    /* Vertices are arranged like so:
-     * 0: top center
-     * 1 to 2*slices: odds on top, evens on bottom;
-     *                pairs of vertices like 1&2, 3&4, 5&6, etc. have same theta
-     * 2*slices+1: bottom center
-     *
-     * Each loop will make 4 triangles to connect top center, bottom center, and two pairs
-     */
+    for (int i = 0; i < kCylinderSegments; ++i) {
+        const float theta = static_cast<float>(i) * theta_increment;
+        const float x = radius * std::cos(theta);
+        const float y = radius * std::sin(theta);
+        top_vertices[i] = transform * QVector3D(x, y, height);
+        bottom_vertices[i] = transform * QVector3D(x, y, 0.0f);
+    }
 
-    center_top = 0;
-    center_bottom = 2 * segments + 1;
+    const QVector3D top_center = transform * QVector3D(0.0f, 0.0f, height);
+    const QVector3D bottom_center = transform * QVector3D(0.0f, 0.0f, 0.0f);
+    const Rgba rgba(color);
+    reserveTriangleMesh(vertices, colors, normals, static_cast<std::size_t>(kCylinderSegments) * 4);
 
-    // first_top and first_bottom have same theta but different z
-    first_top = 1;
-    first_bottom = 2;
-
-    // second_top and second_bottom have same theta but different z
-    second_top = 3;
-    second_bottom = 4;
-
-    // Create four triangles per slice.
-    QVector3D vertex1, vertex2, vertex3; // vertices of a face
-    QVector3D normal;                    // normal of a face shared by each of its vertices
-    for (int i = 0; i < segments; ++i) {
-        // Triangle on top circle
-        vertex1 = temp_vertices.at(center_top);
-        vertex2 = temp_vertices.at(first_top);
-        vertex3 = temp_vertices.at(second_top);
-        vertices.push_back(vertex1.x());
-        vertices.push_back(vertex1.y());
-        vertices.push_back(vertex1.z());
-        vertices.push_back(vertex2.x());
-        vertices.push_back(vertex2.y());
-        vertices.push_back(vertex2.z());
-        vertices.push_back(vertex3.x());
-        vertices.push_back(vertex3.y());
-        vertices.push_back(vertex3.z());
-
-        // All vertices in a triangle share the same normal
-        // All vertices have the same color, convenient to put in for loop here
-        normal = QVector3D::crossProduct(vertex3 - vertex2, vertex1 - vertex2).normalized();
-        for (int i = 0; i < 3; ++i) {
-            normals.push_back(normal.x());
-            normals.push_back(normal.y());
-            normals.push_back(normal.z());
-            colors.push_back(color.redF());
-            colors.push_back(color.greenF());
-            colors.push_back(color.blueF());
-            colors.push_back(color.alphaF());
-        }
-
-        // Triangles along cylinder side
-        vertex1 = temp_vertices.at(second_top);
-        vertex2 = temp_vertices.at(first_top);
-        vertex3 = temp_vertices.at(first_bottom);
-        vertices.push_back(vertex1.x());
-        vertices.push_back(vertex1.y());
-        vertices.push_back(vertex1.z());
-        vertices.push_back(vertex2.x());
-        vertices.push_back(vertex2.y());
-        vertices.push_back(vertex2.z());
-        vertices.push_back(vertex3.x());
-        vertices.push_back(vertex3.y());
-        vertices.push_back(vertex3.z());
-
-        normal = QVector3D::crossProduct(vertex3 - vertex2, vertex1 - vertex2).normalized();
-        for (int i = 0; i < 3; ++i) {
-            normals.push_back(normal.x());
-            normals.push_back(normal.y());
-            normals.push_back(normal.z());
-            colors.push_back(color.redF());
-            colors.push_back(color.greenF());
-            colors.push_back(color.blueF());
-            colors.push_back(color.alphaF());
-        }
-
-        vertex1 = temp_vertices.at(second_top);
-        vertex2 = temp_vertices.at(first_bottom);
-        vertex3 = temp_vertices.at(second_bottom);
-        vertices.push_back(vertex1.x());
-        vertices.push_back(vertex1.y());
-        vertices.push_back(vertex1.z());
-        vertices.push_back(vertex2.x());
-        vertices.push_back(vertex2.y());
-        vertices.push_back(vertex2.z());
-        vertices.push_back(vertex3.x());
-        vertices.push_back(vertex3.y());
-        vertices.push_back(vertex3.z());
-
-        normal = QVector3D::crossProduct(vertex3 - vertex2, vertex1 - vertex2).normalized();
-        for (int i = 0; i < 3; ++i) {
-            normals.push_back(normal.x());
-            normals.push_back(normal.y());
-            normals.push_back(normal.z());
-            colors.push_back(color.redF());
-            colors.push_back(color.greenF());
-            colors.push_back(color.blueF());
-            colors.push_back(color.alphaF());
-        }
-
-        // Triangle on bottom circle
-        vertex1 = temp_vertices.at(second_bottom);
-        vertex2 = temp_vertices.at(first_bottom);
-        vertex3 = temp_vertices.at(center_bottom);
-        vertices.push_back(vertex1.x());
-        vertices.push_back(vertex1.y());
-        vertices.push_back(vertex1.z());
-        vertices.push_back(vertex2.x());
-        vertices.push_back(vertex2.y());
-        vertices.push_back(vertex2.z());
-        vertices.push_back(vertex3.x());
-        vertices.push_back(vertex3.y());
-        vertices.push_back(vertex3.z());
-
-        normal = QVector3D::crossProduct(vertex3 - vertex2, vertex1 - vertex2).normalized();
-        for (int i = 0; i < 3; ++i) {
-            normals.push_back(normal.x());
-            normals.push_back(normal.y());
-            normals.push_back(normal.z());
-            colors.push_back(color.redF());
-            colors.push_back(color.greenF());
-            colors.push_back(color.blueF());
-            colors.push_back(color.alphaF());
-        }
-
-        first_top = second_top;
-        first_bottom = second_bottom;
-        second_top = first_top + 2;
-        second_bottom = first_bottom + 2;
-
-        // Last segment connects with first two vertices (vertices 1&2),
-        // so this is just doing some modulo
-        if (second_top > (2 * segments)) {
-            second_top -= 2 * segments;
-        }
-        if (second_bottom > (2 * segments)) {
-            second_bottom -= 2 * segments;
-        }
+    for (int i = 0; i < kCylinderSegments; ++i) {
+        const int next = (i + 1) % kCylinderSegments;
+        appendTriangleData(top_center, top_vertices[i], top_vertices[next], rgba, vertices, colors, normals);
+        appendTriangleData(top_vertices[next], top_vertices[i], bottom_vertices[i], rgba, vertices, colors, normals);
+        appendTriangleData(top_vertices[next], bottom_vertices[i], bottom_vertices[next], rgba, vertices, colors,
+                           normals);
+        appendTriangleData(bottom_vertices[next], bottom_vertices[i], bottom_center, rgba, vertices, colors, normals);
     }
 }
 
 void ShapeFactory::createSphere(float radius, int sectorCount, int stackCount, const QMatrix4x4& transform,
                                 const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
                                 std::vector<float>& normals) {
-    std::vector<QVector3D> tmpVertices;
+    if (radius <= kVectorEpsilon || sectorCount < kSphereMinSectorCount || stackCount < kSphereMinStackCount) {
+        return;
+    }
 
-    float sectorStep = 2 * M_PI / sectorCount;
-    float stackStep = M_PI / stackCount;
-    float sectorAngle, stackAngle;
+    const float sector_step = kTwoPi / static_cast<float>(sectorCount);
+    const float stack_step = kPi / static_cast<float>(stackCount);
 
-    // compute all vertices first, each vertex contains (x,y,z,s,t) except normal
+    std::vector<QVector3D> tmp_vertices;
+    tmp_vertices.reserve(static_cast<std::size_t>(stackCount + 1) * static_cast<std::size_t>(sectorCount + 1));
+
     for (int i = 0; i <= stackCount; ++i) {
-        stackAngle = M_PI / 2 - i * stackStep; // starting from pi/2 to -pi/2
-        float xy = radius * cosf(stackAngle);  // r * cos(u)
-        float z = radius * sinf(stackAngle);   // r * sin(u)
+        const float stack_angle = (kPi / 2.0f) - (static_cast<float>(i) * stack_step);
+        const float xy = radius * std::cos(stack_angle);
+        const float z = radius * std::sin(stack_angle);
 
-        // add (sectorCount+1) vertices per stack
-        // the first and last vertices have same position and normal, but different tex coords
         for (int j = 0; j <= sectorCount; ++j) {
-            sectorAngle = j * sectorStep; // starting from 0 to 2pi
-
-            QVector3D vertex;
-            vertex.setX(xy * cosf(sectorAngle)); // x = r * cos(u) * cos(v)
-            vertex.setY(xy * sinf(sectorAngle)); // y = r * cos(u) * sin(v)
-            vertex.setZ(z);                      // z = r * sin(u)
-            tmpVertices.push_back(transform * vertex);
+            const float sector_angle = static_cast<float>(j) * sector_step;
+            tmp_vertices.push_back(transform * QVector3D(xy * std::cos(sector_angle), xy * std::sin(sector_angle), z));
         }
     }
 
-    vertices.reserve(tmpVertices.size());
-    normals.reserve(vertices.size() / 3.0);
-    colors.reserve(vertices.size() / 3.0 * 4.0);
+    const std::size_t triangle_count =
+        static_cast<std::size_t>(sectorCount) * static_cast<std::size_t>((2 * stackCount) - 2);
+    const Rgba rgba(color);
+    reserveTriangleMesh(vertices, colors, normals, triangle_count);
 
-    QVector3D v1, v2, v3, v4; // 4 vertex positions and tex coords
-    QVector3D n;              // 1 face normal
+    for (int i = 0; i < stackCount; ++i) {
+        int vi1 = i * (sectorCount + 1);
+        int vi2 = (i + 1) * (sectorCount + 1);
 
-    int i, j, k, vi1, vi2;
-    int index = 0; // index for vertex
-    for (i = 0; i < stackCount; ++i) {
-        vi1 = i * (sectorCount + 1); // index of tmpVertices
-        vi2 = (i + 1) * (sectorCount + 1);
+        for (int j = 0; j < sectorCount; ++j, ++vi1, ++vi2) {
+            const QVector3D& v1 = tmp_vertices[vi1];
+            const QVector3D& v2 = tmp_vertices[vi2];
+            const QVector3D& v3 = tmp_vertices[vi1 + 1];
+            const QVector3D& v4 = tmp_vertices[vi2 + 1];
 
-        for (j = 0; j < sectorCount; ++j, ++vi1, ++vi2) {
-            // get 4 vertices per sector
-            //  v1--v3
-            //  |    |
-            //  v2--v4
-            v1 = tmpVertices[vi1];
-            v2 = tmpVertices[vi2];
-            v3 = tmpVertices[vi1 + 1];
-            v4 = tmpVertices[vi2 + 1];
-
-            // if 1st stack and last stack, store only 1 triangle per sector
-            // otherwise, store 2 triangles (quad) per sector
-            if (i == 0) { // a triangle for first stack ==========================
-                vertices.push_back(v1.x());
-                vertices.push_back(v1.y());
-                vertices.push_back(v1.z());
-                vertices.push_back(v2.x());
-                vertices.push_back(v2.y());
-                vertices.push_back(v2.z());
-                vertices.push_back(v4.x());
-                vertices.push_back(v4.y());
-                vertices.push_back(v4.z());
-
-                n = QVector3D::crossProduct(v4 - v2, v1 - v2).normalized();
-                // put normal
-                for (k = 0; k < 3; ++k) { // same normals for 3 vertices
-                    normals.push_back(n.x());
-                    normals.push_back(n.y());
-                    normals.push_back(n.z());
-                    colors.push_back(color.redF());
-                    colors.push_back(color.greenF());
-                    colors.push_back(color.blueF());
-                    colors.push_back(color.alphaF());
-                }
-                index += 3; // for next
+            if (i == 0) {
+                appendTriangleData(v1, v2, v4, rgba, vertices, colors, normals);
             }
-            else if (i == (stackCount - 1)) { // a triangle for last stack =========
-                vertices.push_back(v1.x());
-                vertices.push_back(v1.y());
-                vertices.push_back(v1.z());
-                vertices.push_back(v2.x());
-                vertices.push_back(v2.y());
-                vertices.push_back(v2.z());
-                vertices.push_back(v3.x());
-                vertices.push_back(v3.y());
-                vertices.push_back(v3.z());
-
-                n = QVector3D::crossProduct(v3 - v2, v1 - v2).normalized();
-
-                // put normal
-                for (k = 0; k < 3; ++k) { // same normals for 3 vertices
-                    normals.push_back(n.x());
-                    normals.push_back(n.y());
-                    normals.push_back(n.z());
-                    colors.push_back(color.redF());
-                    colors.push_back(color.greenF());
-                    colors.push_back(color.blueF());
-                    colors.push_back(color.alphaF());
-                }
-                index += 3; // for next
+            else if (i == (stackCount - 1)) {
+                appendTriangleData(v1, v2, v3, rgba, vertices, colors, normals);
             }
-            else { // 2 triangles for others ====================================
-                // put quad vertices: v1-v2-v3-v4
-                vertices.push_back(v1.x());
-                vertices.push_back(v1.y());
-                vertices.push_back(v1.z());
-                vertices.push_back(v2.x());
-                vertices.push_back(v2.y());
-                vertices.push_back(v2.z());
-                vertices.push_back(v3.x());
-                vertices.push_back(v3.y());
-                vertices.push_back(v3.z());
-
-                vertices.push_back(v3.x());
-                vertices.push_back(v3.y());
-                vertices.push_back(v3.z());
-                vertices.push_back(v2.x());
-                vertices.push_back(v2.y());
-                vertices.push_back(v2.z());
-                vertices.push_back(v4.x());
-                vertices.push_back(v4.y());
-                vertices.push_back(v4.z());
-                // 0-1-2, 2-1-3
-
-                // put normal
-                n = QVector3D::crossProduct(v3 - v2, v1 - v2).normalized();
-
-                // put normal
-                for (k = 0; k < 6; ++k) { // same normals for 6 vertices
-                    normals.push_back(n.x());
-                    normals.push_back(n.y());
-                    normals.push_back(n.z());
-                    colors.push_back(color.redF());
-                    colors.push_back(color.greenF());
-                    colors.push_back(color.blueF());
-                    colors.push_back(color.alphaF());
-                }
-
-                index += 4; // for next
+            else {
+                appendTriangleData(v1, v2, v3, rgba, vertices, colors, normals);
+                appendTriangleData(v3, v2, v4, rgba, vertices, colors, normals);
             }
         }
     }
 }
 
-void ShapeFactory::createGcodeCylinder(const float& width, const float& length, const float& height,
-                                       const QVector3D& start, const QVector3D& end, const QColor& color,
-                                       std::vector<float>& vertices, std::vector<float>& colors,
-                                       std::vector<float>& normals) {
-    // Compute the transformation matrix for the clipped cylinder
-    QMatrix4x4 transform = computeGcodeCylinderTransform(start, end);
-
-    // Radius of the clipped cylinder and number of quads per side
-    float radius;
-    unsigned int quads_per_side;
-
-    // If the height is greater than the width, the clipped cylinder is a rectangular prism
-    if (height > width) {
-        radius = std::sqrt((width / 2.0f) * (width / 2.0f) + (height / 2.0f) * (height / 2.0f));
-        quads_per_side = 1;
-    }
-    else { // Otherwise, the clipped cylinder is approximated by 6 quads per side
-        radius = width / 2.0f;
-        quads_per_side = 6;
+void ShapeFactory::createGcodeCylinder(float width, float length, float height, const QVector3D& start,
+                                       const QVector3D& end, const QColor& color, std::vector<float>& vertices,
+                                       std::vector<float>& colors, std::vector<float>& normals) {
+    if (width <= kVectorEpsilon || height <= kVectorEpsilon || length <= kVectorEpsilon ||
+        (end - start).lengthSquared() <= kVectorEpsilonSquared) {
+        return;
     }
 
-    // Compute number of vertices per arc and side of the clipped cylinder
-    unsigned int vertices_per_arc = quads_per_side + 1;
-    unsigned int vertices_per_side = 2 * vertices_per_arc;
+    const QMatrix4x4 transform = computeGcodeCylinderTransform(start, end);
 
-    // Compute the angular range based on the height and radius
-    float theta_start = -std::asin((height / 2.0f) / radius);
-    float theta_end = -theta_start;
-    float theta_increment = (theta_end - theta_start) / quads_per_side;
+    const bool rectangular_prism = height > width;
+    const float radius = rectangular_prism
+                             ? std::sqrt(((width / 2.0f) * (width / 2.0f)) + ((height / 2.0f) * (height / 2.0f)))
+                             : width / 2.0f;
+    if (radius <= kVectorEpsilon) {
+        return;
+    }
 
-    // Vectors to hold the vertices of the top and bottom of the clipped cylinder
-    std::vector<QVector3D> top_vertices(2 * vertices_per_arc);
-    std::vector<QVector3D> bottom_vertices(2 * vertices_per_arc);
+    const unsigned int quads_per_side = rectangular_prism ? 1 : 6;
+    const unsigned int vertices_per_arc = quads_per_side + 1;
+    const unsigned int vertices_per_side = 2 * vertices_per_arc;
+    const float theta_start = -std::asin(std::clamp((height / 2.0f) / radius, -1.0f, 1.0f));
+    const float theta_end = -theta_start;
+    const float theta_increment = (theta_end - theta_start) / static_cast<float>(quads_per_side);
 
-    // Generate vertices vertices for the top and bottom of the clipped cylinder
-    for (int i = 0; i < vertices_per_arc; ++i) {
-        float theta = theta_start + i * theta_increment;
+    std::vector<QVector3D> top_vertices(vertices_per_side);
+    std::vector<QVector3D> bottom_vertices(vertices_per_side);
 
-        float x = radius * std::cos(theta);
-        float y = radius * std::sin(theta);
+    for (unsigned int i = 0; i < vertices_per_arc; ++i) {
+        const float theta = theta_start + (static_cast<float>(i) * theta_increment);
+        const float x = radius * std::cos(theta);
+        const float y = radius * std::sin(theta);
 
-        // Right side vertices
         top_vertices[i] = transform * QVector3D(x, y, length);
         bottom_vertices[i] = transform * QVector3D(x, y, 0.0f);
-
-        // Left side vertices
         top_vertices[i + vertices_per_arc] = transform * QVector3D(-x, -y, length);
         bottom_vertices[i + vertices_per_arc] = transform * QVector3D(-x, -y, 0.0f);
     }
 
-    // Compute the top and bottom center points
-    QVector3D top_center = transform * QVector3D(0.0f, 0.0f, length);
-    QVector3D bottom_center = transform * QVector3D(0.0f, 0.0f, 0.0f);
+    const QVector3D top_center = transform * QVector3D(0.0f, 0.0f, length);
+    const QVector3D bottom_center = transform * QVector3D(0.0f, 0.0f, 0.0f);
+    const Rgba rgba(color);
+    reserveTriangleMesh(vertices, colors, normals, static_cast<std::size_t>(vertices_per_side) * 4);
 
-    // Generate triangle faces for each slice (quads split into two triangles)
     for (unsigned int i = 0; i < vertices_per_side; ++i) {
-        unsigned int j = (i + 1) % vertices_per_side;
-        appendTriangle(top_center, top_vertices[j], top_vertices[i], color, vertices, colors, normals); // Top triangle
-        appendTriangle(top_vertices[i], bottom_vertices[j], bottom_vertices[i], color, vertices, colors,
-                       normals); // Quad triangle 1
-        appendTriangle(top_vertices[i], top_vertices[j], bottom_vertices[j], color, vertices, colors,
-                       normals); // Quad triangle 2
-        appendTriangle(bottom_center, bottom_vertices[i], bottom_vertices[j], color, vertices, colors,
-                       normals); // Bottom triangle
+        const unsigned int next = (i + 1) % vertices_per_side;
+        appendTriangleData(top_center, top_vertices[next], top_vertices[i], rgba, vertices, colors, normals);
+        appendTriangleData(top_vertices[i], bottom_vertices[next], bottom_vertices[i], rgba, vertices, colors, normals);
+        appendTriangleData(top_vertices[i], top_vertices[next], bottom_vertices[next], rgba, vertices, colors, normals);
+        appendTriangleData(bottom_center, bottom_vertices[i], bottom_vertices[next], rgba, vertices, colors, normals);
     }
 }
 
 void ShapeFactory::createCone(float radius, float height, const QMatrix4x4& transform, const QColor& color,
                               std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals) {
-    unsigned int slices = 50; // Number of segments used to approximate a cone
-    float theta = 0;          // Theta of each segment, starts at 0
-    float theta_increment = 2 * float(M_PI) / float(slices);
-    unsigned int start_vertex;            // Used to build triangles at the end
-    unsigned int next_vertex;             // Used to build triangles at the end
-    std::vector<QVector3D> temp_vertices; // store all the raw values of the vertices used to construct the triangles
-
-    /*
-     * The cone is drawn as a series of pairs of triangles: one with a vertex at the tip and two
-     * vertices along the circle. The other with two vertices on the circle and one vertex at the base's center
-     */
-
-    // Tip of cone
-    temp_vertices.push_back(transform * QVector3D(0.0f, 0.0f, height));
-
-    // Perimeter of base
-    for (int i = 0; i < slices; ++i) {
-        temp_vertices.push_back(transform * QVector3D(radius * qSin(theta), radius * qCos(theta), 0.0f));
-        theta += theta_increment;
+    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
+        return;
     }
 
-    // Center of base
-    temp_vertices.push_back(transform * QVector3D(0.0f, 0.0f, 0.0f));
+    std::array<QVector3D, kConeSlices> perimeter_vertices;
+    const float theta_increment = kTwoPi / static_cast<float>(kConeSlices);
 
-    // Iterativel draw pairs of triangles
-    start_vertex = 1;
-    next_vertex = 2;
-    QVector3D vertex1, vertex2, vertex3;
-    QVector3D normal;
-    for (int i = 0; i < slices; ++i) {
-        // Triangle from tip to two points on circle
-        vertex1 = temp_vertices.at(0);
-        vertex2 = temp_vertices.at(next_vertex);
-        vertex3 = temp_vertices.at(start_vertex);
-        vertices.push_back(vertex1.x());
-        vertices.push_back(vertex1.y());
-        vertices.push_back(vertex1.z());
-        vertices.push_back(vertex2.x());
-        vertices.push_back(vertex2.y());
-        vertices.push_back(vertex2.z());
-        vertices.push_back(vertex3.x());
-        vertices.push_back(vertex3.y());
-        vertices.push_back(vertex3.z());
+    for (int i = 0; i < kConeSlices; ++i) {
+        const float theta = static_cast<float>(i) * theta_increment;
+        perimeter_vertices[i] = transform * QVector3D(radius * std::sin(theta), radius * std::cos(theta), 0.0f);
+    }
 
-        // Each vertex in a face has the same normals
-        // Each vertex has same color, convenient to push back color data in these loops
-        normal = QVector3D::crossProduct(vertex3 - vertex2, vertex1 - vertex2).normalized();
-        for (int i = 0; i < 3; ++i) {
-            normals.push_back(normal.x());
-            normals.push_back(normal.y());
-            normals.push_back(normal.z());
-            colors.push_back(color.redF());
-            colors.push_back(color.greenF());
-            colors.push_back(color.blueF());
-            colors.push_back(color.alphaF());
-        }
+    const QVector3D tip = transform * QVector3D(0.0f, 0.0f, height);
+    const QVector3D base_center = transform * QVector3D(0.0f, 0.0f, 0.0f);
+    const Rgba rgba(color);
+    reserveTriangleMesh(vertices, colors, normals, static_cast<std::size_t>(kConeSlices) * 2);
 
-        // Triangle from center of base to two points on circle
-        vertex1 = temp_vertices.at(start_vertex);
-        vertex2 = temp_vertices.at(next_vertex);
-        vertex3 = temp_vertices.at((slices + 1));
-        vertices.push_back(vertex1.x());
-        vertices.push_back(vertex1.y());
-        vertices.push_back(vertex1.z());
-        vertices.push_back(vertex2.x());
-        vertices.push_back(vertex2.y());
-        vertices.push_back(vertex2.z());
-        vertices.push_back(vertex3.x());
-        vertices.push_back(vertex3.y());
-        vertices.push_back(vertex3.z());
-
-        normal = QVector3D::crossProduct(vertex3 - vertex2, vertex1 - vertex2).normalized();
-        for (int i = 0; i < 3; ++i) {
-            normals.push_back(normal.x());
-            normals.push_back(normal.y());
-            normals.push_back(normal.z());
-            colors.push_back(color.redF());
-            colors.push_back(color.greenF());
-            colors.push_back(color.blueF());
-            colors.push_back(color.alphaF());
-        }
-
-        start_vertex = next_vertex;
-        ++next_vertex;
-
-        // Handle last slice where you come back to the first vertex to be added after the cone tip
-        if (next_vertex > slices) {
-            next_vertex -= slices;
-        }
+    for (int i = 0; i < kConeSlices; ++i) {
+        const int next = (i + 1) % kConeSlices;
+        appendTriangleData(tip, perimeter_vertices[next], perimeter_vertices[i], rgba, vertices, colors, normals);
+        appendTriangleData(perimeter_vertices[i], perimeter_vertices[next], base_center, rgba, vertices, colors,
+                           normals);
     }
 }
 
 void ShapeFactory::createGridPlane(float length, float width, float x_grid_dist, float y_grid_dist, const QColor& color,
                                    std::vector<float>& vertices, std::vector<float>& colors) {
-    float y_min = -width / 2;
-    float y_max = width / 2;
-    float x_min = -length / 2;
-    float x_max = length / 2;
-    float z = 0;
+    const float y_min = -width / 2.0f;
+    const float y_max = width / 2.0f;
+    const float x_min = -length / 2.0f;
+    const float x_max = length / 2.0f;
+    constexpr float z = 0.0f;
+    const Rgba rgba(color);
 
-    if (x_grid_dist > 0) {
-        float totalDist = x_max - x_min;
+    std::size_t line_count = 0;
+    if (x_grid_dist > 0.0f && x_grid_dist < (x_max - x_min)) {
+        line_count += countLoopValues(x_min, x_max + (x_grid_dist / 2.0f), x_grid_dist);
+    }
+    if (y_grid_dist > 0.0f && y_grid_dist < (y_max - y_min)) {
+        line_count += countLoopValues(y_min, y_max + (y_grid_dist / 2.0f), y_grid_dist);
+    }
+    reserveLineMesh(vertices, colors, line_count);
 
-        if (x_grid_dist < totalDist) {
-            float currentX = x_min;
-
-            while (currentX < (x_max + (x_grid_dist / 2))) {
-                vertices.push_back(currentX);
-                vertices.push_back(y_min);
-                vertices.push_back(z);
-                vertices.push_back(currentX);
-                vertices.push_back(y_max);
-                vertices.push_back(z);
-                currentX += x_grid_dist;
-            }
+    if (x_grid_dist > 0.0f && x_grid_dist < (x_max - x_min)) {
+        for (float current_x = x_min; current_x < (x_max + (x_grid_dist / 2.0f)); current_x += x_grid_dist) {
+            appendLine(QVector3D(current_x, y_min, z), QVector3D(current_x, y_max, z), rgba, vertices, colors);
         }
     }
 
-    if (y_grid_dist > 0) {
-        float totalDist = y_max - y_min;
-
-        if (y_grid_dist < totalDist) {
-            float currentY = y_min;
-
-            while (currentY < (y_max + (y_grid_dist / 2))) {
-                vertices.push_back(x_min);
-                vertices.push_back(currentY);
-                vertices.push_back(z);
-                vertices.push_back(x_max);
-                vertices.push_back(currentY);
-                vertices.push_back(z);
-                currentY += y_grid_dist;
-            }
+    if (y_grid_dist > 0.0f && y_grid_dist < (y_max - y_min)) {
+        for (float current_y = y_min; current_y < (y_max + (y_grid_dist / 2.0f)); current_y += y_grid_dist) {
+            appendLine(QVector3D(x_min, current_y, z), QVector3D(x_max, current_y, z), rgba, vertices, colors);
         }
-    }
-
-    int colorSize = vertices.size() / 3 * 4;
-    colors.reserve(colorSize);
-    for (int i = 0; i < colorSize; i += 4) {
-        colors.push_back(color.redF());
-        colors.push_back(color.greenF());
-        colors.push_back(color.blueF());
-        colors.push_back(color.alphaF());
     }
 }
 
-void ShapeFactory::createBuildVolumeRectangle(const QVector3D& min, const QVector3D& max, const float& x_grid_dist,
-                                              const float& x_grid_offset, const float& y_grid_dist,
-                                              const float& y_grid_offset, const QColor& color,
-                                              std::vector<float>& vertices, std::vector<float>& colors) {
-    float printer_x_min = min.x();
-    float printer_x_max = max.x();
-    float printer_y_min = min.y();
-    float printer_y_max = max.y();
-    float printer_z_min = min.z();
-    float printer_z_max = max.z();
+void ShapeFactory::createBuildVolumeRectangle(const QVector3D& min, const QVector3D& max, float x_grid_dist,
+                                              float x_grid_offset, float y_grid_dist, float y_grid_offset,
+                                              const QColor& color, std::vector<float>& vertices,
+                                              std::vector<float>& colors) {
+    const float printer_x_min = min.x();
+    const float printer_x_max = max.x();
+    const float printer_y_min = min.y();
+    const float printer_y_max = max.y();
+    const float printer_z_min = min.z();
+    const float printer_z_max = max.z();
 
-    vertices = {
-        // Line from back top left to...
-        // back top right
-        printer_x_min,
-        printer_y_min,
-        printer_z_max,
-        printer_x_max,
-        printer_y_min,
-        printer_z_max,
+    std::size_t line_count = 12;
+    if (x_grid_dist > 0.0f && x_grid_dist < (printer_x_max - printer_x_min)) {
+        line_count += countLoopValues(printer_x_min + x_grid_offset, printer_x_max, x_grid_dist);
+    }
+    if (y_grid_dist > 0.0f && y_grid_dist < (printer_y_max - printer_y_min)) {
+        line_count += countLoopValues(printer_y_min + y_grid_offset, printer_y_max, y_grid_dist);
+    }
 
-        // front top left
-        printer_x_min,
-        printer_y_min,
-        printer_z_max,
-        printer_x_min,
-        printer_y_max,
-        printer_z_max,
+    const Rgba rgba(color);
+    reserveLineMesh(vertices, colors, line_count);
 
-        // back bottom left
-        printer_x_min,
-        printer_y_min,
-        printer_z_max,
-        printer_x_min,
-        printer_y_min,
-        printer_z_min,
+    appendLine(QVector3D(printer_x_min, printer_y_min, printer_z_max),
+               QVector3D(printer_x_max, printer_y_min, printer_z_max), rgba, vertices, colors);
+    appendLine(QVector3D(printer_x_min, printer_y_min, printer_z_max),
+               QVector3D(printer_x_min, printer_y_max, printer_z_max), rgba, vertices, colors);
+    appendLine(QVector3D(printer_x_min, printer_y_min, printer_z_max),
+               QVector3D(printer_x_min, printer_y_min, printer_z_min), rgba, vertices, colors);
 
-        // Line from front top right to...
-        // back top right
-        printer_x_max,
-        printer_y_max,
-        printer_z_max,
-        printer_x_max,
-        printer_y_min,
-        printer_z_max,
+    appendLine(QVector3D(printer_x_max, printer_y_max, printer_z_max),
+               QVector3D(printer_x_max, printer_y_min, printer_z_max), rgba, vertices, colors);
+    appendLine(QVector3D(printer_x_max, printer_y_max, printer_z_max),
+               QVector3D(printer_x_min, printer_y_max, printer_z_max), rgba, vertices, colors);
+    appendLine(QVector3D(printer_x_max, printer_y_max, printer_z_max),
+               QVector3D(printer_x_max, printer_y_max, printer_z_min), rgba, vertices, colors);
 
-        // front top left
-        printer_x_max,
-        printer_y_max,
-        printer_z_max,
-        printer_x_min,
-        printer_y_max,
-        printer_z_max,
+    appendLine(QVector3D(printer_x_max, printer_y_min, printer_z_min),
+               QVector3D(printer_x_max, printer_y_min, printer_z_max), rgba, vertices, colors);
+    appendLine(QVector3D(printer_x_max, printer_y_min, printer_z_min),
+               QVector3D(printer_x_min, printer_y_min, printer_z_min), rgba, vertices, colors);
+    appendLine(QVector3D(printer_x_max, printer_y_min, printer_z_min),
+               QVector3D(printer_x_max, printer_y_max, printer_z_min), rgba, vertices, colors);
 
-        // front bottom right
-        printer_x_max,
-        printer_y_max,
-        printer_z_max,
-        printer_x_max,
-        printer_y_max,
-        printer_z_min,
+    appendLine(QVector3D(printer_x_min, printer_y_max, printer_z_min),
+               QVector3D(printer_x_min, printer_y_max, printer_z_max), rgba, vertices, colors);
+    appendLine(QVector3D(printer_x_min, printer_y_max, printer_z_min),
+               QVector3D(printer_x_min, printer_y_min, printer_z_min), rgba, vertices, colors);
+    appendLine(QVector3D(printer_x_min, printer_y_max, printer_z_min),
+               QVector3D(printer_x_max, printer_y_max, printer_z_min), rgba, vertices, colors);
 
-        // Line from back bottom right to...
-        // back top right
-        printer_x_max,
-        printer_y_min,
-        printer_z_min,
-        printer_x_max,
-        printer_y_min,
-        printer_z_max,
-
-        // back bottom left
-        printer_x_max,
-        printer_y_min,
-        printer_z_min,
-        printer_x_min,
-        printer_y_min,
-        printer_z_min,
-
-        // front bottom right
-        printer_x_max,
-        printer_y_min,
-        printer_z_min,
-        printer_x_max,
-        printer_y_max,
-        printer_z_min,
-
-        // Line from front bottom left to...
-        // front top left
-        printer_x_min,
-        printer_y_max,
-        printer_z_min,
-        printer_x_min,
-        printer_y_max,
-        printer_z_max,
-
-        // back bottom left
-        printer_x_min,
-        printer_y_max,
-        printer_z_min,
-        printer_x_min,
-        printer_y_min,
-        printer_z_min,
-
-        // front bottom right
-        printer_x_min,
-        printer_y_max,
-        printer_z_min,
-        printer_x_max,
-        printer_y_max,
-        printer_z_min,
-    };
-
-    if (x_grid_dist > 0) {
-        float totalDist = printer_x_max - printer_x_min;
-
-        if (x_grid_dist < totalDist) {
-            float currentX = printer_x_min + x_grid_offset;
-
-            while (currentX < printer_x_max) {
-                vertices.push_back(currentX);
-                vertices.push_back(printer_y_min);
-                vertices.push_back(printer_z_min);
-                vertices.push_back(currentX);
-                vertices.push_back(printer_y_max);
-                vertices.push_back(printer_z_min);
-                currentX += x_grid_dist;
-            }
+    if (x_grid_dist > 0.0f && x_grid_dist < (printer_x_max - printer_x_min)) {
+        for (float current_x = printer_x_min + x_grid_offset; current_x < printer_x_max; current_x += x_grid_dist) {
+            appendLine(QVector3D(current_x, printer_y_min, printer_z_min),
+                       QVector3D(current_x, printer_y_max, printer_z_min), rgba, vertices, colors);
         }
     }
 
-    if (y_grid_dist > 0) {
-        float totalDist = printer_y_max - printer_y_min;
-
-        if (y_grid_dist < totalDist) {
-            float currentY = printer_y_min + y_grid_offset;
-
-            while (currentY < printer_y_max) {
-                vertices.push_back(printer_x_min);
-                vertices.push_back(currentY);
-                vertices.push_back(printer_z_min);
-                vertices.push_back(printer_x_max);
-                vertices.push_back(currentY);
-                vertices.push_back(printer_z_min);
-                currentY += y_grid_dist;
-            }
+    if (y_grid_dist > 0.0f && y_grid_dist < (printer_y_max - printer_y_min)) {
+        for (float current_y = printer_y_min + y_grid_offset; current_y < printer_y_max; current_y += y_grid_dist) {
+            appendLine(QVector3D(printer_x_min, current_y, printer_z_min),
+                       QVector3D(printer_x_max, current_y, printer_z_min), rgba, vertices, colors);
         }
-    }
-
-    int colorSize = vertices.size() / 3 * 4;
-    colors.reserve(colorSize);
-    for (int i = 0; i < colorSize; i += 4) {
-        colors.push_back(color.redF());
-        colors.push_back(color.greenF());
-        colors.push_back(color.blueF());
-        colors.push_back(color.alphaF());
     }
 }
 
 void ShapeFactory::createBuildVolumeCylinder(float radius, float height, float x_grid_dist, float y_grid_dist,
                                              const QColor& color, std::vector<float>& vertices,
                                              std::vector<float>& colors) {
-    unsigned int segments = 100; // Number of arc segments used to approximate a cylinder
-    float theta = 0.0f;          // Measure of angle at which each segment starts; first theta is just 0
-    float thetaIncrement = 2.0f * M_PI / float(segments);
-    int verticalIncrement = 6;
+    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
+        return;
+    }
 
-    vertices.reserve(segments * 6 + verticalIncrement * 6);
-    std::vector<float> heights {0.0f, height};
+    const float theta_increment = kTwoPi / static_cast<float>(kBuildVolumeCylinderSegments);
+    const float vertical_step = kTwoPi / static_cast<float>(kBuildVolumeVerticalLines);
+    const float r_squared = radius * radius;
 
-    // draw two circles
-    for (float m_h : heights) {
-        theta = 0.0f;
+    std::size_t line_count = (static_cast<std::size_t>(kBuildVolumeCylinderSegments) * 2) + kBuildVolumeVerticalLines;
+    if (x_grid_dist > 0.0f) {
+        line_count += countLoopValues(-radius, radius + kVectorEpsilon, x_grid_dist);
+    }
+    if (y_grid_dist > 0.0f) {
+        line_count += countLoopValues(-radius, radius + kVectorEpsilon, y_grid_dist);
+    }
 
-        for (int i = 0; i < segments; ++i) {
-            vertices.push_back(radius * qCos(theta));
-            vertices.push_back(radius * qSin(theta));
-            vertices.push_back(m_h);
+    const Rgba rgba(color);
+    reserveLineMesh(vertices, colors, line_count);
 
-            theta += thetaIncrement;
-
-            vertices.push_back(radius * qCos(theta));
-            vertices.push_back(radius * qSin(theta));
-            vertices.push_back(m_h);
+    for (float current_height : std::array<float, 2> {0.0f, height}) {
+        for (int i = 0; i < kBuildVolumeCylinderSegments; ++i) {
+            const float theta = static_cast<float>(i) * theta_increment;
+            const float next_theta = static_cast<float>(i + 1) * theta_increment;
+            appendLine(QVector3D(radius * std::cos(theta), radius * std::sin(theta), current_height),
+                       QVector3D(radius * std::cos(next_theta), radius * std::sin(next_theta), current_height), rgba,
+                       vertices, colors);
         }
     }
 
-    // draw vertical lines
-    theta = 0.0;
-    float verticalStep = 2.0f * M_PI / float(verticalIncrement);
-    for (int i = 0; i < verticalIncrement; ++i) {
-        float x = radius * qCos(theta);
-        float y = radius * qSin(theta);
-
-        vertices.push_back(x);
-        vertices.push_back(y);
-        vertices.push_back(0.0f);
-
-        vertices.push_back(x);
-        vertices.push_back(y);
-        vertices.push_back(height);
-
-        theta += verticalStep;
+    for (int i = 0; i < kBuildVolumeVerticalLines; ++i) {
+        const float theta = static_cast<float>(i) * vertical_step;
+        const float x = radius * std::cos(theta);
+        const float y = radius * std::sin(theta);
+        appendLine(QVector3D(x, y, 0.0f), QVector3D(x, y, height), rgba, vertices, colors);
     }
 
-    float r_squared = radius * radius;
-    float diameter = 2.0 * radius;
-    if (x_grid_dist > 0) {
-        float x = -radius;
-
-        while (x < diameter) {
-            float x_squared = x * x;
-            float y = qSqrt(r_squared - x_squared);
-
-            if (std::isnan(y)) {
-                x += x_grid_dist;
-                continue;
-            }
-
-            vertices.push_back(x);
-            vertices.push_back(y);
-            vertices.push_back(0.0f);
-
-            vertices.push_back(x);
-            vertices.push_back(-y);
-            vertices.push_back(0.0f);
-
-            x += x_grid_dist;
+    if (x_grid_dist > 0.0f) {
+        for (float x = -radius; x <= radius + kVectorEpsilon; x += x_grid_dist) {
+            const float y = std::sqrt(std::max(0.0f, r_squared - (x * x)));
+            appendLine(QVector3D(x, y, 0.0f), QVector3D(x, -y, 0.0f), rgba, vertices, colors);
         }
     }
 
-    if (y_grid_dist > 0) {
-        float y = -radius;
-
-        while (y < diameter) {
-            float y_squared = y * y;
-            float x = qSqrt(r_squared - y_squared);
-
-            if (std::isnan(x)) {
-                y += y_grid_dist;
-                continue;
-            }
-
-            vertices.push_back(x);
-            vertices.push_back(y);
-            vertices.push_back(0.0f);
-
-            vertices.push_back(-x);
-            vertices.push_back(y);
-            vertices.push_back(0.0f);
-
-            y += y_grid_dist;
+    if (y_grid_dist > 0.0f) {
+        for (float y = -radius; y <= radius + kVectorEpsilon; y += y_grid_dist) {
+            const float x = std::sqrt(std::max(0.0f, r_squared - (y * y)));
+            appendLine(QVector3D(x, y, 0.0f), QVector3D(-x, y, 0.0f), rgba, vertices, colors);
         }
-    }
-
-    // set colors for all vertices
-    int colorSize = vertices.size() / 3 * 4;
-    colors.reserve(colorSize);
-    for (int i = 0; i < colorSize; i += 4) {
-        colors.push_back(color.redF());
-        colors.push_back(color.greenF());
-        colors.push_back(color.blueF());
-        colors.push_back(color.alphaF());
     }
 }
 
 QMatrix4x4 ShapeFactory::computeGcodeCylinderTransform(const QVector3D& start, const QVector3D& end) {
-    // Convert the start position and displacement to a transform matrix we can use in the standard method
     QMatrix4x4 transform;
     transform.translate(start);
 
-    // Retrieve the tangent (forward) vector from start to end
-    QVector3D tangent = end.normalized();
+    QVector3D tangent = end - start;
+    if (tangent.lengthSquared() <= kVectorEpsilonSquared) {
+        return transform;
+    }
+    tangent.normalize();
 
-    // Retrieve the normal (up) vector from the global settings
     QVector3D normal = {GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorX),
                         GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorY),
                         GSM->getGlobal()->setting<float>(PS::Slicing::kSlicingVectorZ)};
-    normal.normalize();
+    if (normal.lengthSquared() <= kVectorEpsilonSquared) {
+        normal = QVector3D(0.0f, 0.0f, 1.0f);
+    }
+    else {
+        normal.normalize();
+    }
 
-    // Compute the right vector
     QVector3D binormal = QVector3D::crossProduct(tangent, normal);
-    if (binormal.lengthSquared() < std::numeric_limits<float>::epsilon()) {
-        // Up and forward are parallel or anti-parallel; choose a different up vector
-        normal = QVector3D(1, 0, 0);
+    if (binormal.lengthSquared() <= kVectorEpsilonSquared) {
+        normal = (std::fabs(tangent.x()) < 0.9f) ? QVector3D(1.0f, 0.0f, 0.0f) : QVector3D(0.0f, 1.0f, 0.0f);
         binormal = QVector3D::crossProduct(tangent, normal);
     }
     binormal.normalize();
 
-    // Recompute up vector to ensure orthogonality
     normal = QVector3D::crossProduct(binormal, tangent);
+    normal.normalize();
 
-    // Build the rotation matrix
     QMatrix4x4 rotation;
-    rotation.setColumn(0, QVector4D(binormal, 0));
-    rotation.setColumn(1, QVector4D(normal, 0));
-    rotation.setColumn(2, QVector4D(tangent, 0));
-    rotation.setColumn(3, QVector4D(0, 0, 0, 1));
+    rotation.setColumn(0, QVector4D(binormal, 0.0f));
+    rotation.setColumn(1, QVector4D(normal, 0.0f));
+    rotation.setColumn(2, QVector4D(tangent, 0.0f));
+    rotation.setColumn(3, QVector4D(0.0f, 0.0f, 0.0f, 1.0f));
 
-    // Apply the rotation to the transform
     transform *= rotation;
-
     return transform;
 }
 
-void ShapeFactory::createArcCylinder(const float cylinder_height, const Point& start, const Point& center,
-                                     const Point& end, bool is_ccw, const QColor& color, std::vector<float>& vertices,
+void ShapeFactory::createArcCylinder(float cylinder_height, const Point& start, const Point& center, const Point& end,
+                                     bool is_ccw, const QColor& color, std::vector<float>& vertices,
                                      std::vector<float>& colors, std::vector<float>& normals) {
-    // Convert the start position and displacement to a transform matrix we can use in the standard method
+    const float major_radius = std::hypot(start.x() - center.x(), start.y() - center.y());
+    if (major_radius <= kVectorEpsilon || cylinder_height <= kVectorEpsilon) {
+        return;
+    }
+
     QMatrix4x4 transform;
-    transform.setToIdentity();
     transform.translate(center.toQVector3D());
 
-    Point a(start.x(), start.y(), center.z());
-    Point c(center.x() + (center.distance(a)), center.y(), center.z());
-    transform.rotate(MathUtils::CreateQuaternion((c - center).toQVector3D(), (a - center).toQVector3D()));
+    const Point projected_start(start.x(), start.y(), center.z());
+    const Point reference(center.x() + major_radius, center.y(), center.z());
+    transform.rotate(
+        MathUtils::CreateQuaternion((reference - center).toQVector3D(), (projected_start - center).toQVector3D()));
 
     if (is_ccw) {
         createArcCylinderCCW(cylinder_height, start, center, end, transform, color, vertices, colors, normals);
@@ -1351,4 +736,4 @@ void ShapeFactory::createArcCylinder(const float cylinder_height, const Point& s
     }
 }
 
-} // Namespace ORNL
+} // namespace ORNL

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -707,13 +707,16 @@ void ShapeFactory::appendArcBead(float bead_diameter, const Point& start, const 
         return;
     }
 
-    QMatrix4x4 transform;
-    transform.translate(center.toQVector3D());
+    const Point display_center(center.x(), center.y(), start.z());
 
-    const Point projected_start(start.x(), start.y(), center.z());
-    const Point reference(center.x() + major_radius, center.y(), center.z());
+    QMatrix4x4 transform;
+    transform.translate(display_center.toQVector3D());
+
+    const Point projected_start(start.x(), start.y(), display_center.z());
+    const Point reference(display_center.x() + major_radius, display_center.y(), display_center.z());
     transform.rotate(
-        MathUtils::CreateQuaternion((reference - center).toQVector3D(), (projected_start - center).toQVector3D()));
+        MathUtils::CreateQuaternion((reference - display_center).toQVector3D(),
+                                    (projected_start - display_center).toQVector3D()));
 
     appendArcBeadMesh(bead_diameter, start, center, end, transform, is_ccw, color, vertices, colors, normals);
 }

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -279,20 +279,6 @@ void ShapeFactory::appendBox(float length, float width, float height, const QMat
     }
 }
 
-void ShapeFactory::appendArcBeadCounterClockwise(float bead_diameter, const Point& start, const Point& center,
-                                                 const Point& end, const QMatrix4x4& transform, const QColor& color,
-                                                 std::vector<float>& vertices, std::vector<float>& colors,
-                                                 std::vector<float>& normals) {
-    appendArcBeadMesh(bead_diameter, start, center, end, transform, true, color, vertices, colors, normals);
-}
-
-void ShapeFactory::appendArcBeadClockwise(float bead_diameter, const Point& start, const Point& center,
-                                          const Point& end, const QMatrix4x4& transform, const QColor& color,
-                                          std::vector<float>& vertices, std::vector<float>& colors,
-                                          std::vector<float>& normals) {
-    appendArcBeadMesh(bead_diameter, start, center, end, transform, false, color, vertices, colors, normals);
-}
-
 void ShapeFactory::appendSplineBead(float bead_diameter, const Point& start, const Point& control_a,
                                     const Point& control_b, const Point& end, const QColor& color,
                                     std::vector<float>& vertices, std::vector<float>& colors,
@@ -728,12 +714,7 @@ void ShapeFactory::appendArcBead(float bead_diameter, const Point& start, const 
     transform.rotate(
         MathUtils::CreateQuaternion((reference - center).toQVector3D(), (projected_start - center).toQVector3D()));
 
-    if (is_ccw) {
-        appendArcBeadCounterClockwise(bead_diameter, start, center, end, transform, color, vertices, colors, normals);
-    }
-    else {
-        appendArcBeadClockwise(bead_diameter, start, center, end, transform, color, vertices, colors, normals);
-    }
+    appendArcBeadMesh(bead_diameter, start, center, end, transform, is_ccw, color, vertices, colors, normals);
 }
 
 } // namespace ORNL

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -430,7 +430,8 @@ void ShapeFactory::appendSphere(float radius, int sector_count, int stack_count,
 
 void ShapeFactory::appendLinearBead(float width, float length, float height, const QVector3D& start,
                                     const QVector3D& end, const QColor& color, std::vector<float>& vertices,
-                                    std::vector<float>& colors, std::vector<float>& normals) {
+                                    std::vector<float>& colors, std::vector<float>& normals,
+                                    unsigned int quads_per_side) {
     if (width <= kVectorEpsilon || height <= kVectorEpsilon || length <= kVectorEpsilon ||
         (end - start).lengthSquared() <= kVectorEpsilonSquared) {
         return;
@@ -446,12 +447,12 @@ void ShapeFactory::appendLinearBead(float width, float length, float height, con
         return;
     }
 
-    const unsigned int quads_per_side = rectangular_prism ? 1 : 6;
-    const unsigned int vertices_per_arc = quads_per_side + 1;
+    const unsigned int resolved_quads_per_side = rectangular_prism ? 1 : std::max(1u, quads_per_side);
+    const unsigned int vertices_per_arc = resolved_quads_per_side + 1;
     const unsigned int vertices_per_side = 2 * vertices_per_arc;
     const float theta_start = -std::asin(std::clamp((height / 2.0f) / radius, -1.0f, 1.0f));
     const float theta_end = -theta_start;
-    const float theta_increment = (theta_end - theta_start) / static_cast<float>(quads_per_side);
+    const float theta_increment = (theta_end - theta_start) / static_cast<float>(resolved_quads_per_side);
 
     std::vector<QVector3D> top_vertices(vertices_per_side);
     std::vector<QVector3D> bottom_vertices(vertices_per_side);

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -151,11 +151,11 @@ float arcSweepAngle(const Point& start, const Point& center, const Point& end, b
     return angle;
 }
 
-void createArcCylinderMesh(float cylinder_height, const Point& start, const Point& center, const Point& end,
-                           const QMatrix4x4& transform, bool counterclockwise, const QColor& color,
-                           std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals) {
+void appendArcBeadMesh(float bead_diameter, const Point& start, const Point& center, const Point& end,
+                       const QMatrix4x4& transform, bool counterclockwise, const QColor& color,
+                       std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals) {
     const float major_radius = std::hypot(start.x() - center.x(), start.y() - center.y());
-    const float minor_radius = cylinder_height / 2.0f;
+    const float minor_radius = bead_diameter / 2.0f;
     if (major_radius <= kVectorEpsilon || minor_radius <= kVectorEpsilon) {
         return;
     }
@@ -238,9 +238,8 @@ void createArcCylinderMesh(float cylinder_height, const Point& start, const Poin
 }
 } // namespace
 
-void ShapeFactory::createRectangle(float length, float width, float height, const QMatrix4x4& transform,
-                                   const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
-                                   std::vector<float>& normals) {
+void ShapeFactory::appendBox(float length, float width, float height, const QMatrix4x4& transform, const QColor& color,
+                             std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals) {
     const float half_length = length / 2.0f;
     const float half_width = width / 2.0f;
     const float half_height = height / 2.0f;
@@ -280,24 +279,25 @@ void ShapeFactory::createRectangle(float length, float width, float height, cons
     }
 }
 
-void ShapeFactory::createArcCylinderCCW(float cylinder_height, const Point& start, const Point& center,
-                                        const Point& end, const QMatrix4x4& transform, const QColor& color,
-                                        std::vector<float>& vertices, std::vector<float>& colors,
-                                        std::vector<float>& normals) {
-    createArcCylinderMesh(cylinder_height, start, center, end, transform, true, color, vertices, colors, normals);
+void ShapeFactory::appendArcBeadCounterClockwise(float bead_diameter, const Point& start, const Point& center,
+                                                 const Point& end, const QMatrix4x4& transform, const QColor& color,
+                                                 std::vector<float>& vertices, std::vector<float>& colors,
+                                                 std::vector<float>& normals) {
+    appendArcBeadMesh(bead_diameter, start, center, end, transform, true, color, vertices, colors, normals);
 }
 
-void ShapeFactory::createArcCylinder(float cylinder_height, const Point& start, const Point& center, const Point& end,
-                                     const QMatrix4x4& transform, const QColor& color, std::vector<float>& vertices,
-                                     std::vector<float>& colors, std::vector<float>& normals) {
-    createArcCylinderMesh(cylinder_height, start, center, end, transform, false, color, vertices, colors, normals);
+void ShapeFactory::appendArcBeadClockwise(float bead_diameter, const Point& start, const Point& center,
+                                          const Point& end, const QMatrix4x4& transform, const QColor& color,
+                                          std::vector<float>& vertices, std::vector<float>& colors,
+                                          std::vector<float>& normals) {
+    appendArcBeadMesh(bead_diameter, start, center, end, transform, false, color, vertices, colors, normals);
 }
 
-void ShapeFactory::createSplineCylinder(float diameter, const Point& start, const Point& control_a,
-                                        const Point& control_b, const Point& end, const QColor& color,
-                                        std::vector<float>& vertices, std::vector<float>& colors,
-                                        std::vector<float>& normals) {
-    const float radius = diameter / 2.0f;
+void ShapeFactory::appendSplineBead(float bead_diameter, const Point& start, const Point& control_a,
+                                    const Point& control_b, const Point& end, const QColor& color,
+                                    std::vector<float>& vertices, std::vector<float>& colors,
+                                    std::vector<float>& normals) {
+    const float radius = bead_diameter / 2.0f;
     if (radius <= kVectorEpsilon) {
         return;
     }
@@ -355,7 +355,7 @@ void ShapeFactory::createSplineCylinder(float diameter, const Point& start, cons
     }
 }
 
-void ShapeFactory::createCylinder(float radius, float height, const QMatrix4x4& transform, const QColor& color,
+void ShapeFactory::appendCylinder(float radius, float height, const QMatrix4x4& transform, const QColor& color,
                                   std::vector<float>& vertices, std::vector<float>& colors,
                                   std::vector<float>& normals) {
     if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
@@ -389,40 +389,40 @@ void ShapeFactory::createCylinder(float radius, float height, const QMatrix4x4& 
     }
 }
 
-void ShapeFactory::createSphere(float radius, int sectorCount, int stackCount, const QMatrix4x4& transform,
+void ShapeFactory::appendSphere(float radius, int sector_count, int stack_count, const QMatrix4x4& transform,
                                 const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
                                 std::vector<float>& normals) {
-    if (radius <= kVectorEpsilon || sectorCount < kSphereMinSectorCount || stackCount < kSphereMinStackCount) {
+    if (radius <= kVectorEpsilon || sector_count < kSphereMinSectorCount || stack_count < kSphereMinStackCount) {
         return;
     }
 
-    const float sector_step = kTwoPi / static_cast<float>(sectorCount);
-    const float stack_step = kPi / static_cast<float>(stackCount);
+    const float sector_step = kTwoPi / static_cast<float>(sector_count);
+    const float stack_step = kPi / static_cast<float>(stack_count);
 
     std::vector<QVector3D> tmp_vertices;
-    tmp_vertices.reserve(static_cast<std::size_t>(stackCount + 1) * static_cast<std::size_t>(sectorCount + 1));
+    tmp_vertices.reserve(static_cast<std::size_t>(stack_count + 1) * static_cast<std::size_t>(sector_count + 1));
 
-    for (int i = 0; i <= stackCount; ++i) {
+    for (int i = 0; i <= stack_count; ++i) {
         const float stack_angle = (kPi / 2.0f) - (static_cast<float>(i) * stack_step);
         const float xy = radius * std::cos(stack_angle);
         const float z = radius * std::sin(stack_angle);
 
-        for (int j = 0; j <= sectorCount; ++j) {
+        for (int j = 0; j <= sector_count; ++j) {
             const float sector_angle = static_cast<float>(j) * sector_step;
             tmp_vertices.push_back(transform * QVector3D(xy * std::cos(sector_angle), xy * std::sin(sector_angle), z));
         }
     }
 
     const std::size_t triangle_count =
-        static_cast<std::size_t>(sectorCount) * static_cast<std::size_t>((2 * stackCount) - 2);
+        static_cast<std::size_t>(sector_count) * static_cast<std::size_t>((2 * stack_count) - 2);
     const Rgba rgba(color);
     reserveTriangleMesh(vertices, colors, normals, triangle_count);
 
-    for (int i = 0; i < stackCount; ++i) {
-        int vi1 = i * (sectorCount + 1);
-        int vi2 = (i + 1) * (sectorCount + 1);
+    for (int i = 0; i < stack_count; ++i) {
+        int vi1 = i * (sector_count + 1);
+        int vi2 = (i + 1) * (sector_count + 1);
 
-        for (int j = 0; j < sectorCount; ++j, ++vi1, ++vi2) {
+        for (int j = 0; j < sector_count; ++j, ++vi1, ++vi2) {
             const QVector3D& v1 = tmp_vertices[vi1];
             const QVector3D& v2 = tmp_vertices[vi2];
             const QVector3D& v3 = tmp_vertices[vi1 + 1];
@@ -431,7 +431,7 @@ void ShapeFactory::createSphere(float radius, int sectorCount, int stackCount, c
             if (i == 0) {
                 appendTriangleData(v1, v2, v4, rgba, vertices, colors, normals);
             }
-            else if (i == (stackCount - 1)) {
+            else if (i == (stack_count - 1)) {
                 appendTriangleData(v1, v2, v3, rgba, vertices, colors, normals);
             }
             else {
@@ -442,15 +442,15 @@ void ShapeFactory::createSphere(float radius, int sectorCount, int stackCount, c
     }
 }
 
-void ShapeFactory::createGcodeCylinder(float width, float length, float height, const QVector3D& start,
-                                       const QVector3D& end, const QColor& color, std::vector<float>& vertices,
-                                       std::vector<float>& colors, std::vector<float>& normals) {
+void ShapeFactory::appendLinearBead(float width, float length, float height, const QVector3D& start,
+                                    const QVector3D& end, const QColor& color, std::vector<float>& vertices,
+                                    std::vector<float>& colors, std::vector<float>& normals) {
     if (width <= kVectorEpsilon || height <= kVectorEpsilon || length <= kVectorEpsilon ||
         (end - start).lengthSquared() <= kVectorEpsilonSquared) {
         return;
     }
 
-    const QMatrix4x4 transform = computeGcodeCylinderTransform(start, end);
+    const QMatrix4x4 transform = computeLinearBeadTransform(start, end);
 
     const bool rectangular_prism = height > width;
     const float radius = rectangular_prism
@@ -495,7 +495,7 @@ void ShapeFactory::createGcodeCylinder(float width, float length, float height, 
     }
 }
 
-void ShapeFactory::createCone(float radius, float height, const QMatrix4x4& transform, const QColor& color,
+void ShapeFactory::appendCone(float radius, float height, const QMatrix4x4& transform, const QColor& color,
                               std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals) {
     if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
         return;
@@ -522,8 +522,8 @@ void ShapeFactory::createCone(float radius, float height, const QMatrix4x4& tran
     }
 }
 
-void ShapeFactory::createGridPlane(float length, float width, float x_grid_dist, float y_grid_dist, const QColor& color,
-                                   std::vector<float>& vertices, std::vector<float>& colors) {
+void ShapeFactory::appendGridPlaneLines(float length, float width, float x_grid_dist, float y_grid_dist,
+                                        const QColor& color, std::vector<float>& vertices, std::vector<float>& colors) {
     const float y_min = -width / 2.0f;
     const float y_max = width / 2.0f;
     const float x_min = -length / 2.0f;
@@ -553,10 +553,10 @@ void ShapeFactory::createGridPlane(float length, float width, float x_grid_dist,
     }
 }
 
-void ShapeFactory::createBuildVolumeRectangle(const QVector3D& min, const QVector3D& max, float x_grid_dist,
-                                              float x_grid_offset, float y_grid_dist, float y_grid_offset,
-                                              const QColor& color, std::vector<float>& vertices,
-                                              std::vector<float>& colors) {
+void ShapeFactory::appendBuildVolumeBoxLines(const QVector3D& min, const QVector3D& max, float x_grid_dist,
+                                             float x_grid_offset, float y_grid_dist, float y_grid_offset,
+                                             const QColor& color, std::vector<float>& vertices,
+                                             std::vector<float>& colors) {
     const float printer_x_min = min.x();
     const float printer_x_max = max.x();
     const float printer_y_min = min.y();
@@ -618,9 +618,9 @@ void ShapeFactory::createBuildVolumeRectangle(const QVector3D& min, const QVecto
     }
 }
 
-void ShapeFactory::createBuildVolumeCylinder(float radius, float height, float x_grid_dist, float y_grid_dist,
-                                             const QColor& color, std::vector<float>& vertices,
-                                             std::vector<float>& colors) {
+void ShapeFactory::appendBuildVolumeCylinderLines(float radius, float height, float x_grid_dist, float y_grid_dist,
+                                                  const QColor& color, std::vector<float>& vertices,
+                                                  std::vector<float>& colors) {
     if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
         return;
     }
@@ -672,7 +672,7 @@ void ShapeFactory::createBuildVolumeCylinder(float radius, float height, float x
     }
 }
 
-QMatrix4x4 ShapeFactory::computeGcodeCylinderTransform(const QVector3D& start, const QVector3D& end) {
+QMatrix4x4 ShapeFactory::computeLinearBeadTransform(const QVector3D& start, const QVector3D& end) {
     QMatrix4x4 transform;
     transform.translate(start);
 
@@ -712,11 +712,11 @@ QMatrix4x4 ShapeFactory::computeGcodeCylinderTransform(const QVector3D& start, c
     return transform;
 }
 
-void ShapeFactory::createArcCylinder(float cylinder_height, const Point& start, const Point& center, const Point& end,
-                                     bool is_ccw, const QColor& color, std::vector<float>& vertices,
-                                     std::vector<float>& colors, std::vector<float>& normals) {
+void ShapeFactory::appendArcBead(float bead_diameter, const Point& start, const Point& center, const Point& end,
+                                 bool is_ccw, const QColor& color, std::vector<float>& vertices,
+                                 std::vector<float>& colors, std::vector<float>& normals) {
     const float major_radius = std::hypot(start.x() - center.x(), start.y() - center.y());
-    if (major_radius <= kVectorEpsilon || cylinder_height <= kVectorEpsilon) {
+    if (major_radius <= kVectorEpsilon || bead_diameter <= kVectorEpsilon) {
         return;
     }
 
@@ -729,10 +729,10 @@ void ShapeFactory::createArcCylinder(float cylinder_height, const Point& start, 
         MathUtils::CreateQuaternion((reference - center).toQVector3D(), (projected_start - center).toQVector3D()));
 
     if (is_ccw) {
-        createArcCylinderCCW(cylinder_height, start, center, end, transform, color, vertices, colors, normals);
+        appendArcBeadCounterClockwise(bead_diameter, start, center, end, transform, color, vertices, colors, normals);
     }
     else {
-        createArcCylinder(cylinder_height, start, center, end, transform, color, vertices, colors, normals);
+        appendArcBeadClockwise(bead_diameter, start, center, end, transform, color, vertices, colors, normals);
     }
 }
 

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -33,6 +33,7 @@
 namespace ORNL {
 namespace {
 constexpr float kLinePickToleranceSquared = 0.000225f;
+constexpr uint kHoverTrackingSegmentLimit = 10000;
 
 float distanceSquaredToSegment(const QPointF& point, const QPointF& start, const QPointF& end) {
     const float dx = end.x() - start.x();
@@ -117,6 +118,7 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
 
         m_printer->adoptChild(m_gcode_object);
     }
+    updateHoverTracking();
 
     // Clear out old ghosted parts
     for (auto ghost : m_ghosted_parts) {
@@ -153,6 +155,15 @@ void GCodeView::hideSegmentType(SegmentDisplayType type, bool hidden) {
     m_gcode_object->hideSegmentType(type, hidden);
 
     this->update();
+}
+
+void GCodeView::updateHoverTracking() {
+    if (m_gcode_object.isNull()) {
+        this->setMouseTracking(true);
+        return;
+    }
+
+    this->setMouseTracking(m_gcode_object->visibleSegmentCount() <= kHoverTrackingSegmentLimit);
 }
 
 void GCodeView::updateSegmentWidths(bool use_true_width) {
@@ -394,14 +405,8 @@ void GCodeView::setLowLayer(uint low_layer) {
     m_gcode_object->showLow(low_layer);
     m_state.low_layer = low_layer;
 
-    // When there are more than 10000 segments being shown at once,
-    // disable the mouse tracking (highlighting when mouse on top of
-    // segment). This helps performance.
     uint segment_count = m_gcode_object->visibleSegmentCount();
-    if (segment_count > 10000)
-        this->setMouseTracking(false);
-    else
-        this->setMouseTracking(true);
+    updateHoverTracking();
 
     emit maxSegmentChanged(segment_count - 1);
 
@@ -416,10 +421,7 @@ void GCodeView::setHighLayer(uint high_layer) {
     m_state.high_layer = high_layer;
 
     uint segment_count = m_gcode_object->visibleSegmentCount();
-    if (segment_count > 10000)
-        this->setMouseTracking(false);
-    else
-        this->setMouseTracking(true);
+    updateHoverTracking();
 
     emit maxSegmentChanged(segment_count - 1);
 
@@ -432,10 +434,7 @@ void GCodeView::setLowSegment(uint low_segment) {
 
     m_gcode_object->showLowSegment(low_segment);
 
-    if (m_gcode_object->visibleSegmentCount() > 10000)
-        this->setMouseTracking(false);
-    else
-        this->setMouseTracking(true);
+    updateHoverTracking();
 
     this->update();
 }
@@ -446,10 +445,7 @@ void GCodeView::setHighSegment(uint high_segment) {
 
     m_gcode_object->showHighSegment(high_segment);
 
-    if (m_gcode_object->visibleSegmentCount() > 10000)
-        this->setMouseTracking(false);
-    else
-        this->setMouseTracking(true);
+    updateHoverTracking();
 
     this->update();
 }

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -1,6 +1,8 @@
 #include "graphics/view/gcode_view.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include <qcontainerfwd.h>
 #include <qlist.h>
@@ -29,6 +31,44 @@
 #include "widgets/part_widget/model/part_meta_model.h"
 
 namespace ORNL {
+namespace {
+constexpr float kLinePickToleranceSquared = 0.000225f;
+
+float distanceSquaredToSegment(const QPointF& point, const QPointF& start, const QPointF& end) {
+    const float dx = end.x() - start.x();
+    const float dy = end.y() - start.y();
+    const float length_squared = (dx * dx) + (dy * dy);
+
+    if (length_squared <= std::numeric_limits<float>::epsilon()) {
+        const float point_dx = point.x() - start.x();
+        const float point_dy = point.y() - start.y();
+        return (point_dx * point_dx) + (point_dy * point_dy);
+    }
+
+    float t = ((point.x() - start.x()) * dx + (point.y() - start.y()) * dy) / length_squared;
+    t = MathUtils::clamp(0.0f, t, 1.0f);
+
+    const float projected_x = start.x() + (t * dx);
+    const float projected_y = start.y() + (t * dy);
+    const float point_dx = point.x() - projected_x;
+    const float point_dy = point.y() - projected_y;
+    return (point_dx * point_dx) + (point_dy * point_dy);
+}
+
+bool projectToNdc(const QMatrix4x4& projection, const QMatrix4x4& view, const QVector3D& point, QPointF& ndc,
+                  float& depth) {
+    const QVector4D clip = projection * view * QVector4D(point, 1.0f);
+    if (qFuzzyIsNull(clip.w())) {
+        return false;
+    }
+
+    const QVector3D projected = clip.toVector3DAffine();
+    ndc = QPointF(projected.x(), projected.y());
+    depth = projected.z();
+    return true;
+}
+} // namespace
+
 GCodeView::GCodeView(QSharedPointer<SettingsBase> sb, QSharedPointer<GCodeInfoControl> segmentInfoControl) {
     m_sb = sb;
     m_segment_info_control = segmentInfoControl;
@@ -273,6 +313,30 @@ uint GCodeView::pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeOb
         if (dist < min_dist) {
             min_dist = dist;
             picked_seg = tri.first;
+        }
+    }
+
+    if (picked_seg != 0) {
+        return picked_seg;
+    }
+
+    float min_line_depth = std::numeric_limits<float>::infinity();
+    auto lines = gog->segmentLines();
+    for (auto& line : lines) {
+        QPointF start_ndc;
+        QPointF end_ndc;
+        float start_depth;
+        float end_depth;
+        if (!projectToNdc(this->projectionMatrix(), this->viewMatrix(), line.second.first, start_ndc, start_depth) ||
+            !projectToNdc(this->projectionMatrix(), this->viewMatrix(), line.second.second, end_ndc, end_depth)) {
+            continue;
+        }
+
+        const float distance_squared = distanceSquaredToSegment(mouse_ndc_pos, start_ndc, end_ndc);
+        const float line_depth = std::min(start_depth, end_depth);
+        if (distance_squared <= kLinePickToleranceSquared && line_depth < min_line_depth) {
+            min_line_depth = line_depth;
+            picked_seg = line.first;
         }
     }
 

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -1,8 +1,8 @@
 #include "graphics/view/gcode_view.h"
 
-#include <algorithm>
 #include <cmath>
 #include <limits>
+#include <tuple>
 
 #include <qcontainerfwd.h>
 #include <qlist.h>
@@ -35,7 +35,13 @@ namespace {
 constexpr float kLinePickToleranceSquared = 0.000225f;
 constexpr uint kHoverTrackingSegmentLimit = 10000;
 
-float distanceSquaredToSegment(const QPointF& point, const QPointF& start, const QPointF& end) {
+struct LinePickResult {
+    float distance_squared;
+    float depth;
+};
+
+LinePickResult projectLineHit(const QPointF& point, const QPointF& start, const QPointF& end, float start_depth,
+                              float end_depth) {
     const float dx = end.x() - start.x();
     const float dy = end.y() - start.y();
     const float length_squared = (dx * dx) + (dy * dy);
@@ -43,7 +49,7 @@ float distanceSquaredToSegment(const QPointF& point, const QPointF& start, const
     if (length_squared <= std::numeric_limits<float>::epsilon()) {
         const float point_dx = point.x() - start.x();
         const float point_dy = point.y() - start.y();
-        return (point_dx * point_dx) + (point_dy * point_dy);
+        return {(point_dx * point_dx) + (point_dy * point_dy), start_depth};
     }
 
     float t = ((point.x() - start.x()) * dx + (point.y() - start.y()) * dy) / length_squared;
@@ -53,7 +59,8 @@ float distanceSquaredToSegment(const QPointF& point, const QPointF& start, const
     const float projected_y = start.y() + (t * dy);
     const float point_dx = point.x() - projected_x;
     const float point_dy = point.y() - projected_y;
-    return (point_dx * point_dx) + (point_dy * point_dy);
+    const float depth = start_depth + (t * (end_depth - start_depth));
+    return {(point_dx * point_dx) + (point_dy * point_dy), depth};
 }
 
 bool projectToNdc(const QMatrix4x4& projection, const QMatrix4x4& view, const QVector3D& point, QPointF& ndc,
@@ -312,26 +319,27 @@ void GCodeView::resizeGL(int width, int height) {
 }
 
 uint GCodeView::pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeObject> gog) {
-    float min_dist = Constants::Limits::Maximums::kMaxFloat;
+    float min_triangle_dist = Constants::Limits::Maximums::kMaxFloat;
+    float min_pick_depth = std::numeric_limits<float>::infinity();
     uint picked_seg = 0;
 
     auto tris = gog->segmentTriangles();
 
     for (auto& tri : tris) {
-        float dist = PartPicker::pickDistance(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, tri.second,
-                                              m_state.ortho);
+        const auto pick = PartPicker::pickDistanceAndIntersection(this->projectionMatrix(), this->viewMatrix(),
+                                                                  mouse_ndc_pos, tri.second, m_state.ortho);
+        const float dist = std::get<0>(pick);
 
-        if (dist < min_dist) {
-            min_dist = dist;
+        if (dist < min_triangle_dist) {
+            QPointF ndc;
+            float depth = min_pick_depth;
+            projectToNdc(this->projectionMatrix(), this->viewMatrix(), std::get<1>(pick), ndc, depth);
+            min_triangle_dist = dist;
+            min_pick_depth = depth;
             picked_seg = tri.first;
         }
     }
 
-    if (picked_seg != 0) {
-        return picked_seg;
-    }
-
-    float min_line_depth = std::numeric_limits<float>::infinity();
     auto lines = gog->segmentLines();
     for (auto& line : lines) {
         QPointF start_ndc;
@@ -343,10 +351,9 @@ uint GCodeView::pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeOb
             continue;
         }
 
-        const float distance_squared = distanceSquaredToSegment(mouse_ndc_pos, start_ndc, end_ndc);
-        const float line_depth = std::min(start_depth, end_depth);
-        if (distance_squared <= kLinePickToleranceSquared && line_depth < min_line_depth) {
-            min_line_depth = line_depth;
+        const LinePickResult line_hit = projectLineHit(mouse_ndc_pos, start_ndc, end_ndc, start_depth, end_depth);
+        if (line_hit.distance_squared <= kLinePickToleranceSquared && line_hit.depth < min_pick_depth) {
+            min_pick_depth = line_hit.depth;
             picked_seg = line.first;
         }
     }

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -1,5 +1,6 @@
 #include "threading/gcode_loader.h"
 
+#include <cmath>
 #include <limits>
 #include <tuple>
 
@@ -843,28 +844,26 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
             Point center;
 
             if (parameters.contains('R') && !parameters.contains('I') && !parameters.contains('J')) {
-                Distance R(parameters['R'] * Constants::OpenGL::kObjectToView);
-                Distance H = m_start_pos.distanceToPoint(end_pos) / 2.0;
-                const double center_offset_squared = ((R * R) - (H * H))();
+                const double radius = parameters['R'] * Constants::OpenGL::kObjectToView;
+                const double abs_radius = qAbs(radius);
+                const double dx = end_pos.x() - m_start_pos.x();
+                const double dy = end_pos.y() - m_start_pos.y();
+                const double chord_length = std::hypot(dx, dy);
+                const double half_chord = chord_length / 2.0;
+                const double center_offset_squared = (abs_radius * abs_radius) - (half_chord * half_chord);
 
-                if (center_offset_squared >= 0.0) {
-                    Distance L = qSqrt(center_offset_squared);
+                if (chord_length > std::numeric_limits<double>::epsilon() && center_offset_squared >= 0.0) {
+                    const double center_offset = qSqrt(center_offset_squared);
+                    const double mid_x = (m_start_pos.x() + end_pos.x()) / 2.0;
+                    const double mid_y = (m_start_pos.y() + end_pos.y()) / 2.0;
+                    const double left_normal_x = -dy / chord_length;
+                    const double left_normal_y = dx / chord_length;
+                    const bool use_left_center = (command_id == 3) == (radius >= 0.0);
+                    const double direction = use_left_center ? 1.0 : -1.0;
 
-                    center = m_start_pos;
-                    center.moveTowards(end_pos, H);
-
-                    QVector3D se = end_pos - m_start_pos;
-                    QVector3D perp(se.y(), -se.x(), se.z());
-                    perp.normalize();
-                    perp *= L();
-
-                    if (command_id == 2) {
-                        center += perp;
-                    }
-                    else {
-                        center -= perp;
-                    }
-
+                    center.x(mid_x + (direction * left_normal_x * center_offset));
+                    center.y(mid_y + (direction * left_normal_y * center_offset));
+                    center.z(m_start_pos.z());
                     segment = QSharedPointer<ArcSegment>::create(m_start_pos, end_pos, center, (command_id == 3));
                 }
             }

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -614,6 +614,12 @@ QColor GCodeLoader::determineFontColor(const QString& comment) {
     if (m_leadin.indexIn(comment) != -1) {
         return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kLeadIn);
     }
+    if (m_travel.indexIn(comment) != -1) {
+        return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kTravel);
+    }
+    if (m_support.indexIn(comment) != -1) {
+        return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kSupport);
+    }
     if (m_perimeter.indexIn(comment) != -1) {
         return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kPerimeter);
     }
@@ -635,12 +641,6 @@ QColor GCodeLoader::determineFontColor(const QString& comment) {
     if (m_skeleton.indexIn(comment) != -1) {
         return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kSkeleton);
     }
-    if (m_support.indexIn(comment) != -1) {
-        return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kSupport);
-    }
-    if (m_travel.indexIn(comment) != -1) {
-        return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kTravel);
-    }
     if (m_raft.indexIn(comment) != -1) {
         return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kRaft);
     }
@@ -660,22 +660,22 @@ QColor GCodeLoader::determineFontColor(const QString& comment) {
     return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kUnknown);
 }
 
-void GCodeLoader::setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, const QColor& color,
-                                        const QString& comment, const QVector3D& start_pos, const QVector3D& end_pos,
-                                        const int& line_num, const int& layer_num) {
-    // Determine the display type of the segment
-    SegmentDisplayType type;
+SegmentDisplayType GCodeLoader::determineSegmentDisplayType(const QString& comment) {
+    SegmentDisplayType type = SegmentDisplayType::kNone;
 
-    if (color == PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kTravel)) {
-        type = SegmentDisplayType::kTravel;
+    if (m_travel.indexIn(comment) != -1) {
+        type |= SegmentDisplayType::kTravel;
     }
-    else if (color == PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kSupport)) {
-        type = SegmentDisplayType::kSupport;
-    }
-    else {
-        type = SegmentDisplayType::kLine;
+    if (m_support.indexIn(comment) != -1) {
+        type |= SegmentDisplayType::kSupport;
     }
 
+    return type == SegmentDisplayType::kNone ? SegmentDisplayType::kLine : type;
+}
+
+void GCodeLoader::setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, SegmentDisplayType type,
+                                        const QColor& color, const QString& comment, const QVector3D& start_pos,
+                                        const QVector3D& end_pos, const int& line_num, const int& layer_num) {
     // Set the display info of the segment
     float display_width = 0.0f;
     float display_height = m_sb->setting<float>(PS::Layer::kLayerHeight) * Constants::OpenGL::kObjectToView;
@@ -757,7 +757,8 @@ void GCodeLoader::setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const
 QVector<QSharedPointer<SegmentBase>>
 GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& color, int command_id,
                                    const QMap<char, double>& parameters, bool extruder_on, double extruder_speed,
-                                   bool is_travel, QString comment, const QMap<char, double>& optional_parameters) {
+                                   bool include_non_extruding_moves, QString comment,
+                                   const QMap<char, double>& optional_parameters) {
     // Parameters for drawing and placing each segment in the world correctly
     QVector3D end_pos = m_start_pos;
     QVector3D info_end_pos = m_info_start_pos;
@@ -833,7 +834,7 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
 
     QVector<QSharedPointer<SegmentBase>> generated_segments;
 
-    if (extruder_on || is_travel) {
+    if (extruder_on || include_non_extruding_moves) {
         QSharedPointer<SegmentBase> segment;
 
         // Builds and draws segments according to their type (Line, Arc, Spline)
@@ -844,24 +845,28 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
             if (parameters.contains('R') && !parameters.contains('I') && !parameters.contains('J')) {
                 Distance R(parameters['R'] * Constants::OpenGL::kObjectToView);
                 Distance H = m_start_pos.distanceToPoint(end_pos) / 2.0;
-                Distance L = qSqrt(((R * R) - (H * H))());
+                const double center_offset_squared = ((R * R) - (H * H))();
 
-                center = m_start_pos;
-                center.moveTowards(end_pos, H);
+                if (center_offset_squared >= 0.0) {
+                    Distance L = qSqrt(center_offset_squared);
 
-                QVector3D se = end_pos - m_start_pos;
-                QVector3D perp(se.y(), -se.x(), se.z());
-                perp.normalize();
-                perp *= L();
+                    center = m_start_pos;
+                    center.moveTowards(end_pos, H);
 
-                if (command_id == 2) {
-                    center += perp;
+                    QVector3D se = end_pos - m_start_pos;
+                    QVector3D perp(se.y(), -se.x(), se.z());
+                    perp.normalize();
+                    perp *= L();
+
+                    if (command_id == 2) {
+                        center += perp;
+                    }
+                    else {
+                        center -= perp;
+                    }
+
+                    segment = QSharedPointer<ArcSegment>::create(m_start_pos, end_pos, center, (command_id == 3));
                 }
-                else {
-                    center -= perp;
-                }
-
-                segment = QSharedPointer<ArcSegment>::create(m_start_pos, end_pos, center, (command_id == 3));
             }
             else if (parameters.contains('I') && parameters.contains('J')) {
                 // Determine center from I, J
@@ -896,8 +901,13 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
             segment = QSharedPointer<LineSegment>::create(m_start_pos, end_pos);
         }
 
+        if (segment.isNull()) {
+            segment = QSharedPointer<LineSegment>::create(m_start_pos, end_pos);
+        }
+
         // Set the segment's display info
-        setSegmentDisplayInfo(segment, color, comment, m_start_pos, end_pos, line_num, layer_num);
+        setSegmentDisplayInfo(segment, determineSegmentDisplayType(comment), color, comment, m_start_pos, end_pos,
+                              line_num, layer_num);
 
         // Set the segment's meta info
         setSegmentMetaInfo(segment, comment, info_end_pos, extruder_on, info_speed_set, extruder_speed);

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -757,8 +757,7 @@ void GCodeLoader::setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const
 QVector<QSharedPointer<SegmentBase>>
 GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& color, int command_id,
                                    const QMap<char, double>& parameters, bool extruder_on, double extruder_speed,
-                                   bool is_travel,
-                                   QString comment, const QMap<char, double>& optional_parameters) {
+                                   bool is_travel, QString comment, const QMap<char, double>& optional_parameters) {
     // Parameters for drawing and placing each segment in the world correctly
     QVector3D end_pos = m_start_pos;
     QVector3D info_end_pos = m_info_start_pos;
@@ -837,75 +836,74 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
     if (extruder_on || is_travel) {
         QSharedPointer<SegmentBase> segment;
 
-            // Builds and draws segments according to their type (Line, Arc, Spline)
-            if (command_id == 2 || command_id == 3) { // G2 clockwise arc & G3 counter-clockwise arc
-                // Parse extra params
-                Point center;
+        // Builds and draws segments according to their type (Line, Arc, Spline)
+        if (command_id == 2 || command_id == 3) { // G2 clockwise arc & G3 counter-clockwise arc
+            // Parse extra params
+            Point center;
 
-                if (parameters.contains('R') && !parameters.contains('I') && !parameters.contains('J')) {
-                    Distance R(parameters['R'] * Constants::OpenGL::kObjectToView);
-                    Distance H = m_start_pos.distanceToPoint(end_pos) / 2.0;
-                    Distance L = qSqrt(((R * R) - (H * H))());
+            if (parameters.contains('R') && !parameters.contains('I') && !parameters.contains('J')) {
+                Distance R(parameters['R'] * Constants::OpenGL::kObjectToView);
+                Distance H = m_start_pos.distanceToPoint(end_pos) / 2.0;
+                Distance L = qSqrt(((R * R) - (H * H))());
 
-                    center = m_start_pos;
-                    center.moveTowards(end_pos, H);
+                center = m_start_pos;
+                center.moveTowards(end_pos, H);
 
-                    QVector3D se = end_pos - m_start_pos;
-                    QVector3D perp(se.y(), -se.x(), se.z());
-                    perp.normalize();
-                    perp *= L();
+                QVector3D se = end_pos - m_start_pos;
+                QVector3D perp(se.y(), -se.x(), se.z());
+                perp.normalize();
+                perp *= L();
 
-                    if (command_id == 2) {
-                        center += perp;
-                    }
-                    else {
-                        center -= perp;
-                    }
-
-                    segment = QSharedPointer<ArcSegment>::create(m_start_pos, end_pos, center, (command_id == 3));
+                if (command_id == 2) {
+                    center += perp;
                 }
-                else if (parameters.contains('I') && parameters.contains('J')) {
-                    // Determine center from I, J
-                    center.x(m_start_pos.x() + ((parameters['I']) * Constants::OpenGL::kObjectToView));
-                    center.y(m_start_pos.y() + ((parameters['J']) * Constants::OpenGL::kObjectToView));
-
-                    if (parameters.contains('K')) {
-                        center.z(m_start_pos.z() + ((parameters['K']) * Constants::OpenGL::kObjectToView));
-                    }
-                    else {
-                        center.z(m_start_pos.z());
-                    }
-
-                    segment = QSharedPointer<ArcSegment>::create(m_start_pos, end_pos, center, (command_id == 3));
+                else {
+                    center -= perp;
                 }
+
+                segment = QSharedPointer<ArcSegment>::create(m_start_pos, end_pos, center, (command_id == 3));
             }
-            else if (command_id == 5) { // G5 splines
-                Point control_a;
-                Point control_b;
+            else if (parameters.contains('I') && parameters.contains('J')) {
+                // Determine center from I, J
+                center.x(m_start_pos.x() + ((parameters['I']) * Constants::OpenGL::kObjectToView));
+                center.y(m_start_pos.y() + ((parameters['J']) * Constants::OpenGL::kObjectToView));
 
-                if (parameters.contains('I') && parameters.contains('J') && parameters.contains('P') &&
-                    parameters.contains('Q')) {
-                    control_a.x(m_start_pos.x() + ((parameters['I']) * Constants::OpenGL::kObjectToView));
-                    control_a.y(m_start_pos.y() + ((parameters['J']) * Constants::OpenGL::kObjectToView));
-                    control_b.x(end_pos.x() + ((parameters['P']) * Constants::OpenGL::kObjectToView));
-                    control_b.y(end_pos.y() + ((parameters['Q']) * Constants::OpenGL::kObjectToView));
-
-                    segment = QSharedPointer<BezierSegment>::create(m_start_pos, control_a, control_b, end_pos);
+                if (parameters.contains('K')) {
+                    center.z(m_start_pos.z() + ((parameters['K']) * Constants::OpenGL::kObjectToView));
                 }
-            }
-            else { // G0, G1, or anything else is drawn as a line
-                // Create line segment
-                segment = QSharedPointer<LineSegment>::create(m_start_pos, end_pos - m_start_pos);
-            }
+                else {
+                    center.z(m_start_pos.z());
+                }
 
-            // Set the segment's display info
-            setSegmentDisplayInfo(segment, color, comment, m_start_pos, end_pos, line_num, layer_num);
+                segment = QSharedPointer<ArcSegment>::create(m_start_pos, end_pos, center, (command_id == 3));
+            }
+        }
+        else if (command_id == 5) { // G5 splines
+            Point control_a;
+            Point control_b;
 
-            // Set the segment's meta info
+            if (parameters.contains('I') && parameters.contains('J') && parameters.contains('P') &&
+                parameters.contains('Q')) {
+                control_a.x(m_start_pos.x() + ((parameters['I']) * Constants::OpenGL::kObjectToView));
+                control_a.y(m_start_pos.y() + ((parameters['J']) * Constants::OpenGL::kObjectToView));
+                control_b.x(end_pos.x() + ((parameters['P']) * Constants::OpenGL::kObjectToView));
+                control_b.y(end_pos.y() + ((parameters['Q']) * Constants::OpenGL::kObjectToView));
+
+                segment = QSharedPointer<BezierSegment>::create(m_start_pos, control_a, control_b, end_pos);
+            }
+        }
+        else { // G0, G1, or anything else is drawn as a line
+            segment = QSharedPointer<LineSegment>::create(m_start_pos, end_pos);
+        }
+
+        // Set the segment's display info
+        setSegmentDisplayInfo(segment, color, comment, m_start_pos, end_pos, line_num, layer_num);
+
+        // Set the segment's meta info
         setSegmentMetaInfo(segment, comment, info_end_pos, extruder_on, info_speed_set, extruder_speed);
 
-            // Add the segment to the list of generated segments
-            generated_segments.append(segment);
+        // Add the segment to the list of generated segments
+        generated_segments.append(segment);
     }
     // Update our start position for the next command
     m_start_pos = end_pos;

--- a/src/threading/slicers/polymer_slicer.cpp
+++ b/src/threading/slicers/polymer_slicer.cpp
@@ -540,7 +540,8 @@ void PolymerSlicer::postProcess(nlohmann::json opt_data) {
             m_global_layers[g_layer_num]->reorient();
 
             // update status in UI
-            emit statusUpdate(StatusUpdateStepType::kPostProcess, (g_layer_num + 1) / max_layers * 100);
+            emit statusUpdate(StatusUpdateStepType::kPostProcess,
+                              qRound(static_cast<double>(g_layer_num + 1) / static_cast<double>(max_layers) * 100.0));
         }
     }
     else {


### PR DESCRIPTION
## Summary

This PR refactors the graphics shape generation utilities and improves G-code visualization performance, correctness, and usability.

The ShapeFactory changes make generated geometry APIs more explicit, reduce unnecessary work while appending mesh data, and clarify bead-generation behavior. The G-code visualization changes decouple travel/support semantics from display colors, render travel moves as lightweight line geometry, and now automatically fall back to lightweight line rendering when generated bead meshes would be too large for interactive loading.

## ShapeFactory Changes

- Renamed geometry factory APIs from `create*` to `append*` to reflect that they append vertex/color/normal data into caller-owned buffers.
- Reorganized `shape_factory.h` into clearer groups for closed triangle meshes, toolpath bead meshes, and line geometry.
- Replaced the misleading G-code cylinder naming with `appendLinearBead`, since the function generates squished bead geometry rather than a true cylinder.
- Updated Doxygen documentation and switched ShapeFactory header comments to `@` syntax.
- Simplified arc bead generation by using one direction-aware arc bead path instead of separate clockwise/counterclockwise wrappers.
- Added configurable linear bead side resolution through `quads_per_side`, defaulting to `4`.
- Preserved the rectangular-prism fallback when bead height exceeds width.

## Travel Visualization Changes

- Classifies travel/support display behavior semantically from G-code comments instead of inferring type from `QColor` equality.
- Gives `TRAVEL` matching precedence so mixed comments classify correctly for visibility behavior.
- Renamed `is_travel` to `include_non_extruding_moves`, matching what the parameter actually controls.
- Added fallback handling for unsupported or malformed visual arc/spline commands.
- Renders travel segments as lightweight `GL_LINES` instead of full bead meshes.
- Keeps the existing all-lines fallback for very large G-code files.
- Adds a secondary travel-line buffer while preserving selection/highlight color updates.
- Adds line-based picking support so travel lines remain selectable after switching away from bead triangles.

## Large G-code Visualization Fix

- Estimates full bead-mesh vertex count before building the final `GCodeObject`.
- Uses lightweight line rendering when the estimated true-width bead mesh would exceed the interactive threshold, even if the logical segment count is below the previous one-million-segment cutoff.
- Prevents large projects, such as the 1852 Grid A perimeter project, from reaching 100% visualization progress and then appearing to hang while the GUI thread allocates and uploads very large bead-mesh buffers.
- Reduces duplicate G-code parsing progress updates so large files do not flood the UI/event queue with repeated percentages.
- Fixes polymer post-processing progress math so the post-process bar advances normally instead of staying at 0% until completion.

## Why

Travel moves do not represent deposited material, but the previous visualization rendered them through the same bead mesh path used for printed segments. That made travel moves more expensive than necessary and visually implied physical bead geometry.

The previous classification path also tied visibility behavior to configured colors, which made travel/support hiding fragile when comments or color preferences changed.

ShapeFactory had related naming and documentation issues: several APIs were named like they created standalone objects, while they actually append buffer data, and the old G-code cylinder naming did not describe the bead geometry it generated.

The large-project hang had a separate cause: the fallback to lightweight visualization only considered logical segment count. A project with roughly 298k visualization motions could still expand into tens of millions of bead-mesh vertices, blocking the GUI after the loader reported visualization at 100%.

## Validation

- Built successfully with `cmake --build build/generic-llvm-ninja --config Debug --target ornlslicer`.
- Re-sliced `/home/fnx/Downloads/1852-Grid A_Perimeter V02 Rev 1.s2p` through console mode with a fresh `/tmp` app-data path.
- Verified the generated G-code was about 10.7 MB with 303,848 lines and completed through G-code parsing and visualization.
- Verified G-code parsing progress now emits one update per percentage point instead of repeated duplicate percentages.
- Verified `git diff --check` passed.
