### PR TITLE
Use theme-aware slice progress colors

### DIFF
--- a/src/windows/dialogs/slice_dialog.cpp
+++ b/src/windows/dialogs/slice_dialog.cpp
@@ -1,8 +1,10 @@
 #include "windows/dialogs/slice_dialog.h"
 
 #include <QApplication>
+#include <QColor>
 #include <QGridLayout>
 #include <QLabel>
+#include <QPalette>
 #include <QPushButton>
 #include <qdialog.h>
 #include <qfont.h>
@@ -11,9 +13,22 @@
 #include <qtmetamacros.h>
 #include <qwidget.h>
 
+#include "managers/preferences_manager.h"
+#include "utilities/constants.h"
 #include "utilities/enums.h"
 
+namespace {
+
+QColor progressBarFillColor() {
+    return ORNL::PreferencesManager::getInstance()->getThemeText() == ORNL::Constants::UI::Themes::kDarkMode
+               ? QColor(132, 196, 70)
+               : QColor(0, 102, 44);
+}
+
+} // namespace
+
 namespace ORNL {
+
 SliceDialog::SliceDialog(QWidget* parent) : QDialog(parent) { this->setupUi(); }
 
 void SliceDialog::setupUi() {
@@ -29,11 +44,17 @@ void SliceDialog::setupUi() {
     layout->addWidget(stages, 0, 0, 1, 3, Qt::AlignCenter);
 
     // currently 6 step types
+    QColor fill_color = progressBarFillColor();
     for (int i = 0; i < 6; ++i) {
         QProgressBar* bar = new QProgressBar(this);
         bar->setMinimum(0);
         bar->setMaximum(100);
         bar->setMinimumWidth(300);
+        QPalette palette = bar->palette();
+        palette.setColor(QPalette::Active, QPalette::Highlight, fill_color);
+        palette.setColor(QPalette::Inactive, QPalette::Highlight, fill_color);
+        palette.setColor(QPalette::Disabled, QPalette::Highlight, fill_color);
+        bar->setPalette(palette);
 
         m_progress_bars.push_back(bar);
         layout->addWidget(new QLabel(toString(static_cast<StatusUpdateStepType>(i))), i + 2, 0);
@@ -50,4 +71,5 @@ void SliceDialog::setupUi() {
 void SliceDialog::updateStatus(StatusUpdateStepType type, int percentage) {
     m_progress_bars[(int)type]->setValue(percentage);
 }
+
 } // namespace ORNL


### PR DESCRIPTION
## Summary

Updates the slice progress dialog so its progress bars use a fixed fill color based on the selected app theme.

- Uses `#84C446` when Dark Mode is enabled.
- Uses `#00662C` for non-dark mode. This is the official color for ORNL Green.
- Applies the color through `QPalette::Highlight` instead of a progress-bar stylesheet so the native rounded progress-bar shape is preserved.

## User Impact

Slice progress bars no longer inherit unpredictable system theme accent colors, while retaining the existing progress-bar shape and sizing.

## Validation

- `git diff --check`
- `nix develop --command ninja -C build/generic-llvm-ninja CMakeFiles/ornlslicer_obj.dir/Debug/src/windows/dialogs/slice_dialog.cpp.o`