### PR TITLE
Fix: STL loading and part visualization

### DIFF
--- a/include/geometry/mesh/closed_mesh.h
+++ b/include/geometry/mesh/closed_mesh.h
@@ -153,9 +153,13 @@ class ClosedMesh : public MeshBase {
     static std::pair<QVector<MeshVertex>, QVector<MeshFace>>
     FacesAndVerticesFromPolyhedron(MeshTypes::Polyhedron& mesh);
 
-    //! \brief cleans a supplied polyhedron
-    //! \param polyhedron the object to clean
-    static void CleanPolyhedron(MeshTypes::Polyhedron& polyhedron);
+    //! \brief Attempts to clean a supplied polyhedron for closed-mesh import.
+    //! \param polyhedron Candidate polyhedron to clean in place.
+    //! \return True if the cleaned polyhedron should replace the import candidate; false if callers should keep the
+    //! original mesh.
+    //! \note Repair operations are expected to run on a caller-owned copy so failed repairs do not partially replace
+    //! the original import geometry.
+    static bool CleanPolyhedron(MeshTypes::Polyhedron& polyhedron);
 
     MeshTypes::SurfaceMesh extractUpwardFaces() override;
 

--- a/include/graphics/objects/part_object.h
+++ b/include/graphics/objects/part_object.h
@@ -106,6 +106,7 @@ class PartObject : public GraphicsObject {
     QSharedPointer<TextObject> m_label_object;
     QSharedPointer<AxesObject> m_axes_object;
     QSharedPointer<PlaneObject> m_plane_object;
+    QSharedPointer<GraphicsObject> m_feature_edge_object;
 
     //! \brief Overhang angle to use for calculations.
     Angle m_overhang_angle;

--- a/include/graphics/objects/part_object.h
+++ b/include/graphics/objects/part_object.h
@@ -95,6 +95,14 @@ class PartObject : public GraphicsObject {
     void paint(QColor color) override;
 
   private:
+    //! \brief Sorts triangle vertex, normal, and color buffers from back to front for transparent rendering.
+    //!
+    //! Transparent triangle blending is order-dependent. Sorting by view-space depth before drawing reduces dark
+    //! self-overlap artifacts on translucent parts without changing the underlying mesh or stored normals.
+    void sortTrianglesForTransparency();
+
+    //! \brief Repaints the feature-edge overlay to match the current part transparency.
+    void updateFeatureEdgeAppearance();
     //! \brief Part pointer.
     QSharedPointer<Part> m_part;
 
@@ -106,6 +114,7 @@ class PartObject : public GraphicsObject {
     QSharedPointer<TextObject> m_label_object;
     QSharedPointer<AxesObject> m_axes_object;
     QSharedPointer<PlaneObject> m_plane_object;
+    //! \brief Optional overlay that draws silhouette and sharp feature edges over shaded parts.
     QSharedPointer<GraphicsObject> m_feature_edge_object;
 
     //! \brief Overhang angle to use for calculations.

--- a/resources/shaders/shader.frag
+++ b/resources/shaders/shader.frag
@@ -2,7 +2,6 @@
 
 in vec4 vColor;
 in vec3 fragPos;
-in vec3 vNormal;
 in vec3 vWorldPos;
 in vec3 vWorldNormal;
 in vec2 texcoord_uv;
@@ -20,22 +19,26 @@ uniform bool usingSolidWireframeMode;
 void main()
 {
 
-        // Ambient
+    // Ambient
     vec3 ambient = ambientStrength * lightColor;
 
     // Diffuse
-    vec3 norm = normalize(vNormal);
+    vec3 norm = normalize(vWorldNormal);
     vec3 lightDir = normalize(lightPos - fragPos);
-    float diff = max(dot(vNormal, lightDir), 0.0);
-    vec3 diffuse = diff * lightColor;
+    vec3 viewDir = normalize(viewPos - fragPos);
+    vec3 fillDir = normalize(vec3(-0.35, 0.25, 0.9));
+    float keyDiff = max(dot(norm, lightDir), 0.0);
+    float fillDiff = max(dot(norm, fillDir), 0.0);
+    float facing = max(dot(norm, viewDir), 0.0);
+    vec3 diffuse = ((0.7 * keyDiff) + (0.25 * fillDiff) + (0.12 * facing)) * lightColor;
 
 
     // Specular
-    float specularStrength = 0.5;
-    vec3 viewDir = normalize(viewPos - fragPos);
+    float specularStrength = 0.25;
     vec3 reflectDir = reflect(-lightDir, norm);
-    float spec = pow(max(dot(viewDir, reflectDir), 0.0), 64);
+    float spec = pow(max(dot(viewDir, reflectDir), 0.0), 48);
     vec3 specular = specularStrength * spec * lightColor;
+    vec3 rim = 0.08 * pow(1.0 - facing, 2.0) * lightColor;
 
 
     float nearD = min(min(bary[0],bary[1]),bary[2]);
@@ -48,9 +51,7 @@ void main()
     //and no edges are rendered.
     float edgeIntensity =  exp2(edgeIntensityCoefficient*nearD) * float(usingSolidWireframeMode);
 
-    vec4 color = vec4(1,0,0,1);
-
-    vec3 result = (ambient + diffuse + specular) * vec3(vColor) * (1.0-edgeIntensity);
+    vec3 result = clamp((ambient + diffuse + specular + rim) * vec3(vColor), 0.0, 1.0) * (1.0-edgeIntensity);
     fColor =  vec4(0.1,0.1,0.1,0) + vec4(result, vColor.a);
 
 

--- a/resources/shaders/shader.vert
+++ b/resources/shaders/shader.vert
@@ -5,7 +5,6 @@ layout(location = 2) in vec4 color;
 layout(location = 3) in vec2 uv;
 out vec4 vColor;
 out vec3 fragPos;
-out vec3 vNormal;
 out vec3 vWorldPos;
 out vec3 vWorldNormal;
 out vec2 texcoord_uv;
@@ -17,18 +16,13 @@ uniform vec3 stackingAxis;
 uniform float overhangAngle;
 uniform bool usingOverhangMode;
 uniform bool renderingPartObject;
-mat3 rotation;
 
 void main()
 {
     vec4 temp = (model * vec4(position, 1));
     vWorldPos = vec3(temp.x, temp.y, temp.z);
-    rotation = mat3(model[0][0], model[0][1], model[0][2],
-                    model[1][0], model[1][1], model[1][2],
-                    model[2][0], model[2][1], model[2][2]);
-    vNormal = normalize(normal);
     vColor = color;
-    vWorldNormal = rotation * normal;
+    vWorldNormal = normalize(transpose(inverse(mat3(model))) * normal);
     fragPos = vec3(model * vec4(position, 1.0));
     gl_Position = projection * view * model * vec4(position, 1.0);
     texcoord_uv = uv;
@@ -42,7 +36,7 @@ void main()
     //Z pointing down
     if (upward < 0.0 && usingOverhangMode && renderingPartObject)
     {
-        vec4 overhangColor = vec4(255, 0, 0, 255);
+        vec4 overhangColor = vec4(1, 0, 0, 1);
         float M_PI = 3.14159265358979323846;
         float faceAngle;
         float val = dot(stackingAxis, vWorldNormal) / (length(vWorldNormal) * length(stackingAxis));

--- a/src/geometry/mesh/closed_mesh.cpp
+++ b/src/geometry/mesh/closed_mesh.cpp
@@ -418,27 +418,28 @@ ClosedMesh::FacesAndVerticesFromPolyhedron(MeshTypes::Polyhedron& mesh) {
     return std::pair<QVector<MeshVertex>, QVector<MeshFace>>(mesh_vertices, mesh_faces);
 }
 
-void ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
+bool ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
     CGAL::Polygon_mesh_processing::remove_degenerate_faces(polyhedron);
     CGAL::Polygon_mesh_processing::remove_isolated_vertices(polyhedron);
     CGAL::Polygon_mesh_processing::remove_connected_components_of_negligible_size(polyhedron);
 
     MeshTypes::Polyhedron self_intersection_repair = polyhedron;
     try {
-        if (CGAL::Polygon_mesh_processing::experimental::autorefine_and_remove_self_intersections(
+        if (!CGAL::Polygon_mesh_processing::experimental::autorefine_and_remove_self_intersections(
                 self_intersection_repair)) {
-            polyhedron = self_intersection_repair;
-        }
-        else {
             qWarning() << "CGAL could not repair all self-intersections; continuing with the unrepaired mesh.";
+            return false;
         }
     } catch (const CGAL::Failure_exception& error) {
         qWarning() << "CGAL self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
+        return false;
     } catch (const std::exception& error) {
         qWarning() << "Self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
+        return false;
     }
+    polyhedron = self_intersection_repair;
 
-    // If the mesh is not closed, fill holes
+    // If the mesh is not closed, fill holes.
     if (!polyhedron.is_closed()) {
         typedef boost::graph_traits<MeshTypes::Polyhedron>::halfedge_descriptor halfedge_descriptor;
         std::vector<halfedge_descriptor> non_manifold_vertices;
@@ -446,20 +447,31 @@ void ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
 
         if (!non_manifold_vertices.empty()) {
             qWarning() << "Skipping hole filling because the mesh has non-manifold boundary vertices.";
-            return;
+            return false;
         }
 
         for (boost::graph_traits<MeshTypes::Polyhedron>::halfedge_descriptor h : halfedges(polyhedron)) {
             if (CGAL::is_border(h, polyhedron)) {
                 std::vector<boost::graph_traits<MeshTypes::Polyhedron>::face_descriptor> patch_facets;
                 std::vector<boost::graph_traits<MeshTypes::Polyhedron>::vertex_descriptor> patch_vertices;
-                bool success = std::get<0>(CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole(
+                const bool success = std::get<0>(CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole(
                     polyhedron, h, std::back_inserter(patch_facets), std::back_inserter(patch_vertices),
                     CGAL::parameters::vertex_point_map(get(CGAL::vertex_point, polyhedron))
                         .geom_traits(MeshTypes::Kernel())));
+                if (!success) {
+                    qWarning() << "CGAL hole filling failed; continuing with the unrepaired mesh.";
+                    return false;
+                }
             }
         }
     }
+
+    if (!polyhedron.is_closed()) {
+        qWarning() << "CGAL mesh repair left the mesh open; continuing with the unrepaired mesh.";
+        return false;
+    }
+
+    return true;
 }
 
 void ClosedMesh::convert() {

--- a/src/geometry/mesh/closed_mesh.cpp
+++ b/src/geometry/mesh/closed_mesh.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstddef>
+#include <exception>
 #include <iterator>
 #include <list>
 #include <utility>
@@ -15,10 +16,10 @@
 #include <CGAL/Polygon_mesh_processing/clip.h>
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
+#include <CGAL/Polygon_mesh_processing/manifoldness.h>
 #include <CGAL/Polygon_mesh_processing/measure.h>
 #include <CGAL/Polygon_mesh_processing/repair.h>
 #include <CGAL/Polygon_mesh_processing/repair_degeneracies.h>
-#include <CGAL/Polygon_mesh_processing/repair_self_intersections.h>
 #include <CGAL/Polygon_mesh_processing/transform.h>
 #include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
 #include <CGAL/Polygon_mesh_slicer.h>
@@ -32,6 +33,8 @@
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/boost/graph/properties_Polyhedron_3.h>
+#include <CGAL/exceptions.h>
+#include <QtDebug>
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qsharedpointer.h>
@@ -419,10 +422,33 @@ void ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
     CGAL::Polygon_mesh_processing::remove_degenerate_faces(polyhedron);
     CGAL::Polygon_mesh_processing::remove_isolated_vertices(polyhedron);
     CGAL::Polygon_mesh_processing::remove_connected_components_of_negligible_size(polyhedron);
-    CGAL::Polygon_mesh_processing::experimental::remove_self_intersections(polyhedron);
+
+    MeshTypes::Polyhedron self_intersection_repair = polyhedron;
+    try {
+        if (CGAL::Polygon_mesh_processing::experimental::autorefine_and_remove_self_intersections(
+                self_intersection_repair)) {
+            polyhedron = self_intersection_repair;
+        }
+        else {
+            qWarning() << "CGAL could not repair all self-intersections; continuing with the unrepaired mesh.";
+        }
+    } catch (const CGAL::Failure_exception& error) {
+        qWarning() << "CGAL self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
+    } catch (const std::exception& error) {
+        qWarning() << "Self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
+    }
 
     // If the mesh is not closed, fill holes
     if (!polyhedron.is_closed()) {
+        typedef boost::graph_traits<MeshTypes::Polyhedron>::halfedge_descriptor halfedge_descriptor;
+        std::vector<halfedge_descriptor> non_manifold_vertices;
+        CGAL::Polygon_mesh_processing::non_manifold_vertices(polyhedron, std::back_inserter(non_manifold_vertices));
+
+        if (!non_manifold_vertices.empty()) {
+            qWarning() << "Skipping hole filling because the mesh has non-manifold boundary vertices.";
+            return;
+        }
+
         for (boost::graph_traits<MeshTypes::Polyhedron>::halfedge_descriptor h : halfedges(polyhedron)) {
             if (CGAL::is_border(h, polyhedron)) {
                 std::vector<boost::graph_traits<MeshTypes::Polyhedron>::face_descriptor> patch_facets;

--- a/src/graphics/objects/part_object.cpp
+++ b/src/graphics/objects/part_object.cpp
@@ -34,11 +34,33 @@ namespace ORNL {
 namespace {
 constexpr float kFeatureEdgeCosThreshold = 0.9063078f; // 25 degrees.
 constexpr float kFeatureEdgePositionTolerance = 1.0f;
+//! \brief Base opacity for feature-edge lines when the parent part is fully opaque.
+constexpr float kFeatureEdgeAlpha = 0.35f;
+//! \brief Number of floats used by one triangle's three positions.
+constexpr size_t kTrianglePositionFloatCount = 9;
+//! \brief Number of floats used by one triangle's three RGBA vertex colors.
+constexpr size_t kTriangleColorFloatCount = 12;
 
 struct EdgeSample {
     int start_index;
     int end_index;
     QVector3D normal;
+};
+
+//! \brief View-space depth for a triangle in a PartObject render buffer.
+struct TriangleDepth {
+    size_t triangle_index;
+    float view_z;
+};
+
+//! \brief Graphics object wrapper that exposes repainting for the feature-edge overlay.
+class FeatureEdgeObject : public GraphicsObject {
+  public:
+    using GraphicsObject::GraphicsObject;
+
+    //! \brief Repaints every feature-edge vertex with the supplied display color.
+    //! \param color Color and alpha to apply to the overlay lines.
+    void setEdgeColor(QColor color) { this->paint(color); }
 };
 
 std::array<long long, 3> vertexKey(const QVector3D& vertex) {
@@ -55,6 +77,26 @@ std::array<long long, 6> edgeKey(const QVector3D& start, const QVector3D& end) {
         return {end_key[0], end_key[1], end_key[2], start_key[0], start_key[1], start_key[2]};
 
     return {start_key[0], start_key[1], start_key[2], end_key[0], end_key[1], end_key[2]};
+}
+
+//! \brief Builds the feature-edge line color using the current part transparency.
+//! \param part_transparency Current PartObject alpha in the range [0, 255].
+//! \return RGBA color for feature-edge vertices.
+QColor featureEdgeColor(uint part_transparency) {
+    QColor color;
+    color.setRgbF(0.04f, 0.06f, 0.07f, kFeatureEdgeAlpha * (static_cast<float>(part_transparency) / 255.0f));
+    return color;
+}
+
+//! \brief Appends one triangle's contiguous float data to a sorted render buffer.
+//! \param source Buffer containing packed per-triangle data.
+//! \param triangle_index Triangle to copy.
+//! \param floats_per_triangle Number of floats occupied by one triangle in \p source.
+//! \param sorted Destination buffer receiving the copied triangle data.
+void appendTriangleData(const std::vector<float>& source, size_t triangle_index, size_t floats_per_triangle,
+                        std::vector<float>& sorted) {
+    const size_t offset = triangle_index * floats_per_triangle;
+    sorted.insert(sorted.end(), source.begin() + offset, source.begin() + offset + floats_per_triangle);
 }
 
 bool isFeatureEdge(const QVector<EdgeSample>& edge_samples) {
@@ -156,16 +198,17 @@ QSharedPointer<GraphicsObject> createFeatureEdgeObject(BaseView* view, QSharedPo
         edge_normals[i] = 1.0f;
     }
 
+    const QColor edge_color = featureEdgeColor(255);
     std::vector<float> edge_colors;
     edge_colors.reserve((edge_vertices.size() / 3) * 4);
     for (size_t i = 0; i < edge_vertices.size() / 3; ++i) {
-        edge_colors.push_back(0.04f);
-        edge_colors.push_back(0.06f);
-        edge_colors.push_back(0.07f);
-        edge_colors.push_back(0.35f);
+        edge_colors.push_back(edge_color.redF());
+        edge_colors.push_back(edge_color.greenF());
+        edge_colors.push_back(edge_color.blueF());
+        edge_colors.push_back(edge_color.alphaF());
     }
 
-    return QSharedPointer<GraphicsObject>::create(view, edge_vertices, edge_normals, edge_colors, GL_LINES);
+    return QSharedPointer<FeatureEdgeObject>::create(view, edge_vertices, edge_normals, edge_colors, GL_LINES);
 }
 } // namespace
 
@@ -231,6 +274,7 @@ PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mod
     this->populateGL(view, vertices, normals, colors, render_mode);
 
     m_feature_edge_object = createFeatureEdgeObject(this->view(), mesh);
+    this->updateFeatureEdgeAppearance();
 
     // Make a label.
     auto got = QSharedPointer<TextObject>::create(this->view(), m_part->name());
@@ -285,7 +329,17 @@ void PartObject::draw() {
         m_view->glEnable(GL_CULL_FACE);
     }
     else {
+        const bool sort_for_transparency = m_transparency < 255 && renderMode() == GL_TRIANGLES;
+        if (sort_for_transparency) {
+            this->sortTrianglesForTransparency();
+            m_view->glDepthMask(GL_FALSE);
+        }
+
         m_view->glDrawArrays(renderMode(), 0, m_vertices.size() / 3);
+
+        if (sort_for_transparency)
+            m_view->glDepthMask(GL_TRUE);
+
         if (!getSolidWireFrameMode() && !m_feature_edge_object.isNull()) {
             m_view->glDepthFunc(GL_LEQUAL);
             m_feature_edge_object->render();
@@ -428,6 +482,56 @@ void PartObject::overhangUpdate() {
     this->view()->shaderProgram()->release();
 }
 
+void PartObject::sortTrianglesForTransparency() {
+    const size_t triangle_count = m_vertices.size() / kTrianglePositionFloatCount;
+    if (triangle_count < 2 || m_normals.size() != m_vertices.size() ||
+        m_colors.size() != triangle_count * kTriangleColorFloatCount)
+        return;
+
+    const QMatrix4x4 model_view = this->view()->camera()->viewMatrix() * this->transformation();
+
+    std::vector<TriangleDepth> triangle_depths;
+    triangle_depths.reserve(triangle_count);
+    for (size_t triangle_index = 0; triangle_index < triangle_count; ++triangle_index) {
+        const size_t offset = triangle_index * kTrianglePositionFloatCount;
+        const QVector3D center =
+            (QVector3D(m_vertices[offset], m_vertices[offset + 1], m_vertices[offset + 2]) +
+             QVector3D(m_vertices[offset + 3], m_vertices[offset + 4], m_vertices[offset + 5]) +
+             QVector3D(m_vertices[offset + 6], m_vertices[offset + 7], m_vertices[offset + 8])) /
+            3.0f;
+
+        triangle_depths.push_back({triangle_index, (model_view * center).z()});
+    }
+
+    std::stable_sort(triangle_depths.begin(), triangle_depths.end(),
+                     [](const TriangleDepth& lhs, const TriangleDepth& rhs) { return lhs.view_z < rhs.view_z; });
+
+    std::vector<float> sorted_vertices;
+    std::vector<float> sorted_normals;
+    std::vector<float> sorted_colors;
+    sorted_vertices.reserve(m_vertices.size());
+    sorted_normals.reserve(m_normals.size());
+    sorted_colors.reserve(m_colors.size());
+    for (const TriangleDepth& triangle_depth : triangle_depths) {
+        appendTriangleData(m_vertices, triangle_depth.triangle_index, kTrianglePositionFloatCount, sorted_vertices);
+        appendTriangleData(m_normals, triangle_depth.triangle_index, kTrianglePositionFloatCount, sorted_normals);
+        appendTriangleData(m_colors, triangle_depth.triangle_index, kTriangleColorFloatCount, sorted_colors);
+    }
+
+    this->replaceVertices(sorted_vertices);
+    this->replaceNormals(sorted_normals);
+    this->replaceColors(sorted_colors);
+}
+
+void PartObject::updateFeatureEdgeAppearance() {
+    if (m_feature_edge_object.isNull())
+        return;
+
+    QSharedPointer<FeatureEdgeObject> feature_edge_object = m_feature_edge_object.dynamicCast<FeatureEdgeObject>();
+    if (!feature_edge_object.isNull())
+        feature_edge_object->setEdgeColor(featureEdgeColor(m_transparency));
+}
+
 void PartObject::transformationCallback() {
     if (!m_feature_edge_object.isNull())
         m_feature_edge_object->setTransformation(this->transformation(), false);
@@ -491,6 +595,7 @@ void PartObject::paint(QColor color) {
     color.setAlpha(m_transparency);
 
     this->GraphicsObject::paint(color);
+    this->updateFeatureEdgeAppearance();
     if (m_overhang_shown)
         this->overhangUpdate();
 }

--- a/src/graphics/objects/part_object.cpp
+++ b/src/graphics/objects/part_object.cpp
@@ -2,7 +2,10 @@
 
 #include <GL/gl.h>
 
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <map>
 #include <tuple>
 #include <vector>
 
@@ -28,6 +31,144 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
+namespace {
+constexpr float kFeatureEdgeCosThreshold = 0.9063078f; // 25 degrees.
+constexpr float kFeatureEdgePositionTolerance = 1.0f;
+
+struct EdgeSample {
+    int start_index;
+    int end_index;
+    QVector3D normal;
+};
+
+std::array<long long, 3> vertexKey(const QVector3D& vertex) {
+    return {std::llround(vertex.x() / kFeatureEdgePositionTolerance),
+            std::llround(vertex.y() / kFeatureEdgePositionTolerance),
+            std::llround(vertex.z() / kFeatureEdgePositionTolerance)};
+}
+
+std::array<long long, 6> edgeKey(const QVector3D& start, const QVector3D& end) {
+    const std::array<long long, 3> start_key = vertexKey(start);
+    const std::array<long long, 3> end_key = vertexKey(end);
+
+    if (end_key < start_key)
+        return {end_key[0], end_key[1], end_key[2], start_key[0], start_key[1], start_key[2]};
+
+    return {start_key[0], start_key[1], start_key[2], end_key[0], end_key[1], end_key[2]};
+}
+
+bool isFeatureEdge(const QVector<EdgeSample>& edge_samples) {
+    if (edge_samples.size() == 1)
+        return true;
+
+    for (int i = 0; i < edge_samples.size(); ++i) {
+        QVector3D first_normal = edge_samples[i].normal.normalized();
+
+        if (first_normal.isNull())
+            continue;
+
+        for (int j = i + 1; j < edge_samples.size(); ++j) {
+            QVector3D second_normal = edge_samples[j].normal.normalized();
+
+            if (second_normal.isNull())
+                continue;
+
+            float edge_angle_cos = std::fabs(QVector3D::dotProduct(first_normal, second_normal));
+            edge_angle_cos = std::max(-1.0f, std::min(1.0f, edge_angle_cos));
+
+            if (edge_angle_cos <= kFeatureEdgeCosThreshold)
+                return true;
+        }
+    }
+
+    return false;
+}
+
+void appendFeatureEdge(std::vector<float>& edge_vertices, const QVector<MeshVertex>& vertices,
+                       const EdgeSample& edge_sample) {
+    if (edge_sample.start_index < 0 || edge_sample.start_index >= vertices.size() || edge_sample.end_index < 0 ||
+        edge_sample.end_index >= vertices.size())
+        return;
+
+    const QVector3D start = vertices[edge_sample.start_index].location * Constants::OpenGL::kObjectToView;
+    const QVector3D end = vertices[edge_sample.end_index].location * Constants::OpenGL::kObjectToView;
+
+    edge_vertices.push_back(start.x());
+    edge_vertices.push_back(start.y());
+    edge_vertices.push_back(start.z());
+    edge_vertices.push_back(end.x());
+    edge_vertices.push_back(end.y());
+    edge_vertices.push_back(end.z());
+}
+
+bool isValidFaceEdge(const QVector<MeshVertex>& vertices, const MeshFace& face, int edge_index) {
+    const int start_index = face.vertex_index[edge_index];
+    const int end_index = face.vertex_index[(edge_index + 1) % 3];
+
+    return start_index >= 0 && start_index < vertices.size() && end_index >= 0 && end_index < vertices.size();
+}
+
+std::map<std::array<long long, 6>, QVector<EdgeSample>> buildEdgeMap(const QVector<MeshVertex>& vertices,
+                                                                     const QVector<MeshFace>& faces) {
+    std::map<std::array<long long, 6>, QVector<EdgeSample>> edge_map;
+
+    for (const MeshFace& face : faces) {
+        for (int edge_index = 0; edge_index < 3; ++edge_index) {
+            if (!isValidFaceEdge(vertices, face, edge_index))
+                continue;
+
+            const int start_index = face.vertex_index[edge_index];
+            const int end_index = face.vertex_index[(edge_index + 1) % 3];
+            const QVector3D& start = vertices[start_index].location;
+            const QVector3D& end = vertices[end_index].location;
+
+            edge_map[edgeKey(start, end)].push_back({start_index, end_index, face.normal});
+        }
+    }
+
+    return edge_map;
+}
+
+std::vector<float> buildFeatureEdgeVertices(QSharedPointer<MeshBase> mesh) {
+    const QVector<MeshVertex> vertices = mesh->originalVertices();
+    const QVector<MeshFace> faces = mesh->originalFaces();
+    const std::map<std::array<long long, 6>, QVector<EdgeSample>> edge_map = buildEdgeMap(vertices, faces);
+
+    std::vector<float> edge_vertices;
+    edge_vertices.reserve(faces.size() * 6);
+
+    for (auto edge_iter = edge_map.cbegin(); edge_iter != edge_map.cend(); ++edge_iter) {
+        if (isFeatureEdge(edge_iter->second))
+            appendFeatureEdge(edge_vertices, vertices, edge_iter->second.first());
+    }
+
+    return edge_vertices;
+}
+
+QSharedPointer<GraphicsObject> createFeatureEdgeObject(BaseView* view, QSharedPointer<MeshBase> mesh) {
+    std::vector<float> edge_vertices = buildFeatureEdgeVertices(mesh);
+
+    if (edge_vertices.empty())
+        return QSharedPointer<GraphicsObject>();
+
+    std::vector<float> edge_normals(edge_vertices.size(), 0.0f);
+    for (size_t i = 2; i < edge_normals.size(); i += 3) {
+        edge_normals[i] = 1.0f;
+    }
+
+    std::vector<float> edge_colors;
+    edge_colors.reserve((edge_vertices.size() / 3) * 4);
+    for (size_t i = 0; i < edge_vertices.size() / 3; ++i) {
+        edge_colors.push_back(0.04f);
+        edge_colors.push_back(0.06f);
+        edge_colors.push_back(0.07f);
+        edge_colors.push_back(0.35f);
+    }
+
+    return QSharedPointer<GraphicsObject>::create(view, edge_vertices, edge_normals, edge_colors, GL_LINES);
+}
+} // namespace
+
 PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mode) {
     m_part = p;
     QSharedPointer<MeshBase> mesh = p->rootMesh();
@@ -89,6 +230,8 @@ PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mod
 
     this->populateGL(view, vertices, normals, colors, render_mode);
 
+    m_feature_edge_object = createFeatureEdgeObject(this->view(), mesh);
+
     // Make a label.
     auto got = QSharedPointer<TextObject>::create(this->view(), m_part->name());
     got->setOnTop(true);
@@ -143,6 +286,11 @@ void PartObject::draw() {
     }
     else {
         m_view->glDrawArrays(renderMode(), 0, m_vertices.size() / 3);
+        if (!getSolidWireFrameMode() && !m_feature_edge_object.isNull()) {
+            m_view->glDepthFunc(GL_LEQUAL);
+            m_feature_edge_object->render();
+            m_view->glDepthFunc(GL_LESS);
+        }
     }
 }
 void PartObject::configureUniforms() {
@@ -281,6 +429,9 @@ void PartObject::overhangUpdate() {
 }
 
 void PartObject::transformationCallback() {
+    if (!m_feature_edge_object.isNull())
+        m_feature_edge_object->setTransformation(this->transformation(), false);
+
     if (!m_arrow_object.isNull())
         m_arrow_object->updateEndpoints();
     for (auto& goc : m_part_children) {

--- a/src/threading/mesh_loader.cpp
+++ b/src/threading/mesh_loader.cpp
@@ -3,8 +3,10 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
+#include <exception>
 #include <utility>
 
+#include <CGAL/exceptions.h>
 #include <QLinkedList>
 #include <QStack>
 #include <QtDebug>
@@ -118,8 +120,19 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
                 MeshBuilderAssimp<MeshTypes::HalfedgeDescriptor> builder(mesh);
                 polyhedron.delegate(builder);
 
-                if (GSM->getGlobal()->setting<bool>(PS::SpecialModes::kEnableFixModel))
-                    ClosedMesh::CleanPolyhedron(polyhedron);
+                if (!builder.wasError() && GSM->getGlobal()->setting<bool>(PS::SpecialModes::kEnableFixModel)) {
+                    MeshTypes::Polyhedron repaired_polyhedron = polyhedron;
+                    try {
+                        ClosedMesh::CleanPolyhedron(repaired_polyhedron);
+                        polyhedron = repaired_polyhedron;
+                    } catch (const CGAL::Failure_exception& error) {
+                        qWarning() << "CGAL model repair failed for" << file_info.fileName()
+                                   << "- importing unrepaired mesh:" << error.what();
+                    } catch (const std::exception& error) {
+                        qWarning() << "Model repair failed for" << file_info.fileName()
+                                   << "- importing unrepaired mesh:" << error.what();
+                    }
+                }
 
                 if (builder.wasError() || !polyhedron.is_closed()) {
                     MeshTypes::SurfaceMesh sm = BuildSurfaceMesh(mesh);

--- a/src/threading/mesh_loader.cpp
+++ b/src/threading/mesh_loader.cpp
@@ -123,8 +123,13 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
                 if (!builder.wasError() && GSM->getGlobal()->setting<bool>(PS::SpecialModes::kEnableFixModel)) {
                     MeshTypes::Polyhedron repaired_polyhedron = polyhedron;
                     try {
-                        ClosedMesh::CleanPolyhedron(repaired_polyhedron);
-                        polyhedron = repaired_polyhedron;
+                        if (ClosedMesh::CleanPolyhedron(repaired_polyhedron)) {
+                            polyhedron = repaired_polyhedron;
+                        }
+                        else {
+                            qWarning() << "Model repair did not complete for" << file_info.fileName()
+                                       << "- importing unrepaired mesh.";
+                        }
                     } catch (const CGAL::Failure_exception& error) {
                         qWarning() << "CGAL model repair failed for" << file_info.fileName()
                                    << "- importing unrepaired mesh:" << error.what();


### PR DESCRIPTION
## Summary
These changes improve the visualization of STL files to make edges and other features more noticeable. Changes were also made to STL loading the clear up some errors and crashes with particular geometries.
- improve part-view lighting and add feature-edge rendering while suppressing flat triangulation edges
- make CGAL mesh repair resilient by falling back to the original mesh on repair failures
- skip CGAL hole filling for non-manifold boundary meshes to avoid warnings/assertions when loading problematic STLs

## Verification
- `nix develop -c cmake --build --preset debug-generic-llvm-ninja --target ornlslicer`
- `timeout 25s build/generic-llvm-ninja/Debug/ornlslicer --input_global_settings templates/Desktop_04mm.s2c --input_stl_files /home/rhc/develop/Chair.STL --output_location /tmp/ornl-chair-test.gcode --shift_parts_on_load false --align_parts false --single_slice_height 1`
- `rg -n "CGAL|assertion|check violation|Non-manifold|non-manifold|Skipping hole" /tmp/ornl-chair-load.log`
- `git diff --check`