### PR TITLE
feat: add arrow key camera controls

### DIFF
--- a/include/graphics/base_view.h
+++ b/include/graphics/base_view.h
@@ -4,6 +4,7 @@
 #include <QOpenGLFunctions_3_3_Core>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLWidget>
+#include <qevent.h>
 #include <qlist.h>
 #include <qmatrix4x4.h>
 #include <qobject.h>
@@ -61,6 +62,10 @@ class BaseView : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core {
     //! \brief Responds to mouse wheel events.
     //! \param e Qt event that has data about wheel movement.
     void wheelEvent(QWheelEvent* e) override;
+    //! \brief Responds to keyboard shortcuts for camera navigation.
+    //! \param e Qt event that has data about the pressed key and any keyboard modifiers.
+    //! \note Arrow keys rotate the camera. Shift, Control, or Alt with an arrow key pans the camera.
+    void keyPressEvent(QKeyEvent* e) override;
 
     /*!
      * \title Interactivity - Camera
@@ -183,8 +188,15 @@ class BaseView : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core {
     virtual void handleWheelForward(QPointF mouse_ndc_pos, float delta);
     //! \brief Respond to a mouse wheel backward movement
     virtual void handleWheelBackward(QPointF mouse_ndc_pos, float delta);
-    //! \brief Translates camera (and objects in sub views)
+    //! \brief Applies a pan request from mouse or keyboard navigation.
+    //! \param v World-space translation vector to apply.
+    //! \param absolute If true, set the camera pan target to \p v; otherwise apply \p v as a relative pan.
+    //! \note Derived views can override this when camera panning also affects view-specific scene objects.
     virtual void translateCamera(QVector3D v, bool absolute);
+    //! \brief Applies a camera rotation from a normalized screen-space input delta.
+    //! \param screen_delta Horizontal and vertical NDC-style delta using the same convention as mouse rotation.
+    //! \note Derived views can override this to constrain or disable rotation for a particular projection mode.
+    virtual void rotateCamera(QVector2D screen_delta);
 
     //! \brief Helper: Convert coordinates of point in widget to normalized device coordinates, i.e. x in [-1,1] and y
     //! in [-1,1] \param widget_pos Local widget position of an event

--- a/include/graphics/support/camera_manager.h
+++ b/include/graphics/support/camera_manager.h
@@ -26,18 +26,22 @@ class CameraManager {
     void rotate(const QVector2D dr);
     //! \brief Set the rotation. Horizontal pitch and vertical yaw.
     void rotateAbsolute(const QVector2D r);
+    //! \brief Applies trackball-scaled camera rotation from a normalized screen-space input delta.
+    //! \param delta Horizontal and vertical NDC-style delta used for camera rotation.
+    //! \note Honors the camera inversion preference used by mouse-drag rotation.
+    void rotateByScreenDelta(const QVector2D delta);
 
     //! \brief Update camera position.
     void zoom(float delta);
 
-    /*! Rotate the camera between the point given
-     * @param ndc_pos Position of mouse in NDC
+    /*! \brief Rotates the camera from the previous drag-start point to the current mouse position.
+     * \param ndc_pos Current mouse position in normalized device coordinates.
      */
     void rotateFromPoint(QPointF ndc_pos);
 
-    /*! Translate the camera from the point given
-     * @param ndc_pos Position of mouse in NDC
-     * @return Translation that just occured.
+    /*! \brief Computes camera pan from the previous drag-start point to the current mouse position.
+     * \param ndc_pos Current mouse position in normalized device coordinates.
+     * \return Relative world-space translation produced by the drag.
      */
     QVector3D translateFromPoint(QPointF ndc_pos);
 

--- a/include/graphics/view/gcode_view.h
+++ b/include/graphics/view/gcode_view.h
@@ -105,10 +105,16 @@ class GCodeView : public BaseView {
     //! \brief Alters the view matrix depending on the projection type and the new view size.
     void resizeGL(int width, int height) override;
 
-    //! \brief Handles the translation of the printer in the volume due to camera movement.
-    //! \param v: Translation vector
-    //! \param absolute: If this translation is relative to (0, 0, 0).
+    //! \brief Applies camera pan to the G-code view camera target.
+    //! \param v World-space translation vector to apply.
+    //! \param absolute If true, set the camera target to \p v; otherwise apply \p v as a relative pan.
+    //! \note This override keeps G-code navigation centered on the printer volume.
     void translateCamera(QVector3D v, bool absolute) override;
+
+    //! \brief Applies shared camera rotation unless the G-code view is orthographic.
+    //! \param screen_delta Horizontal and vertical NDC-style delta requested by keyboard or mouse input.
+    //! \note Orthographic G-code previews intentionally keep the top-down orientation locked.
+    void rotateCamera(QVector2D screen_delta) override;
 
     //! \brief Handles the following: Segment deselection
     void handleLeftClick(QPointF mouse_ndc_pos) override;
@@ -116,7 +122,8 @@ class GCodeView : public BaseView {
     //! \brief Handles the following: Segment selection
     void handleLeftDoubleClick(QPointF mouse_ndc_pos) override;
 
-    //! \brief Handles the following: Orthographic rotation blocking
+    //! \brief Handles mouse-drag camera rotation unless orthographic mode is active.
+    //! \param mouse_ndc_pos Mouse position in normalized device coordinates.
     void handleRightMove(QPointF mouse_ndc_pos) override;
 
     //! \brief Handles the following: Segment hover highlighting

--- a/src/graphics/base_view.cpp
+++ b/src/graphics/base_view.cpp
@@ -4,6 +4,7 @@
 #include <GL/gl.h>
 
 #include <QFileDialog>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <qmatrix4x4.h>
 #include <qnamespace.h>
@@ -22,6 +23,35 @@
 #include "utilities/constants.h"
 
 namespace ORNL {
+namespace {
+constexpr float kKeyboardRotateDegrees = 5.0f;
+constexpr float kKeyboardPanNdcStep = 0.10f;
+
+bool isArrowKey(int key) {
+    return key == Qt::Key_Left || key == Qt::Key_Right || key == Qt::Key_Up || key == Qt::Key_Down;
+}
+
+QVector2D arrowDirection(int key) {
+    switch (key) {
+        case Qt::Key_Left:
+            return QVector2D(-1.0f, 0.0f);
+        case Qt::Key_Right:
+            return QVector2D(1.0f, 0.0f);
+        case Qt::Key_Up:
+            return QVector2D(0.0f, 1.0f);
+        case Qt::Key_Down:
+            return QVector2D(0.0f, -1.0f);
+        default:
+            return QVector2D();
+    }
+}
+
+bool hasCameraPanModifier(Qt::KeyboardModifiers modifiers) {
+    return modifiers.testFlag(Qt::ShiftModifier) || modifiers.testFlag(Qt::ControlModifier) ||
+           modifiers.testFlag(Qt::AltModifier);
+}
+} // namespace
+
 BaseView::BaseView(QWidget* parent) : QOpenGLWidget(parent) {
     // Initalize camera projection.
     float aspect;
@@ -34,6 +64,7 @@ BaseView::BaseView(QWidget* parent) : QOpenGLWidget(parent) {
     m_camera = QSharedPointer<CameraManager>::create(); // Manager for camera/view matrix
     m_shader_program.reset(new QOpenGLShaderProgram());
     this->setMouseTracking(true);
+    this->setFocusPolicy(Qt::StrongFocus);
 }
 
 BaseView::~BaseView() {
@@ -149,6 +180,38 @@ void BaseView::wheelEvent(QWheelEvent* e) {
         this->handleWheelForward(ndc_mouse_pos, (float)e->angleDelta().y());
     else
         this->handleWheelBackward(ndc_mouse_pos, (float)e->angleDelta().y());
+}
+
+void BaseView::keyPressEvent(QKeyEvent* e) {
+    if (!isArrowKey(e->key())) {
+        QOpenGLWidget::keyPressEvent(e);
+        return;
+    }
+
+    const QVector2D direction = -arrowDirection(e->key());
+
+    if (hasCameraPanModifier(e->modifiers())) {
+        QMatrix4x4 view = m_camera->viewMatrix();
+        QVector3D right = QVector3D(view(0, 0), view(0, 1), view(0, 2));
+        QVector3D up = QVector3D(view(1, 0), view(1, 1), view(1, 2));
+
+        right.setZ(0);
+        up.setZ(0);
+        right.normalize();
+        up.normalize();
+
+        const float translation_speed = 20.0f * (m_camera->getZoom() / m_camera->getDefaultZoom());
+        const QVector3D camera_trans =
+            translation_speed * kKeyboardPanNdcStep * ((direction.x() * right) + (direction.y() * up));
+        this->translateCamera(camera_trans, false);
+    }
+    else {
+        const float rotation_step = kKeyboardRotateDegrees / Constants::OpenGL::kTrackball;
+        this->rotateCamera(direction * rotation_step);
+    }
+
+    this->update();
+    e->accept();
 }
 
 void BaseView::zoomIn() {
@@ -301,6 +364,8 @@ void BaseView::translateCamera(QVector3D v, bool absolute) {
         m_focus->translateAbsolute(m_camera->getPan());
     }
 }
+
+void BaseView::rotateCamera(QVector2D screen_delta) { m_camera->rotateByScreenDelta(screen_delta); }
 
 void BaseView::initializeGL() {
     // Required for OpenGL to work

--- a/src/graphics/support/camera_manager.cpp
+++ b/src/graphics/support/camera_manager.cpp
@@ -38,6 +38,15 @@ void CameraManager::rotateAbsolute(const QVector2D r) {
     this->updateViewMatrix();
 }
 
+void CameraManager::rotateByScreenDelta(const QVector2D delta) {
+    int invert = (PreferencesManager::getInstance()->invertCamera()) ? 1 : -1;
+
+    m_pitch += delta.x() * Constants::OpenGL::kTrackball * invert;
+    m_yaw += delta.y() * Constants::OpenGL::kTrackball * invert;
+
+    this->updateViewMatrix();
+}
+
 void CameraManager::zoom(float delta) {
     constexpr float kZoomBase = 1.01;
     delta /= 8.75;
@@ -51,12 +60,7 @@ void CameraManager::zoom(float delta) {
 void CameraManager::rotateFromPoint(QPointF ndc_pos) {
     QPointF delta = ndc_pos - m_drag_start;
 
-    int invert = (PreferencesManager::getInstance()->invertCamera()) ? 1 : -1;
-
-    m_pitch += delta.x() * Constants::OpenGL::kTrackball * invert;
-    m_yaw += delta.y() * Constants::OpenGL::kTrackball * invert;
-
-    this->updateViewMatrix();
+    this->rotateByScreenDelta(QVector2D(delta));
 
     this->setDragStart(ndc_pos);
 }

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -290,6 +290,11 @@ void GCodeView::translateCamera(QVector3D v, bool absolute) {
     }
 }
 
+void GCodeView::rotateCamera(QVector2D screen_delta) {
+    if (!m_state.ortho)
+        this->BaseView::rotateCamera(screen_delta);
+}
+
 void GCodeView::resizeGL(int width, int height) {
     if (!m_state.ortho) {
         this->BaseView::resizeGL(width, height);


### PR DESCRIPTION
## Summary
- add keyboard arrow controls for 3D camera rotation
- support Shift/Ctrl/Alt + arrow keys for camera panning
- preserve G-code orthographic rotation locking while sharing the camera rotation helper with mouse controls
- this was implemented to ease accessibility for laptop users

## Verification
- `nix develop -c cmake --build --preset debug-generic-llvm-ninja --target ornlslicer`