### PR TITLE
feat: import STEP files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ function(FindDependencies)
     find_package(Boost         REQUIRED COMPONENTS system)
     find_package(CGAL          REQUIRED)
     find_package(nlohmann_json REQUIRED)
+    find_package(OpenCASCADE REQUIRED)
     find_package(VTK           REQUIRED)
     find_package(Eigen3        REQUIRED NO_MODULE)
     find_package(zip           REQUIRED)
@@ -98,6 +99,7 @@ function(FindDependencies)
         Eigen3::Eigen
         CGAL::Eigen3_support
         nlohmann_json::nlohmann_json
+        ${OpenCASCADE_LIBRARIES}
         ornl::psimpl
         ornl::polyclipping
         zip::zip
@@ -105,11 +107,29 @@ function(FindDependencies)
         ${OPTIONAL_PACKAGES}
     )
 
+    set(RESULT_INCLUDE_DIRS "")
+    if(OpenCASCADE_INCLUDE_DIRS)
+        list(APPEND RESULT_INCLUDE_DIRS ${OpenCASCADE_INCLUDE_DIRS})
+    elseif(OpenCASCADE_INCLUDE_DIR)
+        list(APPEND RESULT_INCLUDE_DIRS ${OpenCASCADE_INCLUDE_DIR})
+    endif()
+
+    set(RESULT_LIBRARY_DIRS "")
+    if(OpenCASCADE_LIBRARY_DIRS)
+        list(APPEND RESULT_LIBRARY_DIRS ${OpenCASCADE_LIBRARY_DIRS})
+    elseif(OpenCASCADE_LIBRARY_DIR)
+        list(APPEND RESULT_LIBRARY_DIRS ${OpenCASCADE_LIBRARY_DIR})
+    endif()
+
     set(RESULT_VAR ${RESULT_VAR} PARENT_SCOPE)
+    set(RESULT_INCLUDE_DIRS ${RESULT_INCLUDE_DIRS} PARENT_SCOPE)
+    set(RESULT_LIBRARY_DIRS ${RESULT_LIBRARY_DIRS} PARENT_SCOPE)
 endfunction()
 
 FindDependencies()
 set(ORNLSLICER_DEPS ${RESULT_VAR})
+set(ORNLSLICER_INCLUDE_DIRS ${RESULT_INCLUDE_DIRS})
+set(ORNLSLICER_LIBRARY_DIRS ${RESULT_LIBRARY_DIRS})
 
 # Find all project files.
 file(GLOB_RECURSE SOURCES "src/**.cpp")
@@ -117,7 +137,12 @@ file(GLOB_RECURSE HEADERS "include/**.h")
 file(GLOB_RECURSE RESOURCES "resources/**.qrc")
 
 add_library(${PROJECT_NAME}_obj OBJECT)
-target_include_directories(${PROJECT_NAME}_obj PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated/include)
+target_include_directories(
+    ${PROJECT_NAME}_obj
+    PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+        ${ORNLSLICER_INCLUDE_DIRS}
+)
 target_sources(
     ${PROJECT_NAME}_obj
     PRIVATE ${SOURCES} ${RESOURCES}
@@ -126,6 +151,9 @@ target_sources(
     FILES ${HEADERS}
 )
 
+if(ORNLSLICER_LIBRARY_DIRS)
+    target_link_directories(${PROJECT_NAME}_obj PRIVATE ${ORNLSLICER_LIBRARY_DIRS})
+endif()
 target_link_libraries(${PROJECT_NAME}_obj ${ORNLSLICER_DEPS})
 target_compile_options(${PROJECT_NAME}_obj PRIVATE $<$<COMPILE_LANGUAGE:CXX>: -fpermissive -Wno-deprecated-declarations>)
 

--- a/include/console/command_line_processor.h
+++ b/include/console/command_line_processor.h
@@ -56,6 +56,10 @@ class CommandLineConverter {
     //! \param suffix: necessary file extension
     bool isValid(QString path, QString suffix);
 
+    //! \brief Check if file path is valid and has a supported model extension
+    //! \param path: path of file
+    bool isValidModelFile(QString path);
+
     //! \brief Copy of master json for access to individual settings
     QSharedPointer<SettingsBase> m_master;
 };

--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -3,7 +3,13 @@
 {
   overlays = [(
     finalPkgs: prevPkgs: {
-      # NOP
+      opencascade-occt = prevPkgs.opencascade-occt.overrideAttrs (old: {
+        propagatedBuildInputs =
+          if finalPkgs.stdenv.hostPlatform.isMinGW then [
+            finalPkgs.freetype
+            finalPkgs.fontconfig
+          ] else old.propagatedBuildInputs;
+      });
     }
   )];
 

--- a/nix/ornlslicer/default.nix
+++ b/nix/ornlslicer/default.nix
@@ -5,7 +5,7 @@
 
   cmake, pkg-config, ninja, wrapQtAppsHook, deployQtWinPluginsHook,
 
-  qtbase, qtcharts, qt5compat, assimp, boost184, cgal_5, eigen, nlohmann_json, gmp, mpfr,
+  qtbase, qtcharts, qt5compat, assimp, boost184, cgal_5, eigen, nlohmann_json, opencascade-occt, gmp, mpfr,
   hdf5, vtk-qt, kuba-zip, clipper, psimpl
 }:
 
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     cgal_5
     eigen
     nlohmann_json
+    opencascade-occt
     hdf5
     vtk-qt
     kuba-zip

--- a/src/console/command_line_processor.cpp
+++ b/src/console/command_line_processor.cpp
@@ -17,6 +17,18 @@
 #include "utilities/constants.h"
 
 namespace ORNL {
+namespace {
+const QStringList kModelSuffixes = {"stl", "3mf", "obj", "amf", "step", "stp"};
+
+QStringList modelNameFilters() {
+    QStringList filters;
+    for (const QString& suffix : kModelSuffixes) {
+        filters << "*." + suffix;
+        filters << "*." + suffix.toUpper();
+    }
+    return filters;
+}
+} // namespace
 
 CommandLineConverter::CommandLineConverter() {
     m_master = QSharedPointer<SettingsBase>::create();
@@ -36,31 +48,33 @@ void CommandLineConverter::setupCommandLineParser(QCommandLineParser& parser) {
     parser.addOption({Constants::ConsoleOptionStrings::kInputProjectFile,
                       "Run ORNLSlicer using project file at <directory>.", "directory", ""});
     parser.addOption({Constants::ConsoleOptionStrings::kInputStlFiles,
-                      "List of STLs to load for slicing. Parameter can be specified multiple times.", "file-list", ""});
+                      "List of model files to load for slicing. Parameter can be specified multiple times.",
+                      "file-list", ""});
     parser.addOption({Constants::ConsoleOptionStrings::kInputSupportStlFiles,
-                      "List of support STLs to load for slicing. Parameter can be specified multiple times.",
+                      "List of support model files to load for slicing. Parameter can be specified multiple times.",
                       "file-list", ""});
     parser.addOption({Constants::ConsoleOptionStrings::kInputStlFilesDirectory,
-                      "Loads all STLs for slicing at <directory>. Equivalent to listing the files individually using "
+                      "Loads all supported model files for slicing at <directory>. Equivalent to listing the files "
+                      "individually using "
                       "--input_stl_files.",
                       "directory", ""});
     parser.addOption({Constants::ConsoleOptionStrings::kInputSupportStlFilesDirectory,
-                      "Loads all STLs as supports for slicing at <directory>. Equivalent to listing the support files "
-                      "individual using --input_support_stl_files.",
+                      "Loads all supported model files as supports for slicing at <directory>. Equivalent to listing "
+                      "the support files individually using --input_support_stl_files.",
                       "directory", ""});
 
     parser.addOption({Constants::ConsoleOptionStrings::kInputGlobalSettings,
                       "Valid settings file to extract global settings from.", "file", ""});
     parser.addOption(
-        {Constants::ConsoleOptionStrings::kInputSTLTransform, "File containing stl transforms.", "file", ""});
+        {Constants::ConsoleOptionStrings::kInputSTLTransform, "File containing model transforms.", "file", ""});
     parser.addOption(
         {Constants::ConsoleOptionStrings::kOutputLocation, "File to write out Gcode to.", "directory", ""});
 
     // preference option
     parser.addOption({Constants::ConsoleOptionStrings::kShiftPartsOnLoad,
-                      "Specifies whether or not to shift STLs after load. Default is true.", "bool", "true"});
+                      "Specifies whether or not to shift models after load. Default is true.", "bool", "true"});
     parser.addOption({Constants::ConsoleOptionStrings::kAlignParts,
-                      "Specifies whether or not to align/center STLs after load.  Default is true.", "bool", "true"});
+                      "Specifies whether or not to align/center models after load.  Default is true.", "bool", "true"});
     parser.addOption(
         {Constants::ConsoleOptionStrings::kUseImplicitTransforms,
          "Specifies whether or not to use implicit transforms.  Default is false. Typically used in conjunction with "
@@ -103,12 +117,12 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
         return false;
     }
 
-    // either both or neither stls/project file were specified.  Must have one or the other.
+    // Either a model list, model directory, or project file must be specified.
     if (parser.isSet(Constants::ConsoleOptionStrings::kInputStlFiles) +
             parser.isSet(Constants::ConsoleOptionStrings::kInputProjectFile) +
             parser.isSet(Constants::ConsoleOptionStrings::kInputStlFilesDirectory) !=
         1) {
-        qInfo() << "Either stls, an stl directory, or a project file must be specified as input";
+        qInfo() << "Either model files, a model directory, or a project file must be specified as input";
         return false;
     }
 
@@ -123,7 +137,7 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
     if (parser.isSet(Constants::ConsoleOptionStrings::kInputStlFiles)) {
         QStringList stlList = parser.values(Constants::ConsoleOptionStrings::kInputStlFiles);
         for (int i = 0, end = stlList.size(); i < end; ++i) {
-            validSTL = isValid(stlList[i], "stl");
+            validSTL = isValidModelFile(stlList[i]);
             if (!validSTL)
                 return false;
 
@@ -137,7 +151,7 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
     bool validSTLDirectory = false;
     if (parser.isSet(Constants::ConsoleOptionStrings::kInputStlFilesDirectory)) {
         QDir dir(parser.value(Constants::ConsoleOptionStrings::kInputStlFilesDirectory));
-        QStringList names = dir.entryList(QStringList() << "*.stl");
+        QStringList names = dir.entryList(modelNameFilters());
         if (names.size() == 0)
             return false;
 
@@ -150,7 +164,7 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
     }
 
     if (!validProject && !validSTL && !validSTLDirectory) {
-        qInfo() << "No valid stl file, directory, or project was specified";
+        qInfo() << "No valid model file, directory, or project was specified";
         return false;
     }
 
@@ -172,7 +186,7 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
 
     if (parser.isSet(Constants::ConsoleOptionStrings::kInputSTLTransform)) {
         if (!parser.isSet(Constants::ConsoleOptionStrings::kInputStlFiles)) {
-            qInfo() << "No stls specified for transform application";
+            qInfo() << "No models specified for transform application";
             return false;
         }
         options->setSetting<QString>(Constants::ConsoleOptionStrings::kInputSTLTransform,
@@ -190,17 +204,17 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
         return false;
     }
 
-    // optional STLs
+    // optional support models
     if (parser.isSet(Constants::ConsoleOptionStrings::kInputSupportStlFiles) &&
         parser.isSet(Constants::ConsoleOptionStrings::kInputSupportStlFilesDirectory)) {
-        qInfo() << "Either support stls or a directory can be specified, not both";
+        qInfo() << "Either support models or a directory can be specified, not both";
         return false;
     }
 
     if (parser.isSet(Constants::ConsoleOptionStrings::kInputSupportStlFiles)) {
         QStringList stlList = parser.values(Constants::ConsoleOptionStrings::kInputSupportStlFiles);
         for (int i = 0, end = stlList.size(); i < end; ++i) {
-            validSTL = isValid(stlList[i], "stl");
+            validSTL = isValidModelFile(stlList[i]);
             if (!validSTL)
                 return false;
 
@@ -214,10 +228,10 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
 
     if (parser.isSet(Constants::ConsoleOptionStrings::kInputSupportStlFilesDirectory)) {
         QDir dir(parser.value(Constants::ConsoleOptionStrings::kInputSupportStlFilesDirectory));
-        QStringList names = dir.entryList(QStringList() << "*.stl");
+        QStringList names = dir.entryList(modelNameFilters());
         if (names.size() == 0) {
             options->setSetting(Constants::ConsoleOptionStrings::kInputSupportStlCount, 0);
-            qInfo() << "No support stls found in specified directory";
+            qInfo() << "No support model files found in specified directory";
         }
         else {
             for (int i = 0; i < names.size(); ++i)
@@ -360,6 +374,22 @@ bool CommandLineConverter::isValid(QString path, QString suffix) {
         qInfo() << "Input: " + path + " does not have an " + suffix + " extension";
         return false;
     }
+    return true;
+}
+
+bool CommandLineConverter::isValidModelFile(QString path) {
+    QFileInfo info(path);
+    if (!info.exists()) {
+        qInfo() << "Input: " + path + " does not exist";
+        return false;
+    }
+
+    const QString suffix = info.suffix().toLower();
+    if (!kModelSuffixes.contains(suffix)) {
+        qInfo() << "Input: " + path + " does not have a supported model extension";
+        return false;
+    }
+
     return true;
 }
 } // namespace ORNL

--- a/src/managers/session_manager.cpp
+++ b/src/managers/session_manager.cpp
@@ -281,7 +281,7 @@ void SessionManager::reloadPart(QSharedPointer<PartMetaItem> pm) {
         m_models[file_info.fileName()] = {mesh_data.raw_data, mesh_data.size};
 
         emit partReloaded(pm);
-        emit forwardStatusUpdate("Reloaded Part STL, file \"" + file_info.fileName() + "\"");
+        emit forwardStatusUpdate("Reloaded part model, file \"" + file_info.fileName() + "\"");
     });
     loader->start();
 }
@@ -309,7 +309,7 @@ void SessionManager::replacePart(QSharedPointer<PartMetaItem> pm, QString filena
         m_models[file_info.fileName()] = {mesh_data.raw_data, mesh_data.size};
 
         emit partReloaded(pm);
-        emit forwardStatusUpdate("Reloaded Part STL, file \"" + file_info.fileName() + "\"");
+        emit forwardStatusUpdate("Reloaded part model, file \"" + file_info.fileName() + "\"");
     });
     loader->start();
 }

--- a/src/threading/mesh_loader.cpp
+++ b/src/threading/mesh_loader.cpp
@@ -1,19 +1,40 @@
 #include "threading/mesh_loader.h"
 
+#include <array>
+#include <cmath>
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
+#include <map>
+#include <tuple>
 #include <utility>
 
+#include <BRepMesh_IncrementalMesh.hxx>
+#include <BRep_Tool.hxx>
+#include <CGAL/boost/graph/copy_face_graph.h>
+#include <CGAL/boost/graph/helpers.h>
 #include <CGAL/exceptions.h>
+#include <IFSelect_ReturnStatus.hxx>
+#include <Interface_Static.hxx>
+#include <Poly_Triangle.hxx>
+#include <Poly_Triangulation.hxx>
 #include <QLinkedList>
 #include <QStack>
+#include <QTemporaryFile>
 #include <QtDebug>
+#include <STEPControl_Reader.hxx>
+#include <TopAbs_Orientation.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopLoc_Location.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
 #include <assimp/Importer.hpp>
 #include <assimp/mesh.h>
 #include <assimp/postprocess.h>
 #include <qcontainerfwd.h>
+#include <qdir.h>
 #include <qfileinfo.h>
 #include <qmap.h>
 #include <qmatrix4x4.h>
@@ -33,6 +54,165 @@
 #include "utilities/enums.h"
 
 namespace ORNL {
+namespace {
+constexpr double kStepLinearDeflectionMm = 0.1;
+constexpr double kStepAngularDeflectionRadians = 0.1;
+
+bool isStepFile(const QString& suffix) {
+    return suffix.compare("step", Qt::CaseInsensitive) == 0 || suffix.compare("stp", Qt::CaseInsensitive) == 0;
+}
+
+void applyInitialTransform(const QSharedPointer<MeshBase>& mesh, QMatrix4x4 transform, Distance unit) {
+    auto center = mesh->originalCentroid();
+    mesh->center();
+
+    if (transform.isIdentity()) {
+        Distance conv(unit);
+        conv = conv.to(mm);
+        transform.scale(QVector3D(conv(), conv(), conv()));
+        mesh->setUnit(unit);
+
+        if (PreferencesManager::getInstance()->getUseImplicitTransforms())
+            transform.translate(center.toQVector3D());
+    }
+
+    mesh->setTransformation(transform);
+}
+
+MeshTypes::SurfaceMesh buildSurfaceMeshFromStep(const QString& file_path) {
+    MeshTypes::SurfaceMesh surface_mesh;
+
+    Interface_Static::SetCVal("xstep.cascade.unit", "MM");
+
+    STEPControl_Reader reader;
+    const QByteArray file_path_data = file_path.toUtf8();
+    if (reader.ReadFile(file_path_data.constData()) != IFSelect_RetDone)
+        return surface_mesh;
+
+    if (reader.TransferRoots() == 0)
+        return surface_mesh;
+
+    TopoDS_Shape shape = reader.OneShape();
+    if (shape.IsNull())
+        return surface_mesh;
+
+    BRepMesh_IncrementalMesh mesher(shape, kStepLinearDeflectionMm, false, kStepAngularDeflectionRadians, true);
+    mesher.Perform();
+    if (!mesher.IsDone())
+        return surface_mesh;
+
+    using VertexIndex = MeshTypes::SurfaceMesh::Vertex_index;
+    std::map<std::tuple<long long, long long, long long>, VertexIndex> vertex_lookup;
+
+    auto add_vertex = [&surface_mesh, &vertex_lookup](const gp_Pnt& point) {
+        const long long x = std::llround(point.X() * 1000.0);
+        const long long y = std::llround(point.Y() * 1000.0);
+        const long long z = std::llround(point.Z() * 1000.0);
+        const auto key = std::make_tuple(x, y, z);
+
+        auto existing = vertex_lookup.find(key);
+        if (existing != vertex_lookup.end())
+            return existing->second;
+
+        const VertexIndex index = surface_mesh.add_vertex(MeshTypes::Point_3(x, y, z));
+        vertex_lookup[key] = index;
+        return index;
+    };
+
+    for (TopExp_Explorer explorer(shape, TopAbs_FACE); explorer.More(); explorer.Next()) {
+        TopoDS_Face face = TopoDS::Face(explorer.Current());
+
+        TopLoc_Location location;
+        Handle(Poly_Triangulation) triangulation = BRep_Tool::Triangulation(face, location);
+        if (triangulation.IsNull())
+            continue;
+
+        const gp_Trsf& transform = location.Transformation();
+        for (int triangle_index = 1; triangle_index <= triangulation->NbTriangles(); ++triangle_index) {
+            Standard_Integer n1;
+            Standard_Integer n2;
+            Standard_Integer n3;
+            triangulation->Triangle(triangle_index).Get(n1, n2, n3);
+
+            std::array<Standard_Integer, 3> node_ids = {n1, n2, n3};
+            if (face.Orientation() == TopAbs_REVERSED)
+                std::swap(node_ids[1], node_ids[2]);
+
+            std::array<VertexIndex, 3> indices;
+            for (int i = 0; i < 3; ++i) {
+                gp_Pnt point = triangulation->Node(node_ids[i]);
+                point.Transform(transform);
+                indices[i] = add_vertex(point);
+            }
+
+            if (indices[0] == indices[1] || indices[1] == indices[2] || indices[2] == indices[0])
+                continue;
+
+            auto face_index = surface_mesh.add_face(indices[0], indices[1], indices[2]);
+            if (face_index == MeshTypes::SurfaceMesh::null_face())
+                surface_mesh.add_face(indices[0], indices[2], indices[1]);
+        }
+    }
+
+    return surface_mesh;
+}
+
+QSharedPointer<MeshBase> buildMeshFromStepSurfaceMesh(MeshTypes::SurfaceMesh& surface_mesh, const QFileInfo& file_info,
+                                                      MeshType mesh_type) {
+    if (surface_mesh.number_of_faces() == 0 || surface_mesh.number_of_vertices() == 0)
+        return nullptr;
+
+    QSharedPointer<MeshBase> mesh;
+    if (CGAL::is_closed(surface_mesh)) {
+        MeshTypes::Polyhedron polyhedron;
+        CGAL::copy_face_graph(surface_mesh, polyhedron);
+
+        if (GSM->getGlobal()->setting<bool>(PS::SpecialModes::kEnableFixModel))
+            ClosedMesh::CleanPolyhedron(polyhedron);
+
+        if (polyhedron.is_closed())
+            mesh = QSharedPointer<ClosedMesh>::create(polyhedron, file_info.baseName(), file_info.fileName());
+    }
+
+    if (mesh.isNull())
+        mesh = QSharedPointer<OpenMesh>::create(surface_mesh, file_info.baseName(), file_info.fileName());
+
+    mesh->setType(mesh_type);
+    return mesh;
+}
+
+QVector<MeshLoader::MeshData> loadStepMeshes(const QFileInfo& file_info, MeshType mesh_type, QMatrix4x4 transform,
+                                             Distance unit, std::pair<void*, size_t> file_data, bool read_from_memory) {
+    QVector<MeshLoader::MeshData> loaded_meshes;
+
+    QString step_path = file_info.absoluteFilePath();
+    QTemporaryFile temporary_step_file;
+    if (read_from_memory) {
+        temporary_step_file.setFileTemplate(
+            QDir::temp().filePath("ornlslicer_step_XXXXXX." + file_info.suffix().toLower()));
+        if (!temporary_step_file.open())
+            return loaded_meshes;
+
+        if (temporary_step_file.write(static_cast<const char*>(file_data.first), file_data.second) !=
+            static_cast<qint64>(file_data.second))
+            return loaded_meshes;
+
+        temporary_step_file.close();
+        step_path = temporary_step_file.fileName();
+    }
+
+    MeshTypes::SurfaceMesh surface_mesh = buildSurfaceMeshFromStep(step_path);
+    QSharedPointer<MeshBase> mesh = buildMeshFromStepSurfaceMesh(surface_mesh, file_info, mesh_type);
+    if (mesh.isNull())
+        return loaded_meshes;
+
+    applyInitialTransform(mesh, transform, unit);
+    loaded_meshes.push_back({mesh, file_data.first, file_data.second});
+
+    return loaded_meshes;
+}
+} // namespace
+
 MeshLoader::MeshLoader(QString file_path, MeshType mt, QMatrix4x4 transform, Distance unit)
     : m_file_path(file_path), m_mesh_type(mt), m_transform(transform), m_unit(unit) {}
 
@@ -53,6 +233,7 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
     QFileInfo file_info(file_path);
 
     std::pair<void*, size_t> file_data;
+    const bool read_from_memory = raw_data != nullptr && file_size != 0;
 
     if (raw_data == nullptr || file_size == 0) // Data not provided, so load from file
     {
@@ -64,11 +245,24 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
     else
         file_data = std::make_pair(raw_data, file_size);
 
+    if (file_data.first == nullptr || file_data.second == 0) {
+        if (!read_from_memory && file_data.first != nullptr)
+            free(file_data.first);
+        return loaded_meshes;
+    }
+
     const aiScene* scene = nullptr;
 
     Assimp::Importer importer;
 
     auto model_type = file_info.suffix();
+
+    if (isStepFile(model_type)) {
+        auto step_meshes = loadStepMeshes(file_info, mt, transform, unit, file_data, read_from_memory);
+        if (step_meshes.isEmpty() && !read_from_memory)
+            free(file_data.first);
+        return step_meshes;
+    }
 
     if (model_type == "stl" || model_type == "STL") {
         scene =
@@ -100,8 +294,11 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
                                                 aiProcess_SortByPType);
     }
 
-    if (scene == nullptr)
+    if (scene == nullptr) {
+        if (!read_from_memory)
+            free(file_data.first);
         return loaded_meshes;
+    }
 
     if (scene->HasMeshes()) {
         int num_models_added = 0;
@@ -174,6 +371,9 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
             }
         }
     }
+
+    if (loaded_meshes.isEmpty() && !read_from_memory)
+        free(file_data.first);
 
     return loaded_meshes;
 }

--- a/src/widgets/part_widget/right_click_menu.cpp
+++ b/src/widgets/part_widget/right_click_menu.cpp
@@ -29,8 +29,8 @@ void RightClickMenu::setupActions() {
     m_switch_to_clipper_action = new QAction("Switch to Clipper", this);
     m_switch_to_setting_action = new QAction("Switch to Setting", this);
     m_reset_transformation_action = new QAction("Reset Transformation", this);
-    m_replace_part_action = new QAction("Replace Part STL", this);
-    m_reload_part_action = new QAction("Reload Part(s) STL", this);
+    m_replace_part_action = new QAction("Replace Part Model", this);
+    m_reload_part_action = new QAction("Reload Part Model(s)", this);
     m_delete_part_action = new QAction("Delete Part(s)", this);
     m_lock_part_action = new QAction("Toggle Part Lock(s)", this);
 
@@ -119,9 +119,9 @@ void RightClickMenu::setupEvents() {
     });
 
     connect(m_replace_part_action, &QAction::triggered, this, [this]() {
-        QString filepath = QFileDialog::getOpenFileName(nullptr, QObject::tr("Open STL clipping file"),
-                                                        CSM->getMostRecentModelLocation(),
-                                                        QObject::tr("Model File (*.stl *.3mf *.obj *.amf)"));
+        QString filepath =
+            QFileDialog::getOpenFileName(nullptr, QObject::tr("Open model file"), CSM->getMostRecentModelLocation(),
+                                         QObject::tr("Model File (*.stl *.3mf *.obj *.amf *.step *.stp)"));
 
         if (filepath.isNull()) {
             return;

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -1035,20 +1035,18 @@ void MainWindow::doSlice() {
 
 void MainWindow::loadModel(MeshType mt) {
     QStringList filepaths;
+    const QString model_filter = QObject::tr("Model File (*.stl *.3mf *.obj *.amf *.step *.stp)");
     if (mt == MeshType::kClipping) {
-        filepaths = QFileDialog::getOpenFileNames(nullptr, QObject::tr("Open STL clipping file"),
-                                                  CSM->getMostRecentModelLocation(),
-                                                  QObject::tr("Model File (*.stl *.3mf *.obj *.amf)"));
+        filepaths = QFileDialog::getOpenFileNames(nullptr, QObject::tr("Open model clipping file"),
+                                                  CSM->getMostRecentModelLocation(), model_filter);
     }
     else if (mt == MeshType::kSettings) {
-        filepaths = QFileDialog::getOpenFileNames(nullptr, QObject::tr("Open STL settings file"),
-                                                  CSM->getMostRecentModelLocation(),
-                                                  QObject::tr("Model File (*.stl *.3mf *.obj *.amf)"));
+        filepaths = QFileDialog::getOpenFileNames(nullptr, QObject::tr("Open model settings file"),
+                                                  CSM->getMostRecentModelLocation(), model_filter);
     }
     else {
-        filepaths =
-            QFileDialog::getOpenFileNames(nullptr, QObject::tr("Open STL part file"), CSM->getMostRecentModelLocation(),
-                                          QObject::tr("Model File (*.stl *.3mf *.obj *.amf)"));
+        filepaths = QFileDialog::getOpenFileNames(nullptr, QObject::tr("Open model part file"),
+                                                  CSM->getMostRecentModelLocation(), model_filter);
     }
 
     if (filepaths.isEmpty())
@@ -1066,7 +1064,7 @@ void MainWindow::loadModel(MeshType mt) {
 void MainWindow::loadPointCloud() {
     // Load a point cloud from file
     QStringList filepaths =
-        QFileDialog::getOpenFileNames(nullptr, QObject::tr("Open STL part file"), CSM->getMostRecentModelLocation(),
+        QFileDialog::getOpenFileNames(nullptr, QObject::tr("Open point cloud file"), CSM->getMostRecentModelLocation(),
                                       QObject::tr("Point Cloud (*.matrix *.xyz)"));
     if (filepaths.isEmpty())
         return;


### PR DESCRIPTION
## Summary
- add OpenCASCADE-based STEP/STP import that tessellates CAD geometry into the existing triangulated mesh workflow
- extend GUI and CLI model-file filters/validation to accept STEP and STP files
- add OpenCASCADE to CMake and Nix build dependencies

## Verification
- `nix develop -c cmake --preset generic-llvm-ninja`
- `nix develop -c cmake --build --preset debug-generic-llvm-ninja --target ornlslicer`
- `nix develop -c ./build/generic-llvm-ninja/Debug/ornlslicer --help`

Note: no STEP fixture is present in the repo, so this has not been smoke-tested with a real STEP asset.