### PR TITLE
CMake Updates for Generating Windows Installers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ function(FindDependencies)
         message(WARNING "OpenMP NOT found, the build will not be optimized.")
     endif()
 
+    set(OPENCASCADE_LIBRARIES TKDESTEP TKMesh)
+
     set(RESULT_VAR "")
     list(
         APPEND RESULT_VAR
@@ -99,7 +101,7 @@ function(FindDependencies)
         Eigen3::Eigen
         CGAL::Eigen3_support
         nlohmann_json::nlohmann_json
-        ${OpenCASCADE_LIBRARIES}
+        ${OPENCASCADE_LIBRARIES}
         ornl::psimpl
         ornl::polyclipping
         zip::zip
@@ -297,6 +299,8 @@ include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME})
 if(WIN32)
     install(TARGETS ${PROJECT_NAME}_cli)
+    install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}_cli> DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 install(FILES ${CMAKE_CURRENT_LIST_DIR}/docs/ornlslicer-user-guide.pdf DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "major":  "2",
-    "minor":  "0",
+    "minor":  "1",
     "patch":  "0",
     "suffix": ""
 }


### PR DESCRIPTION
## Summary

- Link ORNLSlicer against only the OpenCASCADE toolkits needed for STEP import and meshing instead of the full OpenCASCADE library list.
- Install Windows runtime DLLs discovered from the `ornlslicer` and `ornlslicer_cli` targets during CMake install.

## Why

The Windows installer artifacts began missing OpenCASCADE runtime DLLs after STEP import support was added. Linking every OpenCASCADE toolkit also makes the build/install surface broader than this feature needs. This keeps the app focused on `TKDESTEP` and `TKMesh`, then lets CMake collect the runtime DLLs required by the actual executable targets.

## Validation

- `git diff --check`
- `nix eval --raw .#windows.ornl.ornlslicer.drvPath`
- `nix build --dry-run .#windows.ornl.ornlslicer --accept-flake-config`
- `nix develop --accept-flake-config --command cmake -S . -B /tmp/ornlslicer-cmake-check -G Ninja -DORNLSLICER_AUTO_GENERATE_MASTER_CONFIG=OFF`

## Notes

The Windows-only `$<TARGET_RUNTIME_DLLS:...>` install behavior still needs confirmation from the GitHub Actions Windows installer artifact on a clean Windows machine or VM.