### PR TITLE
Update save and export window behavior

### DIFF
--- a/include/managers/session_manager.h
+++ b/include/managers/session_manager.h
@@ -192,7 +192,7 @@ class SessionManager : public QObject {
     bool changeSlicer(SlicerType type);
 
     //! \brief Creates a new session loader to save the current session.
-    SessionLoader* saveSession(QString path, bool shouldTrack = true);
+    SessionLoader* saveSession(QString path, bool shouldTrack = true, bool notifyOnSuccess = false);
 
     //! \brief Creates a new session loader to load another session.
     //! \param shouldDelete Whether or not to delete current parts/settings before
@@ -248,6 +248,9 @@ class SessionManager : public QObject {
 
     //! \brief Signal that slicing thread has started writing the GCode file.
     void forwardStatusUpdate(QString status);
+
+    //! \brief Signal that a session file has been saved successfully.
+    void sessionSaved(QString path);
 
     //! \brief Signal for total number of parts expected to load from project
     void totalPartsInProject(int total);

--- a/include/threading/session_loader.h
+++ b/include/threading/session_loader.h
@@ -38,6 +38,9 @@ class SessionLoader : public QThread {
     //! \brief Signal that an error has occured.
     void error(QString error);
 
+    //! \brief Signal that a session file has been saved successfully.
+    void saveSucceeded();
+
     //! \brief Signal that a session file has been loaded successfully.
     void loadSucceeded();
 

--- a/src/managers/session_manager.cpp
+++ b/src/managers/session_manager.cpp
@@ -628,12 +628,14 @@ bool SessionManager::changeSlicer(SlicerType type) {
     return true;
 }
 
-SessionLoader* SessionManager::saveSession(QString path, bool shouldTrack) {
+SessionLoader* SessionManager::saveSession(QString path, bool shouldTrack, bool notifyOnSuccess) {
     // Request an update.
     emit requestTransformationUpdate();
 
     SessionLoader* loader = new SessionLoader(path, true);
     connect(loader, &SessionLoader::finished, loader, &SessionLoader::deleteLater);
+    if (notifyOnSuccess)
+        connect(loader, &SessionLoader::saveSucceeded, this, [this, path]() { emit sessionSaved(path); });
 
     loader->start();
     m_file = path;

--- a/src/threading/session_loader.cpp
+++ b/src/threading/session_loader.cpp
@@ -127,6 +127,7 @@ void SessionLoader::saveSession() {
     zip_entry_close(zip);
 
     zip_close(zip);
+    emit saveSucceeded();
 }
 
 fifojson SessionLoader::getSettingsFromZip() {

--- a/src/windows/gcode_export.cpp
+++ b/src/windows/gcode_export.cpp
@@ -36,6 +36,17 @@
 #include "utilities/constants.h"
 
 namespace ORNL {
+namespace {
+QString removeModelFileExtension(QString name) {
+    QFileInfo file_info(name);
+    QString suffix = file_info.suffix().toLower();
+
+    if (suffix == "stl" || suffix == "3mf" || suffix == "obj" || suffix == "amf" || suffix == "step" || suffix == "stp")
+        return file_info.completeBaseName();
+
+    return name;
+}
+} // namespace
 
 GcodeExport::GcodeExport(QWidget* parent) {
     setWindowTitle(QApplication::applicationDisplayName() + ": G-Code/Project Export");
@@ -87,7 +98,7 @@ GcodeExport::GcodeExport(QWidget* parent) {
 
 GcodeExport::~GcodeExport() {}
 
-void GcodeExport::setDefaultName(QString name) { m_default_name = name; }
+void GcodeExport::setDefaultName(QString name) { m_default_name = removeModelFileExtension(name); }
 
 void GcodeExport::updateOutputInformation(QString tempLocation, GcodeMeta meta) {
     m_location = tempLocation;
@@ -356,5 +367,6 @@ void GcodeExport::exportGcode() {
 
 void GcodeExport::showComplete(QString path, QString filename) {
     QMessageBox::information(this, "File Export", filename % " has been succesfully exported to " % path);
+    close();
 }
 } // namespace ORNL

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -22,6 +22,7 @@
 #include <qmap.h>
 #include <qmenu.h>
 #include <qmenubar.h>
+#include <qmessagebox.h>
 #include <qminmax.h>
 #include <qnamespace.h>
 #include <qobject.h>
@@ -777,6 +778,9 @@ void MainWindow::setupEvents() {
         switchViews(1);
     });
     connect(CSM.get(), &SessionManager::forwardStatusUpdate, this, &MainWindow::updateStatus);
+    connect(CSM.get(), &SessionManager::sessionSaved, this, [this](QString path) {
+        QMessageBox::information(this, "Save Project", "Project has been successfully saved to " + path);
+    });
 
     // Hook up updated layer min/max from gcode bar to gcodewidget
     connect(m_gcodebar, &GcodeBar::lowerLayerUpdated, m_gcode_widget->view(), &GCodeView::setLowLayer);
@@ -1161,7 +1165,7 @@ void MainWindow::saveSession() {
     if (filename.isEmpty())
         return;
 
-    CSM->saveSession(filename);
+    CSM->saveSession(filename, true, true);
     CSM->saveSession(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/_lastsession.s2p", false);
 
     this->setTitleInfo(QFileInfo(filename).fileName());


### PR DESCRIPTION
## Summary
- Strip source model extensions from the export g-code default filename before appending the selected g-code suffix.
- Close the export g-code window after the export completion confirmation is acknowledged.
- Show a Save Project success confirmation after the project file is actually written.

## Impact
This keeps generated g-code names cleaner, reduces an extra manual close step after export, and gives users explicit confirmation when project saves finish successfully.

## Validation
- `git diff --check`
- `nix develop --option eval-cache false -c cmake --build build/generic-llvm-ninja --config Release --target ornlslicer_obj`