### PR TITLE
Rename PolymerSlicer to PlanarSlicer

### DIFF
--- a/include/managers/session_manager.h
+++ b/include/managers/session_manager.h
@@ -176,7 +176,7 @@ class SessionManager : public QObject {
     bool isBuildMode();
 
     //! \brief Signals the internal slicing thread to begin computation.
-    //! \note If the internal slicing thread is unset, this function assumes that it should be a polymer slice.
+    //! \note If the internal slicing thread is unset, this function assumes that it should be a planar slice.
     bool doSlice();
 
     //! \brief Signals the internal slicing thread has complete computation.
@@ -186,8 +186,6 @@ class SessionManager : public QObject {
     qint64 getSliceTimeElapsed();
 
     //! \brief Changes which slicer is used for computation.
-    //! \todo Currently, there is only one slicer (the PolymerSlicer). When more methods are added, more Slicer types
-    //! should be added
     //!       Both here and in the SlicerType enum. A dialog still needs to be written to run this function.
     bool changeSlicer(SlicerType type);
 
@@ -301,8 +299,8 @@ class SessionManager : public QObject {
     //! \brief bool to track whether additional files need to be considered for export
     bool m_sensor_files_generated;
 
-    //! \brief default slicer is polymer
-    SlicerType m_slicer_type = SlicerType::kPolymerSlice;
+    //! \brief default slicer is planar
+    SlicerType m_slicer_type = SlicerType::kPlanarSlice;
 
     //! \brief Mutex to serialize final step of loading parts.  Map of parts
     //! must be accessed sequentially.

--- a/include/threading/slicers/planar_slicer.h
+++ b/include/threading/slicers/planar_slicer.h
@@ -14,12 +14,12 @@
 
 namespace ORNL {
 /*!
- * \class PolymerSlicer
- * \brief Implementation of SlicingThread for polymer slices.
+ * \class PlanarSlicer
+ * \brief Implementation of SlicingThread for planar slices.
  */
-class PolymerSlicer : public TraditionalAST {
+class PlanarSlicer : public TraditionalAST {
   public:
-    PolymerSlicer(QString gcodeLocation);
+    PlanarSlicer(QString gcodeLocation);
 
   protected:
     //! \brief Creates layer steps by performing cross-sections.

--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -47,8 +47,8 @@ enum class BuildVolumeType : uint8_t { kRectangular = 0, kCylindrical = 1 };
  * @brief Selects the type of slice to perform. Pass this to Session Manager to decide.
  */
 enum class SlicerType : uint8_t {
-    //! @brief Standard polymer planar slicing.
-    kPolymerSlice = 0,
+    //! @brief Standard planar slicing.
+    kPlanarSlice = 0,
 
     //! @brief Image-based slicing workflow.
     kImageSlice = 1,

--- a/include/windows/main_window.h
+++ b/include/windows/main_window.h
@@ -46,7 +46,7 @@
 
 namespace ORNL {
 
-class PolymerSlicer;
+class PlanarSlicer;
 class SessionLoader;
 
 //! \brief Define for quick access to this singleton.

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -3332,7 +3332,7 @@
       "type":"enumeration",
       "tooltip":"Selects the slicing engine to use",
       "depends":"",
-      "options":"Polymer, Image, Radial Slice, Helical Slice",
+      "options":"Planar, Image, Radial Slice, Helical Slice",
       "default":0,
       "minor":"Slicing",
       "major":"Profile",

--- a/resources/settings/019_profile_slicing.yaml
+++ b/resources/settings/019_profile_slicing.yaml
@@ -7,7 +7,7 @@ settings:
     tooltip: "Selects the slicing engine to use"
     depends: {}
     options:
-      - "Polymer"
+      - "Planar"
       - "Image"
       - "Radial Slice"
       - "Helical Slice"

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -169,7 +169,7 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
         /*
          * Polygon operations that follow cross sectioning are done in 2 dimensions.
          * To allow that, shift and rotate each segment so that the cross-section will be flat in 2D
-         * Polymer_slicer save shift and rotation amount to layer so that this is un-done before gcode writing
+         * PlanarSlicer saves shift and rotation amount to layer so that this is un-done before gcode writing
          */
 
         // Rotate into 2D frame using precomputed shift & rotation

--- a/src/managers/session_manager.cpp
+++ b/src/managers/session_manager.cpp
@@ -30,7 +30,7 @@
 #include "threading/session_loader.h"
 #include "threading/slicers/helical_slicer.h"
 #include "threading/slicers/image_slicer.h"
-#include "threading/slicers/polymer_slicer.h"
+#include "threading/slicers/planar_slicer.h"
 #include "threading/slicers/radial_slicer.h"
 #include "units/derivative_units.h"
 #include "units/unit.h"
@@ -594,8 +594,8 @@ bool SessionManager::changeSlicer(SlicerType type) {
 
     // Reset the AST with a new slicer.
     switch (type) {
-        case SlicerType::kPolymerSlice:
-            m_ast.reset(new PolymerSlicer(tempGcodeFile));
+        case SlicerType::kPlanarSlice:
+            m_ast.reset(new PlanarSlicer(tempGcodeFile));
             break;
         case SlicerType::kImageSlice:
             m_ast.reset(new ImageSlicer(tempGcodeFile));
@@ -607,9 +607,9 @@ bool SessionManager::changeSlicer(SlicerType type) {
             m_ast.reset(new HelicalSlicer(tempGcodeFile));
             break;
         default:
-            qWarning() << "Unknown slicer type requested. Falling back to Polymer slicer.";
-            m_ast.reset(new PolymerSlicer(tempGcodeFile));
-            type = SlicerType::kPolymerSlice;
+            qWarning() << "Unknown slicer type requested. Falling back to Planar slicer.";
+            m_ast.reset(new PlanarSlicer(tempGcodeFile));
+            type = SlicerType::kPlanarSlice;
             break;
     }
 

--- a/src/managers/settings/settings_version_control.cpp
+++ b/src/managers/settings/settings_version_control.cpp
@@ -15,7 +15,7 @@
 namespace {
 constexpr int kCincinnatiSyntax = 1;
 constexpr int kThermwoodSyntax = 16;
-constexpr int kPolymerSlicer = 0;
+constexpr int kPlanarSlicer = 0;
 constexpr int kImageSlicer = 1;
 constexpr int kV3LegacySlicerType2 = 2;
 constexpr int kV3ImageSlicer = 3;
@@ -64,15 +64,15 @@ constexpr std::array<int, 7> kSlicerTypeV2ToV3 = {
     1,                    // Legacy slicer type 1
     2,                    // Legacy slicer type 2
     kV3LegacySlicerType2, // RPBF removed
-    kPolymerSlicer,       // Real Time Polymer removed
+    kPlanarSlicer,        // Real Time Polymer removed
     kV3LegacySlicerType2, // Real Time RPBF removed
     kV3ImageSlicer        // Image
 };
 
 constexpr std::array<int, 4> kSlicerTypeV3ToV4 = {
-    kPolymerSlicer, // Polymer
-    kPolymerSlicer, // Legacy slicer type 1 removed
-    kPolymerSlicer, // Legacy slicer type 2 removed
+    kPlanarSlicer, // Polymer
+    kPlanarSlicer, // Legacy slicer type 1 removed
+    kPlanarSlicer, // Legacy slicer type 2 removed
     kImageSlicer    // Image
 };
 

--- a/src/threading/slicers/planar_slicer.cpp
+++ b/src/threading/slicers/planar_slicer.cpp
@@ -1,5 +1,5 @@
 
-#include "threading/slicers/polymer_slicer.h"
+#include "threading/slicers/planar_slicer.h"
 
 #include <QtCore/QDir>
 #include <QtCore/QSharedPointer>
@@ -37,9 +37,9 @@
 
 namespace ORNL {
 
-PolymerSlicer::PolymerSlicer(QString gcodeLocation) : TraditionalAST(gcodeLocation) {}
+PlanarSlicer::PlanarSlicer(QString gcodeLocation) : TraditionalAST(gcodeLocation) {}
 
-void PolymerSlicer::preProcess(nlohmann::json opt_data) {
+void PlanarSlicer::preProcess(nlohmann::json opt_data) {
     Preprocessor pp;
 
     pp.addInitialProcessing(
@@ -94,7 +94,7 @@ void PolymerSlicer::preProcess(nlohmann::json opt_data) {
                 QVector<PolygonList> split_geometry = next_layer_meta->geometry.splitIntoParts();
 
                 for (const PolygonList& island_geometry : split_geometry) {
-                    // Polymer builds use polymer islands.
+                    // Planar builds use polymer islands.
                     QSharedPointer<PolymerIsland> poly_isl = QSharedPointer<PolymerIsland>::create(
                         island_geometry, next_layer_meta->settings, next_layer_meta->settings_polygons);
                     new_layer->addIsland(IslandType::kPolymer, poly_isl);
@@ -136,7 +136,7 @@ void PolymerSlicer::preProcess(nlohmann::json opt_data) {
 
                     QVector<QSharedPointer<IslandBase>> newIslands;
                     for (const PolygonList& island_geometry : split_geometry) {
-                        // Polymer builds use polymer islands.
+                        // Planar builds use polymer islands.
                         QSharedPointer<PolymerIsland> poly_isl = QSharedPointer<PolymerIsland>::create(
                             island_geometry, next_layer_meta->settings, next_layer_meta->settings_polygons);
                         newIslands.append(poly_isl);
@@ -190,7 +190,7 @@ void PolymerSlicer::preProcess(nlohmann::json opt_data) {
     pp.processAll();
 }
 
-void PolymerSlicer::processSkin(QSharedPointer<Part> part, int part_start, int last_layer_count) {
+void PlanarSlicer::processSkin(QSharedPointer<Part> part, int part_start, int last_layer_count) {
     for (int layer_nr = part_start; layer_nr < last_layer_count; layer_nr++) {
         if (layer_nr < part->countStepPairs()) {
             QSharedPointer<Layer> layer = part->step(layer_nr, StepType::kLayer).dynamicCast<Layer>();
@@ -236,7 +236,7 @@ void PolymerSlicer::processSkin(QSharedPointer<Part> part, int part_start, int l
     }
 }
 
-void PolymerSlicer::processRaft(QSharedPointer<Part> part, int part_start, QSharedPointer<SettingsBase> part_sb) {
+void PlanarSlicer::processRaft(QSharedPointer<Part> part, int part_start, QSharedPointer<SettingsBase> part_sb) {
     if (!part->steps(StepType::kLayer).empty()) {
         if (part_sb->setting<bool>(MS::PlatformAdhesion::kRaftEnable)) {
             int raft_layers = part_sb->setting<int>(MS::PlatformAdhesion::kRaftLayers);
@@ -273,7 +273,7 @@ void PolymerSlicer::processRaft(QSharedPointer<Part> part, int part_start, QShar
     }
 }
 
-void PolymerSlicer::processBrim(QSharedPointer<Part> part, QSharedPointer<SettingsBase> part_sb) {
+void PlanarSlicer::processBrim(QSharedPointer<Part> part, QSharedPointer<SettingsBase> part_sb) {
     if (part_sb->setting<bool>(MS::PlatformAdhesion::kBrimEnable)) {
         QList<QSharedPointer<Step>> steps = part->steps(StepType::kLayer);
         for (int i = 0, end = steps.size(); i < end; ++i) {
@@ -283,7 +283,7 @@ void PolymerSlicer::processBrim(QSharedPointer<Part> part, QSharedPointer<Settin
     }
 }
 
-void PolymerSlicer::processSkirt(QSharedPointer<Part> part, QSharedPointer<SettingsBase> part_sb) {
+void PlanarSlicer::processSkirt(QSharedPointer<Part> part, QSharedPointer<SettingsBase> part_sb) {
     if (part_sb->setting<bool>(MS::PlatformAdhesion::kSkirtEnable)) {
         QList<QSharedPointer<Step>> steps = part->steps(StepType::kLayer);
         for (int i = 0, end = steps.size(); i < end; ++i) {
@@ -293,7 +293,7 @@ void PolymerSlicer::processSkirt(QSharedPointer<Part> part, QSharedPointer<Setti
     }
 }
 
-void PolymerSlicer::processThermalScan(QSharedPointer<Part> part, QSharedPointer<SettingsBase> part_sb) {
+void PlanarSlicer::processThermalScan(QSharedPointer<Part> part, QSharedPointer<SettingsBase> part_sb) {
     if (part_sb->setting<bool>(PS::ThermalScanner::kThermalScanner)) {
         int first_layer = 0;
 
@@ -309,7 +309,7 @@ void PolymerSlicer::processThermalScan(QSharedPointer<Part> part, QSharedPointer
     }
 }
 
-void PolymerSlicer::processLaserScan(QSharedPointer<Part> part, QSharedPointer<SettingsBase> part_sb) {
+void PlanarSlicer::processLaserScan(QSharedPointer<Part> part, QSharedPointer<SettingsBase> part_sb) {
     if (!m_saved_layer_settings.isEmpty() &&
         m_saved_layer_settings.first()->setting<bool>(PS::LaserScanner::kLaserScanner) && !part->steps().isEmpty()) {
         if (m_saved_layer_settings.first()->setting<bool>(PS::LaserScanner::kLaserScanner)) {
@@ -343,7 +343,7 @@ void PolymerSlicer::processLaserScan(QSharedPointer<Part> part, QSharedPointer<S
     }
 }
 
-void PolymerSlicer::processGlobalLayers(QVector<QSharedPointer<Part>> parts,
+void PlanarSlicer::processGlobalLayers(QVector<QSharedPointer<Part>> parts,
                                         const QSharedPointer<SettingsBase>& settings) {
     if (anythingDirty()) {
         // create global layers from all the part layers
@@ -351,7 +351,7 @@ void PolymerSlicer::processGlobalLayers(QVector<QSharedPointer<Part>> parts,
     }
 }
 
-bool PolymerSlicer::anythingDirty() {
+bool PlanarSlicer::anythingDirty() {
     bool anything_dirty = false;
     for (QSharedPointer<Part> curr_part : CSM->parts().values()) {
         if (curr_part->isPartDirty()) {
@@ -373,7 +373,7 @@ bool PolymerSlicer::anythingDirty() {
 // The calculated overhang is then applied to layer #N
 // Get the overlap between the overhang and (layer #N with xy_offset)
 // If the overlap > 0, remove the overlap from the overhang, and add the result to layer #N
-void PolymerSlicer::processSupport(QSharedPointer<Part> part, int layer_count, int partStart) {
+void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, int partStart) {
     if (!part->steps().isEmpty()) {
         auto part_sb = QSharedPointer<SettingsBase>::create(*GSM->getGlobal()); // Copy global
         part_sb->populate(part->getSb());                                       // Fill with part overrides
@@ -517,7 +517,7 @@ void PolymerSlicer::processSupport(QSharedPointer<Part> part, int layer_count, i
     }
 }
 
-void PolymerSlicer::postProcess(nlohmann::json opt_data) {
+void PlanarSlicer::postProcess(nlohmann::json opt_data) {
     if (anythingDirty()) {
         QSharedPointer<SettingsBase> global_sb = QSharedPointer<SettingsBase>::create(*GSM->getGlobal());
         global_sb->makeGlobalAdjustments();
@@ -549,7 +549,7 @@ void PolymerSlicer::postProcess(nlohmann::json opt_data) {
     }
 }
 
-void PolymerSlicer::writeGCode() {
+void PlanarSlicer::writeGCode() {
     QTextStream stream(&m_temp_gcode_output_file);
 
     // for updating status window


### PR DESCRIPTION
## Summary

Renames the planar slicing implementation from `PolymerSlicer` to `PlanarSlicer` across the codebase.

## Changes

- Renamed `polymer_slicer.{h,cpp}` to `planar_slicer.{h,cpp}`.
- Updated class names, constructor definitions, include paths, and session manager construction sites.
- Renamed the default slicer enum value from `kPolymerSlice` to `kPlanarSlice` while preserving numeric value `0` for existing settings compatibility.
- Updated the user-facing slicer option label from `Polymer` to `Planar` in canonical settings metadata and generated master config.

## Impact

This keeps the default planar slicing path behaviorally equivalent while making the naming more accurate. Existing persisted slicer values continue to map to the same numeric setting.

## Validation

- `nix develop --command cmake --preset generic-llvm-ninja`
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer`