### PR TITLE
Rotate g-code info arrow with camera

### DIFF
--- a/include/graphics/view/gcode_view.h
+++ b/include/graphics/view/gcode_view.h
@@ -37,6 +37,24 @@ class GCodeView : public BaseView {
     //! \param segmentInfoControl: Segment info display control
     GCodeView(QSharedPointer<SettingsBase> sb, QSharedPointer<GCodeInfoControl> segmentInfoControl);
 
+    //! \brief Moves the camera toward the print volume.
+    void zoomIn();
+    //! \brief Moves the camera away from the print volume.
+    void zoomOut();
+    //! \brief Moves the camera to its default zoom.
+    void resetZoom() override;
+
+    //! \brief Set camera to view from top.
+    void setTopView();
+    //! \brief Set camera to view from side.
+    void setSideView();
+    //! \brief Set camera to view from front.
+    void setFrontView();
+    //! \brief Set camera to view from the forward direction.
+    void setForwardView();
+    //! \brief Set camera to view from an isometric direction.
+    void setIsoView();
+
   public slots:
     //! \brief Changes the view to use an orthographic projection instead of the normal perspective view.
     void useOrthographic(bool ortho);
@@ -144,6 +162,9 @@ class GCodeView : public BaseView {
     //! \param gog: GCode object to search through.
     //! \return Segment line number.
     uint pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeObject> gog);
+
+    //! \brief Refreshes camera-dependent segment info display.
+    void updateSegmentInfoViewMatrix();
 
     //! \brief Settings for the view.
     QSharedPointer<SettingsBase> m_sb;

--- a/include/widgets/gcode_info_control.h
+++ b/include/widgets/gcode_info_control.h
@@ -8,9 +8,11 @@
 #include <QGridLayout>
 #include <QIcon>
 #include <QLabel>
+#include <QMatrix4x4>
 #include <QMouseEvent>
 #include <QPixmap>
 #include <QPushButton>
+#include <QVector3D>
 #include <QWidget>
 #include <qcontainerfwd.h>
 #include <qlist.h>
@@ -67,12 +69,21 @@ class GCodeInfoControl : public QWidget {
     //! \brief Remove segment from info tracking list.
     void removeSegmentInfo(int selectedLineNumber);
 
+    //! \brief Updates the camera view matrix used to display segment travel direction.
+    void setViewMatrix(const QMatrix4x4& viewMatrix);
+
   private:
     //! \brief Display xy direction
-    inline void updateDirection(double angle);
+    void updateDirection(double angle);
 
     //! \brief Display z direction
-    inline void updateZDirection(double angle);
+    void updateZDirection(double angle);
+
+    //! \brief Display direction for the current camera view.
+    void updateDirectionForSegment(const QSharedPointer<SegmentBase>& segment);
+
+    //! \brief Converts a 3D travel vector to a screen-space angle.
+    double viewAngleForDirection(const QVector3D& direction, double fallbackAngle) const;
 
     //! \brief Initilizes the widget.
     void setupWidget();
@@ -87,6 +98,12 @@ class GCodeInfoControl : public QWidget {
 
     //! \brief list of segments
     QVector<QVector<QSharedPointer<SegmentBase>>> m_gcode;
+
+    //! \brief Segment currently shown in the info panel.
+    QSharedPointer<SegmentBase> m_current_segment;
+
+    //! \brief Current camera view matrix used to orient the direction arrow.
+    QMatrix4x4 m_view_matrix;
 
     //! \brief Int list of gcode line numbers that are currently selected
     QList<int> m_line_no_list;

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -83,6 +83,46 @@ GCodeView::GCodeView(QSharedPointer<SettingsBase> sb, QSharedPointer<GCodeInfoCo
     m_use_true_segment_widths = PreferencesManager::getInstance()->getUseTrueWidthsPreference();
 }
 
+void GCodeView::zoomIn() {
+    this->BaseView::zoomIn();
+    updateSegmentInfoViewMatrix();
+}
+
+void GCodeView::zoomOut() {
+    this->BaseView::zoomOut();
+    updateSegmentInfoViewMatrix();
+}
+
+void GCodeView::resetZoom() {
+    this->BaseView::resetZoom();
+    updateSegmentInfoViewMatrix();
+}
+
+void GCodeView::setTopView() {
+    this->BaseView::setTopView();
+    updateSegmentInfoViewMatrix();
+}
+
+void GCodeView::setSideView() {
+    this->BaseView::setSideView();
+    updateSegmentInfoViewMatrix();
+}
+
+void GCodeView::setFrontView() {
+    this->BaseView::setFrontView();
+    updateSegmentInfoViewMatrix();
+}
+
+void GCodeView::setForwardView() {
+    this->BaseView::setForwardView();
+    updateSegmentInfoViewMatrix();
+}
+
+void GCodeView::setIsoView() {
+    this->BaseView::setIsoView();
+    updateSegmentInfoViewMatrix();
+}
+
 void GCodeView::useOrthographic(bool ortho) {
     m_state.ortho = ortho;
 
@@ -92,6 +132,8 @@ void GCodeView::useOrthographic(bool ortho) {
         this->setForwardView();
     else
         this->setTopView();
+
+    updateSegmentInfoViewMatrix();
 }
 
 void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
@@ -151,6 +193,7 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
 
     this->update();
     m_gcode = gcode;
+    updateSegmentInfoViewMatrix();
 }
 
 void GCodeView::hideSegmentType(SegmentDisplayType type, bool hidden) {
@@ -251,13 +294,16 @@ void GCodeView::handleMouseMove(QPointF mouse_ndc_pos) {
 }
 
 void GCodeView::handleRightMove(QPointF mouse_ndc_pos) {
-    if (!m_state.ortho)
+    if (!m_state.ortho) {
         this->BaseView::handleRightMove(mouse_ndc_pos);
+        updateSegmentInfoViewMatrix();
+    }
 }
 
 void GCodeView::handleWheelForward(QPointF mouse_ndc_pos, float delta) {
     if (!m_state.ortho) {
         this->BaseView::handleWheelForward(mouse_ndc_pos, delta);
+        updateSegmentInfoViewMatrix();
         return;
     }
 
@@ -265,11 +311,13 @@ void GCodeView::handleWheelForward(QPointF mouse_ndc_pos, float delta) {
     m_state.zoom_factor = MathUtils::clamp(0.0f, m_state.zoom_factor, 2.0f);
 
     this->resizeGL(this->width(), this->height());
+    updateSegmentInfoViewMatrix();
 }
 
 void GCodeView::handleWheelBackward(QPointF mouse_ndc_pos, float delta) {
     if (!m_state.ortho) {
         this->BaseView::handleWheelBackward(mouse_ndc_pos, delta);
+        updateSegmentInfoViewMatrix();
         return;
     }
 
@@ -277,6 +325,7 @@ void GCodeView::handleWheelBackward(QPointF mouse_ndc_pos, float delta) {
     m_state.zoom_factor = MathUtils::clamp(0.0f, m_state.zoom_factor, 2.0f);
 
     this->resizeGL(this->width(), this->height());
+    updateSegmentInfoViewMatrix();
 }
 
 void GCodeView::translateCamera(QVector3D v, bool absolute) {
@@ -288,6 +337,8 @@ void GCodeView::translateCamera(QVector3D v, bool absolute) {
         m_camera->pan(v);
         m_focus->translateAbsolute(m_camera->getPan());
     }
+
+    updateSegmentInfoViewMatrix();
 }
 
 void GCodeView::rotateCamera(QVector2D screen_delta) {
@@ -321,6 +372,7 @@ void GCodeView::resizeGL(int width, int height) {
     this->setProjectionMatrix(projection);
 
     this->update();
+    updateSegmentInfoViewMatrix();
 }
 
 uint GCodeView::pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeObject> gog) {
@@ -515,5 +567,11 @@ void GCodeView::resetCamera() {
         QVector3D(m_printer->printerCenter().x(), m_printer->printerCenter().y(), m_printer->minimum().z()), true);
 
     this->update(); // Need to repaint with new model matrices
+    updateSegmentInfoViewMatrix();
+}
+
+void GCodeView::updateSegmentInfoViewMatrix() {
+    if (!m_segment_info_control.isNull())
+        m_segment_info_control->setViewMatrix(this->viewMatrix());
 }
 } // namespace ORNL

--- a/src/widgets/gcode_info_control.cpp
+++ b/src/widgets/gcode_info_control.cpp
@@ -1,5 +1,8 @@
 #include "widgets/gcode_info_control.h"
 
+#include <cmath>
+
+#include <QtMath>
 #include <qboxlayout.h>
 #include <qcombobox.h>
 #include <qcontainerfwd.h>
@@ -26,6 +29,7 @@ GCodeInfoControl::GCodeInfoControl(QWidget* parent) : QWidget(parent) { setupWid
 
 void GCodeInfoControl::setGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     m_gcode = gcode;
+    m_current_segment.clear();
 
     m_line_no_list.clear();
     fillSegmentInfo(0);
@@ -47,17 +51,8 @@ void GCodeInfoControl::fillSegmentInfo(uint lineNo) {
                     m_infolbl_length->setText(seg->m_segment_info_meta.length);
                     m_infolbl_layer_no->setText(QString::number(seg->layerNumber()));
                     m_infolbl_line_no->setText(QString::number(lineNo));
-
-                    if (seg->m_segment_info_meta.isXYmove()) {
-                        updateDirection(360 - seg->m_segment_info_meta.getCCWXAngle());
-                    }
-                    else {
-                        float diff = seg->m_segment_info_meta.getZChange();
-                        if (diff == 0)
-                            m_infolbl_direction->setVisible(false);
-                        else
-                            updateZDirection(diff > 0 ? 180 : 0);
-                    }
+                    m_current_segment = seg;
+                    updateDirectionForSegment(m_current_segment);
 
                     return;
                 }
@@ -72,6 +67,7 @@ void GCodeInfoControl::fillSegmentInfo(uint lineNo) {
     m_infolbl_layer_no->setText("");
     m_infolbl_line_no->setText("");
 
+    m_current_segment.clear();
     m_infolbl_direction->setVisible(false);
 }
 
@@ -114,6 +110,50 @@ void GCodeInfoControl::updateZDirection(double angle) {
     m_infolbl_direction->setPixmap(m_infopm_direction_z->transformed(QTransform().rotate(angle)));
 }
 
+void GCodeInfoControl::updateDirectionForSegment(const QSharedPointer<SegmentBase>& segment) {
+    if (segment.isNull()) {
+        m_infolbl_direction->setVisible(false);
+        return;
+    }
+
+    auto& meta = segment->m_segment_info_meta;
+    QVector3D direction(meta.end.x() - meta.start.x(), meta.end.y() - meta.start.y(), meta.end.z() - meta.start.z());
+
+    if (meta.isXYmove()) {
+        updateDirection(viewAngleForDirection(direction, 360 - meta.getCCWXAngle()));
+    }
+    else {
+        float diff = meta.getZChange();
+        if (diff == 0) {
+            m_infolbl_direction->setVisible(false);
+        }
+        else {
+            updateZDirection(viewAngleForDirection(direction, diff > 0 ? 180 : 0));
+        }
+    }
+}
+
+double GCodeInfoControl::viewAngleForDirection(const QVector3D& direction, double fallbackAngle) const {
+    constexpr float kMinimumVisibleDirection = 1.0e-6f;
+
+    const QVector3D view_direction = m_view_matrix.mapVector(direction);
+    if (std::abs(view_direction.x()) < kMinimumVisibleDirection &&
+        std::abs(view_direction.y()) < kMinimumVisibleDirection) {
+        return fallbackAngle;
+    }
+
+    double angle = qRadiansToDegrees(std::atan2(view_direction.y(), view_direction.x()));
+    if (angle < 0.0)
+        angle += 360.0;
+
+    return 360.0 - angle;
+}
+
+void GCodeInfoControl::setViewMatrix(const QMatrix4x4& viewMatrix) {
+    m_view_matrix = viewMatrix;
+    updateDirectionForSegment(m_current_segment);
+}
+
 void GCodeInfoControl::setupWidget() {
     QLabel* lbl2DAxis = new QLabel;
 
@@ -132,8 +172,8 @@ void GCodeInfoControl::setupWidget() {
     m_info_display_indicator = new QLabel;
     m_info_display_indicator->setPixmap(QPixmap(":/icons/down_black.png"));
 
-    lbl2DAxis->setToolTip("Print Orientation, 2D (X Y)\nOnly Top Projection View (With Out Any Rotation) Considered");
-    m_infolbl_direction->setToolTip("Print Direction\nOnly Top Projection View (With Out Any Rotation) Considered");
+    lbl2DAxis->setToolTip("Print Orientation, 2D (X Y)");
+    m_infolbl_direction->setToolTip("Print Direction\nMatches the current G-Code view");
 
     m_info_grid = new QGridLayout(m_info_display);
     m_info_grid->setRowMinimumHeight(0, 75);


### PR DESCRIPTION
## Summary

- Rotate the bead / segment info direction arrow using the active G-code view matrix.
- Refresh the info overlay after camera view changes, mouse rotation, zoom, orthographic changes, and resets.
- Update the direction tooltip to reflect that the arrow now matches the current G-code view.

## Why

The segment info arrow previously used only the unrotated top-down XY angle, so it became misleading after rotating the camera. The displayed travel direction now follows the same camera orientation as the selected toolpath.

## Validation

- `nix develop -c cmake --build build/generic-llvm-ninja --target ornlslicer -j 2`