### PR TITLE
Add smoothing algorithm options

### DIFF
--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -509,6 +509,17 @@ inline QString toString(PathModifiers modifier_type) {
 }
 
 /*!
+ * \enum  SmoothingType
+ * \brief The Smoothing Type enum
+ */
+enum class SmoothingType : uint8_t {
+    kDouglasPeucker = 0,
+    kRadialDistance = 1,
+    kPerpendicularDistance =2,
+    kReumannWitkam = 3
+};
+
+/*!
  * \enum  IslandOrderOptimization
  * \brief The Path/ Island OrderOptimization enum
  */

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -4965,6 +4965,19 @@
       "symbol":"kEnableSmoothing",
       "local":false
   },
+  "smoothing_type": {
+      "display":"Smoothing Type",
+      "type":"enumeration",
+      "tooltip":"Select the smoothing algorithm to be applied",
+      "depends":{"smoothing":true},
+      "options":"Douglas Peucker, Radial Distance, Perpendicular Distance, Reumann-Witkam",
+      "default":0,
+      "minor":"Special Modes",
+      "major":"Profile",
+      "namespace":"Profile::SpecialModes",
+      "symbol":"kSmoothingType",
+      "local":false
+  },
   "smoothing_tolerance": {
       "display":"Smoothing Tolerance",
       "type":"distance",

--- a/resources/settings/029_profile_special_modes.yaml
+++ b/resources/settings/029_profile_special_modes.yaml
@@ -13,6 +13,22 @@ settings:
     namespace: "Profile::SpecialModes"
     symbol: "kEnableSmoothing"
     local: false
+  - name: "smoothing_type"
+    display: "Smoothing Type"
+    type: "enumeration"
+    tooltip: "Select the smoothing algorithm to be applied"
+    depends: {"smoothing":true}
+    options:
+      - "Douglas Peucker"
+      - "Radial Distance"
+      - "Perpendicular Distance"
+      - "Reumann-Witkam"
+    default: 0
+    minor: "Special Modes"
+    major: "Profile"
+    namespace: "Profile::SpecialModes"
+    symbol: "kSmoothingType"
+    local: false
   - name: "smoothing_tolerance"
     display: "Smoothing Tolerance"
     type: "distance"

--- a/src/cross_section/cross_section_object.cpp
+++ b/src/cross_section/cross_section_object.cpp
@@ -144,8 +144,28 @@ PolygonList CrossSectionObject::makePolygons() {
             }
             std::vector<double> result;
             result.reserve(polyline.size());
-            psimpl::simplify_douglas_peucker<2>(polyline.begin(), polyline.end(), tolerance(),
+            SmoothingType smoothingType =
+                static_cast<SmoothingType>(m_sb->setting<int>(PS::SpecialModes::kSmoothingType));
+            if(smoothingType == SmoothingType::kDouglasPeucker) {
+                psimpl::simplify_douglas_peucker<2>(polyline.begin(), polyline.end(), tolerance(),
                                                 std::back_inserter(result));
+            }
+            else if(smoothingType == SmoothingType::kRadialDistance){
+                psimpl::simplify_radial_distance<2>(polyline.begin(), polyline.end(), tolerance(),
+                                                std::back_inserter(result));
+            }
+            else if(smoothingType == SmoothingType::kPerpendicularDistance){
+                psimpl::simplify_perpendicular_distance<2>(polyline.begin(), polyline.end(), tolerance(),
+                                                std::back_inserter(result));
+            }
+            else if(smoothingType == SmoothingType::kReumannWitkam){
+                psimpl::simplify_reumann_witkam<2>(polyline.begin(), polyline.end(), tolerance(),
+                                                std::back_inserter(result));
+            }
+            else{
+                psimpl::simplify_douglas_peucker<2>(polyline.begin(), polyline.end(), tolerance(),
+                                                std::back_inserter(result));
+            }
 
             Polygon newPolygon;
             for (unsigned int n = 0, end = result.size(); n < end; n += 2) {

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -674,6 +674,7 @@ const QString Constants::ProfileSettings::GCode::kSupportEnd = "support_end_code
 
 // Special Modes
 const QString Constants::ProfileSettings::SpecialModes::kSmoothing = "smoothing";
+const QString Constants::ProfileSettings::SpecialModes::kSmoothingType = "smoothing_type";
 const QString Constants::ProfileSettings::SpecialModes::kSmoothingTolerance = "smoothing_tolerance";
 const QString Constants::ProfileSettings::SpecialModes::kEnableSpiralize = "enable_spiralize_mode";
 const QString Constants::ProfileSettings::SpecialModes::kEnableFixModel = "enable_fix_model";


### PR DESCRIPTION
## Summary
- Add a profile setting for selecting the smoothing algorithm.
- Add `SmoothingType` enum values for Douglas Peucker, Radial Distance, Perpendicular Distance, and Reumann-Witkam.
- Dispatch polygon smoothing through the selected psimpl algorithm while preserving Douglas Peucker as the default/fallback behavior.

## Impact
Users can choose the smoothing strategy from Profile > Special Modes when smoothing is enabled.

## Validation
- `cmake --build --preset debug-generic-llvm-ninja`