### PR TITLE
Add Spiral Perimeter Functionality

### DIFF
--- a/include/geometry/spiral_path.h
+++ b/include/geometry/spiral_path.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <qcontainerfwd.h>
+
+#include "geometry/point.h"
+#include "geometry/polyline.h"
+#include "units/unit.h"
+#include "utilities/mathutils.h"
+
+namespace ORNL {
+namespace SpiralPath {
+namespace detail {
+inline Point pointAlongSegment(const Point& start, const Point& end, double ratio) {
+    return Point(start.x() + ((end.x() - start.x()) * ratio), start.y() + ((end.y() - start.y()) * ratio),
+                 start.z() + ((end.z() - start.z()) * ratio));
+}
+
+inline Point stopPointOnClosingSegment(const Polyline& line, Distance distance_before_start) {
+    if (line.isEmpty()) {
+        return Point();
+    }
+
+    const Point segment_start = line.back();
+    const Point segment_end = line.front();
+    const Distance segment_length = segment_start.distance(segment_end);
+
+    if (segment_length <= distance_before_start) {
+        return segment_start;
+    }
+
+    const double ratio = (segment_length() - distance_before_start()) / segment_length();
+    return pointAlongSegment(segment_start, segment_end, ratio);
+}
+
+inline bool hasSmoothClosingSegment(const Polyline& line) {
+    if (line.size() < 3) {
+        return false;
+    }
+
+    return MathUtils::nearCollinear(line[line.size() - 2], line.back(), line.front(), 45 * deg);
+}
+} // namespace detail
+
+/*!
+ * \brief Returns the length of a polyline treated as a closed loop.
+ */
+inline Distance closedPolylineLength(const Polyline& line) {
+    if (line.size() < 2) {
+        return 0;
+    }
+
+    return line.length() + line.back().distance(line.front());
+}
+
+/*!
+ * \brief Links ordered closed loops into one open spiral-style polyline.
+ *
+ * \param ordered_loops Closed loops without a repeated final point.
+ * \param final_stop_distance Distance to leave unprinted before the loop start when closing smoothly.
+ * \return One polyline that walks each loop and transitions to the next loop before fully closing.
+ */
+inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Distance final_stop_distance) {
+    Polyline spiral;
+
+    for (int loop_index = 0, end = ordered_loops.size(); loop_index < end; ++loop_index) {
+        const Polyline& loop = ordered_loops[loop_index];
+        if (loop.size() < 3) {
+            continue;
+        }
+
+        spiral += loop;
+
+        if (loop_index + 1 < end) {
+            const Point next_start = ordered_loops[loop_index + 1].front();
+            Point connector_start;
+            if (detail::hasSmoothClosingSegment(loop)) {
+                connector_start = detail::stopPointOnClosingSegment(loop, final_stop_distance);
+            }
+            else {
+                connector_start = MathUtils::nearestPointOnSegment(loop.back(), loop.front(), next_start).first;
+            }
+
+            if (spiral.back() != connector_start) {
+                spiral += connector_start;
+            }
+        }
+        else {
+            const Point final_stop = detail::stopPointOnClosingSegment(loop, final_stop_distance);
+
+            if (spiral.back() != final_stop) {
+                spiral += final_stop;
+            }
+        }
+    }
+
+    return spiral;
+}
+} // namespace SpiralPath
+} // namespace ORNL

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -616,6 +616,7 @@ class Constants {
             static const QString kEnableFlyingStart;
             static const QString kFlyingStartDistance;
             static const QString kFlyingStartSpeed;
+            static const QString kEnableSpiralPerimeter;
         };
 
         class Inset {

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -630,6 +630,7 @@ class Constants {
             static const QString kExtrusionMultiplier;
             static const QString kMinPathLength;
             static const QString kOverlap;
+            static const QString kEnableSpiralInset;
         };
 
         class Skeleton {

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -3834,6 +3834,19 @@
       "symbol":"kInsetOverlapDistance",
       "local":true
   },
+  "spiral_inset": {
+      "display":"Enable Spiral Inset",
+      "type":"boolean",
+      "tooltip":"If selected, spiral insets will be generated",
+      "depends":{"inset":true},
+      "options":"",
+      "default":false,
+      "minor":"Inset",
+      "major":"Profile",
+      "namespace":"Profile::Inset",
+      "symbol":"kEnableSpiralInset",
+      "local":true
+  },
   "skeleton": {
       "display":"Enable Skeletons",
       "type":"boolean",

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -3717,6 +3717,19 @@
       "symbol":"kPerimeterFlyingStartSpeed",
       "local":true
   },
+  "spiral_perimeter": {
+      "display":"Enable Spiral Perimeter",
+      "type":"boolean",
+      "tooltip":"If selected, spiral perimeters will be generated",
+      "depends":{"perimeter":true},
+      "options":"",
+      "default":false,
+      "minor":"Perimeter",
+      "major":"Profile",
+      "namespace":"Profile::Perimeter",
+      "symbol":"kEnableSpiralPerimeter",
+      "local":true
+  },
   "inset": {
       "display":"Enable Inset",
       "type":"boolean",

--- a/resources/settings/021_profile_perimeter.yaml
+++ b/resources/settings/021_profile_perimeter.yaml
@@ -184,3 +184,15 @@ settings:
     namespace: "Profile::Perimeter"
     symbol: "kPerimeterFlyingStartSpeed"
     local: true
+  - name: "spiral_perimeter"
+    display: "Enable Spiral Perimeter"
+    type: "boolean"
+    tooltip: "If selected, spiral perimeters will be generated"
+    depends: {"perimeter":true}
+    options: []
+    default: false
+    minor: "Perimeter"
+    major: "Profile"
+    namespace: "Profile::Perimeter"
+    symbol: "kEnableSpiralPerimeter"
+    local: true

--- a/resources/settings/022_profile_inset.yaml
+++ b/resources/settings/022_profile_inset.yaml
@@ -97,3 +97,15 @@ settings:
     namespace: "Profile::Inset"
     symbol: "kInsetOverlapDistance"
     local: true
+  - name: "spiral_inset"
+    display: "Enable Spiral Inset"
+    type: "boolean"
+    tooltip: "If selected, spiral insets will be generated"
+    depends: {"inset":true}
+    options: []
+    default: false
+    minor: "Inset"
+    major: "Profile"
+    namespace: "Profile::Inset"
+    symbol: "kEnableSpiralInset"
+    local: true

--- a/src/step/layer/regions/inset.cpp
+++ b/src/step/layer/regions/inset.cpp
@@ -18,6 +18,7 @@
 #include "geometry/segment_base.h"
 #include "geometry/segments/line.h"
 #include "geometry/settings_polygon.h"
+#include "geometry/spiral_path.h"
 #include "optimizers/polyline_order_optimizer.h"
 #include "step/layer/regions/region_base.h"
 #include "units/unit.h"
@@ -75,33 +76,37 @@ void Inset::compute(uint layer_num) {
 }
 
 void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextPathBeCCW) {
-    PolylineOrderOptimizer poo(current_location, layerNumber);
-
     PathOrderOptimization pathOrderOptimization =
         static_cast<PathOrderOptimization>(this->getSb()->setting<int>(PS::Optimizations::kPathOrder));
-    if (pathOrderOptimization == PathOrderOptimization::kCustomPoint) {
-        Point startOverride(getSb()->setting<double>(PS::Optimizations::kCustomPathXLocation),
-                            getSb()->setting<double>(PS::Optimizations::kCustomPathYLocation));
-
-        poo.setStartOverride(startOverride);
-    }
 
     PointOrderOptimization pointOrderOptimization =
         static_cast<PointOrderOptimization>(this->getSb()->setting<int>(PS::Optimizations::kPointOrder));
 
-    if (pointOrderOptimization == PointOrderOptimization::kCustomPoint) {
-        Point startOverride(getSb()->setting<double>(PS::Optimizations::kCustomPointXLocation),
-                            getSb()->setting<double>(PS::Optimizations::kCustomPointYLocation));
+    auto configureOptimizer = [&](PolylineOrderOptimizer& optimizer, PointOrderOptimization point_order) {
+        if (pathOrderOptimization == PathOrderOptimization::kCustomPoint) {
+            Point startOverride(getSb()->setting<double>(PS::Optimizations::kCustomPathXLocation),
+                                getSb()->setting<double>(PS::Optimizations::kCustomPathYLocation));
 
-        poo.setStartPointOverride(startOverride);
-    }
+            optimizer.setStartOverride(startOverride);
+        }
 
-    poo.setPointParameters(pointOrderOptimization, getSb()->setting<bool>(PS::Optimizations::kMinDistanceEnabled),
-                           getSb()->setting<Distance>(PS::Optimizations::kMinDistanceThreshold),
-                           getSb()->setting<Distance>(PS::Optimizations::kConsecutiveDistanceThreshold),
-                           getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
-                           getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
-                           getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+        if (point_order == PointOrderOptimization::kCustomPoint) {
+            Point startOverride(getSb()->setting<double>(PS::Optimizations::kCustomPointXLocation),
+                                getSb()->setting<double>(PS::Optimizations::kCustomPointYLocation));
+
+            optimizer.setStartPointOverride(startOverride);
+        }
+
+        optimizer.setPointParameters(point_order, getSb()->setting<bool>(PS::Optimizations::kMinDistanceEnabled),
+                                     getSb()->setting<Distance>(PS::Optimizations::kMinDistanceThreshold),
+                                     getSb()->setting<Distance>(PS::Optimizations::kConsecutiveDistanceThreshold),
+                                     getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
+                                     getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
+                                     getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+    };
+
+    PolylineOrderOptimizer poo(current_location, layerNumber);
+    configureOptimizer(poo, pointOrderOptimization);
 
     m_paths.clear();
 
@@ -110,6 +115,65 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
         for (Polyline& line : m_computed_geometry) {
             line = line.reverse();
         }
+    }
+
+    if (m_sb->setting<bool>(PS::Inset::kEnableSpiralInset)) {
+        Point spiral_query_location = current_location;
+        PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
+        configureOptimizer(spiral_poo, pointOrderOptimization);
+        spiral_poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kInset, pathOrderOptimization);
+
+        QVector<Polyline> ordered_insets;
+        const Distance min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
+
+        while (spiral_poo.getCurrentPolylineCount() > 0) {
+            if (!ordered_insets.isEmpty()) {
+                spiral_poo.setPointParameters(PointOrderOptimization::kNextClosest, false, 0, 0, false, 0, true);
+            }
+
+            Polyline result = spiral_poo.linkNextPolyline();
+
+            if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
+                continue;
+            }
+
+            // Keep loop choice near the local seam to avoid jumping across the island on the next transition.
+            spiral_query_location = result.front();
+            ordered_insets.push_back(result);
+        }
+
+        if (ordered_insets.isEmpty()) {
+            return;
+        }
+
+        Polyline result =
+            SpiralPath::linkClosedPolylines(ordered_insets, m_sb->setting<Distance>(PS::Inset::kBeadWidth));
+
+        if (result.size() < 3) {
+            return;
+        }
+
+        Path newPath = createPath(result);
+        newPath.setCCW(ordered_insets.front().orientation());
+
+        if (newPath.size() > 0) {
+            newPath.getSegments().removeLast();
+        }
+
+        if (newPath.calculateLength() < min_path_length) {
+            return;
+        }
+
+        if (newPath.size() > 0) {
+            calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+            PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                  m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+            current_location = newPath.back()->end();
+            m_paths.push_back(newPath);
+        }
+
+        return;
     }
 
     poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kInset,

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -23,6 +23,7 @@
 #include "units/unit.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
+#include "utilities/mathutils.h"
 
 namespace ORNL {
 namespace {
@@ -45,6 +46,94 @@ PolygonList selectedBoundaryOffsetGeometry(const PolygonList& external_boundarie
     PolygonList offset_geometry = offset_external_geometry - internal_boundaries;
     offset_geometry.lost_geometry = offset_external_geometry.lost_geometry;
     return offset_geometry;
+}
+
+Distance closedPolylineLength(const Polyline& line) {
+    if (line.size() < 2) {
+        return 0;
+    }
+
+    return line.length() + line.back().distance(line.front());
+}
+
+Point pointAlongSegment(const Point& start, const Point& end, double ratio) {
+    return Point(start.x() + ((end.x() - start.x()) * ratio), start.y() + ((end.y() - start.y()) * ratio),
+                 start.z() + ((end.z() - start.z()) * ratio));
+}
+
+Point pointBeforeClosedPolylineStart(const Polyline& line, Distance distance_before_start) {
+    if (line.isEmpty()) {
+        return Point();
+    }
+
+    Point segment_end = line.front();
+    Distance remaining_distance = distance_before_start;
+
+    for (int i = line.size() - 1; i >= 0; --i) {
+        const Point segment_start = line[i];
+        const Distance segment_length = segment_start.distance(segment_end);
+
+        if (segment_length > 0) {
+            if (remaining_distance <= segment_length) {
+                const double ratio = (segment_length() - remaining_distance()) / segment_length();
+                return pointAlongSegment(segment_start, segment_end, ratio);
+            }
+
+            remaining_distance -= segment_length;
+        }
+
+        segment_end = segment_start;
+    }
+
+    return line.front();
+}
+
+bool hasSmoothClosingSegment(const Polyline& line) {
+    if (line.size() < 3) {
+        return false;
+    }
+
+    return MathUtils::nearCollinear(line[line.size() - 2], line.back(), line.front(), 45 * deg);
+}
+
+Polyline buildSpiralPerimeterPolyline(const QVector<Polyline>& ordered_perimeters, Distance final_stop_distance) {
+    Polyline spiral;
+
+    for (int perimeter_index = 0, end = ordered_perimeters.size(); perimeter_index < end; ++perimeter_index) {
+        const Polyline& perimeter = ordered_perimeters[perimeter_index];
+        if (perimeter.size() < 3) {
+            continue;
+        }
+
+        spiral += perimeter;
+
+        if (perimeter_index + 1 < end) {
+            const Point next_start = ordered_perimeters[perimeter_index + 1].front();
+            Point connector_start;
+            if (hasSmoothClosingSegment(perimeter)) {
+                connector_start = pointBeforeClosedPolylineStart(perimeter, final_stop_distance);
+            }
+            else {
+                auto [projected_connector_start, distance] =
+                    MathUtils::nearestPointOnSegment(perimeter.back(), perimeter.front(), next_start);
+                Q_UNUSED(distance)
+                connector_start = projected_connector_start;
+            }
+
+            if (spiral.back() != connector_start) {
+                spiral += connector_start;
+            }
+        }
+        else {
+            const Point final_stop = pointBeforeClosedPolylineStart(perimeter, final_stop_distance);
+
+            if (spiral.back() != final_stop) {
+                spiral += final_stop;
+            }
+        }
+    }
+
+    return spiral;
 }
 } // namespace
 
@@ -117,33 +206,37 @@ void Perimeter::compute(uint layer_num) {
 void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldNextPathBeCCW) {
     Q_UNUSED(shouldNextPathBeCCW)
 
-    PolylineOrderOptimizer poo(current_location, layerNumber);
-
     PathOrderOptimization pathOrderOptimization =
         static_cast<PathOrderOptimization>(this->getSb()->setting<int>(PS::Optimizations::kPathOrder));
-    if (pathOrderOptimization == PathOrderOptimization::kCustomPoint) {
-        Point startOverride(getSb()->setting<double>(PS::Optimizations::kCustomPathXLocation),
-                            getSb()->setting<double>(PS::Optimizations::kCustomPathYLocation));
-
-        poo.setStartOverride(startOverride);
-    }
 
     PointOrderOptimization pointOrderOptimization =
         static_cast<PointOrderOptimization>(this->getSb()->setting<int>(PS::Optimizations::kPointOrder));
 
-    if (pointOrderOptimization == PointOrderOptimization::kCustomPoint) {
-        Point startOverride(getSb()->setting<double>(PS::Optimizations::kCustomPointXLocation),
-                            getSb()->setting<double>(PS::Optimizations::kCustomPointYLocation));
+    auto configureOptimizer = [&](PolylineOrderOptimizer& optimizer, PointOrderOptimization point_order) {
+        if (pathOrderOptimization == PathOrderOptimization::kCustomPoint) {
+            Point startOverride(getSb()->setting<double>(PS::Optimizations::kCustomPathXLocation),
+                                getSb()->setting<double>(PS::Optimizations::kCustomPathYLocation));
 
-        poo.setStartPointOverride(startOverride);
-    }
+            optimizer.setStartOverride(startOverride);
+        }
 
-    poo.setPointParameters(pointOrderOptimization, getSb()->setting<bool>(PS::Optimizations::kMinDistanceEnabled),
-                           getSb()->setting<Distance>(PS::Optimizations::kMinDistanceThreshold),
-                           getSb()->setting<Distance>(PS::Optimizations::kConsecutiveDistanceThreshold),
-                           getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
-                           getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
-                           getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+        if (point_order == PointOrderOptimization::kCustomPoint) {
+            Point startOverride(getSb()->setting<double>(PS::Optimizations::kCustomPointXLocation),
+                                getSb()->setting<double>(PS::Optimizations::kCustomPointYLocation));
+
+            optimizer.setStartPointOverride(startOverride);
+        }
+
+        optimizer.setPointParameters(point_order, getSb()->setting<bool>(PS::Optimizations::kMinDistanceEnabled),
+                                     getSb()->setting<Distance>(PS::Optimizations::kMinDistanceThreshold),
+                                     getSb()->setting<Distance>(PS::Optimizations::kConsecutiveDistanceThreshold),
+                                     getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
+                                     getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
+                                     getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+    };
+
+    PolylineOrderOptimizer poo(current_location, layerNumber);
+    configureOptimizer(poo, pointOrderOptimization);
 
     m_paths.clear();
 
@@ -188,6 +281,65 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
             for (Polyline& line : m_computed_geometry) {
                 line = line.reverse();
             }
+
+        if (m_sb->setting<bool>(PS::Perimeter::kEnableSpiralPerimeter)) {
+            Point spiral_query_location = current_location;
+            PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
+            configureOptimizer(spiral_poo, pointOrderOptimization);
+            spiral_poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kPerimeter, pathOrderOptimization);
+
+            QVector<Polyline> ordered_perimeters;
+            const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
+
+            while (spiral_poo.getCurrentPolylineCount() > 0) {
+                if (!ordered_perimeters.isEmpty()) {
+                    spiral_poo.setPointParameters(PointOrderOptimization::kNextClosest, false, 0, 0, false, 0, true);
+                }
+
+                Polyline result = spiral_poo.linkNextPolyline();
+
+                if (result.size() < 3 || closedPolylineLength(result) < min_path_length) {
+                    continue;
+                }
+
+                // Keep loop choice near the local seam to avoid jumping across the island on the next transition.
+                spiral_query_location = result.front();
+                ordered_perimeters.push_back(result);
+            }
+
+            if (ordered_perimeters.isEmpty()) {
+                return;
+            }
+
+            Polyline result =
+                buildSpiralPerimeterPolyline(ordered_perimeters, m_sb->setting<Distance>(PS::Perimeter::kBeadWidth));
+
+            if (result.size() < 3) {
+                return;
+            }
+
+            Path newPath = createPath(result);
+            newPath.setCCW(ordered_perimeters.front().orientation());
+
+            if (newPath.size() > 0) {
+                newPath.getSegments().removeLast();
+            }
+
+            if (newPath.calculateLength() < min_path_length) {
+                return;
+            }
+
+            if (newPath.size() > 0) {
+                calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+                PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                      m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+                current_location = newPath.back()->end();
+                m_paths.push_back(newPath);
+            }
+
+            return;
+        }
 
         poo.setGeometryToEvaluate(
             m_computed_geometry, RegionType::kPerimeter,

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -18,12 +18,12 @@
 #include "geometry/segment_base.h"
 #include "geometry/segments/line.h"
 #include "geometry/settings_polygon.h"
+#include "geometry/spiral_path.h"
 #include "optimizers/polyline_order_optimizer.h"
 #include "step/layer/regions/region_base.h"
 #include "units/unit.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
-#include "utilities/mathutils.h"
 
 namespace ORNL {
 namespace {
@@ -46,84 +46,6 @@ PolygonList selectedBoundaryOffsetGeometry(const PolygonList& external_boundarie
     PolygonList offset_geometry = offset_external_geometry - internal_boundaries;
     offset_geometry.lost_geometry = offset_external_geometry.lost_geometry;
     return offset_geometry;
-}
-
-Distance closedPolylineLength(const Polyline& line) {
-    if (line.size() < 2) {
-        return 0;
-    }
-
-    return line.length() + line.back().distance(line.front());
-}
-
-Point pointAlongSegment(const Point& start, const Point& end, double ratio) {
-    return Point(start.x() + ((end.x() - start.x()) * ratio), start.y() + ((end.y() - start.y()) * ratio),
-                 start.z() + ((end.z() - start.z()) * ratio));
-}
-
-Point stopPointOnClosingSegment(const Polyline& line, Distance distance_before_start) {
-    if (line.isEmpty()) {
-        return Point();
-    }
-
-    const Point segment_start = line.back();
-    const Point segment_end = line.front();
-    const Distance segment_length = segment_start.distance(segment_end);
-
-    if (segment_length <= distance_before_start) {
-        return segment_start;
-    }
-
-    const double ratio = (segment_length() - distance_before_start()) / segment_length();
-    return pointAlongSegment(segment_start, segment_end, ratio);
-}
-
-bool hasSmoothClosingSegment(const Polyline& line) {
-    if (line.size() < 3) {
-        return false;
-    }
-
-    return MathUtils::nearCollinear(line[line.size() - 2], line.back(), line.front(), 45 * deg);
-}
-
-Polyline buildSpiralPerimeterPolyline(const QVector<Polyline>& ordered_perimeters, Distance final_stop_distance) {
-    Polyline spiral;
-
-    for (int perimeter_index = 0, end = ordered_perimeters.size(); perimeter_index < end; ++perimeter_index) {
-        const Polyline& perimeter = ordered_perimeters[perimeter_index];
-        if (perimeter.size() < 3) {
-            continue;
-        }
-
-        spiral += perimeter;
-
-        if (perimeter_index + 1 < end) {
-            const Point next_start = ordered_perimeters[perimeter_index + 1].front();
-            Point connector_start;
-            if (hasSmoothClosingSegment(perimeter)) {
-                connector_start = stopPointOnClosingSegment(perimeter, final_stop_distance);
-            }
-            else {
-                auto [projected_connector_start, distance] =
-                    MathUtils::nearestPointOnSegment(perimeter.back(), perimeter.front(), next_start);
-                Q_UNUSED(distance)
-                connector_start = projected_connector_start;
-            }
-
-            if (spiral.back() != connector_start) {
-                spiral += connector_start;
-            }
-        }
-        else {
-            const Point final_stop = stopPointOnClosingSegment(perimeter, final_stop_distance);
-
-            if (spiral.back() != final_stop) {
-                spiral += final_stop;
-            }
-        }
-    }
-
-    return spiral;
 }
 } // namespace
 
@@ -288,7 +210,7 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 
                 Polyline result = spiral_poo.linkNextPolyline();
 
-                if (result.size() < 3 || closedPolylineLength(result) < min_path_length) {
+                if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
                     continue;
                 }
 
@@ -302,7 +224,7 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
             }
 
             Polyline result =
-                buildSpiralPerimeterPolyline(ordered_perimeters, m_sb->setting<Distance>(PS::Perimeter::kBeadWidth));
+                SpiralPath::linkClosedPolylines(ordered_perimeters, m_sb->setting<Distance>(PS::Perimeter::kBeadWidth));
 
             if (result.size() < 3) {
                 return;

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -61,31 +61,21 @@ Point pointAlongSegment(const Point& start, const Point& end, double ratio) {
                  start.z() + ((end.z() - start.z()) * ratio));
 }
 
-Point pointBeforeClosedPolylineStart(const Polyline& line, Distance distance_before_start) {
+Point stopPointOnClosingSegment(const Polyline& line, Distance distance_before_start) {
     if (line.isEmpty()) {
         return Point();
     }
 
-    Point segment_end = line.front();
-    Distance remaining_distance = distance_before_start;
+    const Point segment_start = line.back();
+    const Point segment_end = line.front();
+    const Distance segment_length = segment_start.distance(segment_end);
 
-    for (int i = line.size() - 1; i >= 0; --i) {
-        const Point segment_start = line[i];
-        const Distance segment_length = segment_start.distance(segment_end);
-
-        if (segment_length > 0) {
-            if (remaining_distance <= segment_length) {
-                const double ratio = (segment_length() - remaining_distance()) / segment_length();
-                return pointAlongSegment(segment_start, segment_end, ratio);
-            }
-
-            remaining_distance -= segment_length;
-        }
-
-        segment_end = segment_start;
+    if (segment_length <= distance_before_start) {
+        return segment_start;
     }
 
-    return line.front();
+    const double ratio = (segment_length() - distance_before_start()) / segment_length();
+    return pointAlongSegment(segment_start, segment_end, ratio);
 }
 
 bool hasSmoothClosingSegment(const Polyline& line) {
@@ -111,7 +101,7 @@ Polyline buildSpiralPerimeterPolyline(const QVector<Polyline>& ordered_perimeter
             const Point next_start = ordered_perimeters[perimeter_index + 1].front();
             Point connector_start;
             if (hasSmoothClosingSegment(perimeter)) {
-                connector_start = pointBeforeClosedPolylineStart(perimeter, final_stop_distance);
+                connector_start = stopPointOnClosingSegment(perimeter, final_stop_distance);
             }
             else {
                 auto [projected_connector_start, distance] =
@@ -125,7 +115,7 @@ Polyline buildSpiralPerimeterPolyline(const QVector<Polyline>& ordered_perimeter
             }
         }
         else {
-            const Point final_stop = pointBeforeClosedPolylineStart(perimeter, final_stop_distance);
+            const Point final_stop = stopPointOnClosingSegment(perimeter, final_stop_distance);
 
             if (spiral.back() != final_stop) {
                 spiral += final_stop;

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -573,6 +573,7 @@ const QString Constants::ProfileSettings::Inset::kExtruderSpeed = "inset_extrude
 const QString Constants::ProfileSettings::Inset::kExtrusionMultiplier = "inset_extrusion_multiplier";
 const QString Constants::ProfileSettings::Inset::kMinPathLength = "inset_minimum_path_length";
 const QString Constants::ProfileSettings::Inset::kOverlap = "inset_overlap_distance";
+const QString Constants::ProfileSettings::Inset::kEnableSpiralInset = "spiral_inset";
 
 // Skeleton
 const QString Constants::ProfileSettings::Skeleton::kEnable = "skeleton";

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -562,6 +562,7 @@ const QString Constants::ProfileSettings::Perimeter::kEnableLeadInY = "perimeter
 const QString Constants::ProfileSettings::Perimeter::kEnableFlyingStart = "perimeter_flying_start";
 const QString Constants::ProfileSettings::Perimeter::kFlyingStartDistance = "perimeter_flying_start_distance";
 const QString Constants::ProfileSettings::Perimeter::kFlyingStartSpeed = "perimeter_flying_start_speed";
+const QString Constants::ProfileSettings::Perimeter::kEnableSpiralPerimeter = "spiral_perimeter";
 
 // Inset
 const QString Constants::ProfileSettings::Inset::kEnable = "inset";


### PR DESCRIPTION
## Summary

Adds functional support for the new spiral perimeter setting. When enabled, perimeter loops are ordered and linked into a single continuous path that spirals inward between concentric perimeter loops instead of printing each loop as a separate closed contour.

## Details

- Adds the `spiral_perimeter` profile setting and constants plumbing.
- Adds spiral perimeter path assembly in `Perimeter::optimize`.
- Reuses existing path and point ordering behavior for the initial perimeter selection.
- Links later loops with local next-closest behavior and segment breaking so inward transitions stay near the selected seam.
- Stops loop closing segments short when transitioning inward, and angles smooth/curved-loop transitions to avoid crossing back through circular perimeters.
- Keeps the final perimeter from fully closing into the seam by stopping short by one perimeter bead width.

## Validation

- Built successfully with:

```bash
nix develop -c cmake --build build/generic-llvm-ninja -j2
```

- Manually previewed square and circular perimeter cases while iterating on the transition geometry.