### PR TITLE
feat: add arc reverse

### DIFF
--- a/include/geometry/segments/arc.h
+++ b/include/geometry/segments/arc.h
@@ -61,6 +61,9 @@ class ArcSegment : public SegmentBase {
     //! \brief Write the gcode for an arc.
     QString writeGCode(QSharedPointer<WriterBase> writer) override;
 
+    //! \brief Reverse direction of the arc.
+    void reverse() override;
+
     //! \brief returns minimum z-coordinate of the arc
     float getMinZ() override;
 

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -41,7 +41,7 @@
   "supports_G2_3": {
       "display":"Supports G2/G3",
       "type":"boolean",
-      "tooltip":"If selected, machine will use G2/G3 for spiral lift commands.  Otherwise, the spiral will be comprised of G1s.",
+      "tooltip":"If selected, machine will use G2/G3 for supported arc moves. Otherwise, those moves will be comprised of G1s.",
       "depends":"",
       "options":"",
       "default":false,

--- a/resources/settings/001_printer_machine_setup.yaml
+++ b/resources/settings/001_printer_machine_setup.yaml
@@ -79,7 +79,7 @@ settings:
   - name: "supports_G2_3"
     display: "Supports G2/G3"
     type: "boolean"
-    tooltip: "If selected, machine will use G2/G3 for spiral lift commands.  Otherwise, the spiral will be comprised of G1s."
+    tooltip: "If selected, machine will use G2/G3 for supported arc moves. Otherwise, those moves will be comprised of G1s."
     depends: {}
     options: []
     default: false

--- a/src/geometry/segments/arc.cpp
+++ b/src/geometry/segments/arc.cpp
@@ -76,6 +76,12 @@ QString ArcSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     return writer->writeArc(m_start, m_end, m_center, m_angle, m_ccw, this->getSb());
 }
 
+void ArcSegment::reverse() {
+    SegmentBase::reverse();
+    m_ccw = !m_ccw;
+    updateAngle();
+}
+
 float ArcSegment::getMinZ() {
     // might not actually be correct
     if (m_start.z() < m_end.z())


### PR DESCRIPTION
## Summary

Adds reverse handling for `ArcSegment` so reversed arc paths preserve the correct clockwise/counterclockwise direction, and updates the `Supports G2/G3` tooltip to describe supported arc moves more generally.

## Related issues

- No related issues.

## Details

`ArcSegment` now overrides `SegmentBase::reverse()`. The implementation swaps the segment endpoints through the base behavior, flips the stored arc direction, and recalculates the arc angle so downstream geometry and G-code generation see the reversed arc consistently.

This also updates the `supports_G2_3` tooltip in both generated config sources:
- `resources/configs/master.conf`
- `resources/settings/001_printer_machine_setup.yaml`

The wording now applies to supported arc moves broadly instead of only spiral lift commands.

## Impact

Risk level: Low.

The behavioral change is limited to reversing arc segments. Existing linear segment reversal is unchanged, and arc writing still flows through the existing `writer->writeArc(...)` path. The config text change only affects user-facing tooltip wording.

## Testing strategy

Built and sliced a project with arcs locally.