### PR TITLE
Implement undo and redo for object transformations and settings changes

### DIFF
--- a/include/widgets/settings/setting_bar.h
+++ b/include/widgets/settings/setting_bar.h
@@ -64,6 +64,13 @@ class SettingBar : public QWidget {
 
   signals:
     /*!
+     * \brief Signals that a setting is about to be modified.
+     * \param setting_key   Setting that is about to be modified.
+     * \param settings_bases Selected local settings bases, or empty for global settings.
+     */
+    void settingAboutToChange(QString setting_key, QList<QSharedPointer<SettingsBase>> settings_bases);
+
+    /*!
      * \brief Signals that a setting has been modified.
      * \param setting_key   Setting that has been modified.
      */
@@ -125,7 +132,17 @@ class SettingBar : public QWidget {
     //! \brief sets the style of the widget according to current theme
     void setupStyle();
 
+    //! \brief Reloads a restored setting row and forwards normal modified-setting notifications.
+    void restoreSettingValue(QString setting_key);
+
   private slots:
+    /*!
+     * \brief Re-emits a signal that a setting is about to be modified.
+     * \param setting_key   Key that is about to be modified.
+     * \param settings_bases Selected local settings bases, or empty for global settings.
+     */
+    void forwardSettingAboutToChange(QString setting_key, QList<QSharedPointer<SettingsBase>> settings_bases);
+
     /*!
      * \brief Re-emitts a signal that a setting has been modified.
      * \param setting_key   Key that was modified.
@@ -212,5 +229,8 @@ class SettingBar : public QWidget {
 
     //! \brief Prevents recursive setting sync while paired radial settings are reloaded.
     bool m_syncing_radial_settings = false;
+
+    //! \brief Prevents restored undo/redo values from being treated like fresh row edits.
+    bool m_restoring_settings = false;
 };
 } // Namespace ORNL

--- a/include/widgets/settings/setting_pane.h
+++ b/include/widgets/settings/setting_pane.h
@@ -66,12 +66,26 @@ class SettingPane : public QWidget {
 
   private slots:
     /*!
+     * \brief Forwards an impending setting modification to the bar for retransmission.
+     * \param setting_key   Key that is about to be modified.
+     * \param settings_bases Selected local settings bases, or empty for global settings.
+     */
+    void forwardSettingAboutToChange(QString setting_key, QList<QSharedPointer<SettingsBase>> settings_bases);
+
+    /*!
      * \brief Forwards a modified setting to the bar for retransmission.
      * \param setting_key   Key that was modified.
      */
     void forwardModifiedSetting(QString setting_key);
 
   signals:
+    /*!
+     * \brief Signal that setting is about to be modified.
+     * \param setting_key   Key that is about to be modified.
+     * \param settings_bases Selected local settings bases, or empty for global settings.
+     */
+    void settingAboutToChange(QString setting_key, QList<QSharedPointer<SettingsBase>> settings_bases);
+
     /*!
      * \brief Signal that setting was modified.
      * \param setting_key   Key that was modified.

--- a/include/widgets/settings/setting_row_base.h
+++ b/include/widgets/settings/setting_row_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include <QCheckBox>
 #include <QComboBox>
 #include <QGridLayout>
@@ -38,6 +40,8 @@ struct DependencyNode {
 class SettingRowBase {
 
   public:
+    using ValueChangeCallback = std::function<void(const QString&, const QList<QSharedPointer<SettingsBase>>&)>;
+
     //! \brief Default Constructor
     //! \param sb: global setting base
     //! \param key: key of current row
@@ -115,6 +119,9 @@ class SettingRowBase {
     //! \param sb: new settingsbase to set
     void setSettingsBase(QSharedPointer<SettingsBase> sb);
 
+    //! \brief Set callback used to notify before this row writes a new value.
+    void setValueChangeCallback(ValueChangeCallback callback);
+
   protected:
     //! \brief Function to handle value changes for each widget type
     virtual void valueChanged(QVariant val) = 0;
@@ -122,12 +129,17 @@ class SettingRowBase {
     //! \brief Check dependencies enforced through dynamic feedback
     void checkDynamicDependencies();
 
+    //! \brief Notify before a setting key is written by this row.
+    void notifyValueAboutToChange(const QString& key);
+
     //! \brief Recursive check of dependencynode logic
     //! \param root: Dependency logic to check
     bool checkLogic(DependencyNode root);
 
     //! \brief Templated helper for all widget types when value is changed
     template <class T> void valueChangedHelper(T value) {
+        notifyValueAboutToChange(m_key);
+
         if (m_settings_bases.size() != 0)
             for (QSharedPointer<SettingsBase> range : m_settings_bases)
                 range->setSetting(m_key, value);
@@ -255,6 +267,9 @@ class SettingRowBase {
 
     //! \brief Holds pointers to dependents to notify when current value changes
     QList<QSharedPointer<SettingRowBase>> m_rows_to_notify;
+
+    //! \brief Callback for snapshotting undo state before a row mutates settings.
+    ValueChangeCallback m_value_change_callback;
 };
 
 } // Namespace ORNL

--- a/include/widgets/settings/setting_tab.h
+++ b/include/widgets/settings/setting_tab.h
@@ -99,6 +99,13 @@ class SettingTab : public QWidget {
 
   signals:
     /*!
+     * \brief Notification before a setting is modified.
+     * \param key   Key that is about to be modified.
+     * \param settings_bases Selected local settings bases, or empty for global settings.
+     */
+    void settingAboutToChange(QString key, QList<QSharedPointer<SettingsBase>> settings_bases);
+
+    /*!
      * \brief Notification that a setting was modified.
      * \param key   Key that was modified.
      */

--- a/include/windows/main_window.h
+++ b/include/windows/main_window.h
@@ -7,9 +7,11 @@
 #include <QLabel>
 #include <QMainWindow>
 #include <QMenuBar>
+#include <QMatrix4x4>
 #include <QTextEdit>
 #include <QToolBar>
 #include <QUdpSocket>
+#include <QUndoStack>
 #include <qboxlayout.h>
 #include <qcontainerfwd.h>
 #include <qcoreapplication.h>
@@ -29,7 +31,9 @@
 #include <qwidget.h>
 
 #include "dialogs/slice_dialog.h"
+#include "configs/settings_base.h"
 #include "utilities/enums.h"
+#include "utilities/qt_json_conversion.h"
 #include "widgets/cmd_widget.h"
 #include "widgets/gcode_widget.h"
 #include "widgets/gcodebar.h"
@@ -48,6 +52,9 @@ namespace ORNL {
 
 class PlanarSlicer;
 class SessionLoader;
+class PartMetaItem;
+class PartTransformUndoCommand;
+class SettingValueUndoCommand;
 
 //! \brief Define for quick access to this singleton.
 #define MWIN MainWindow::getInstance()
@@ -60,6 +67,9 @@ class SessionLoader;
  */
 class MainWindow : public QMainWindow {
     Q_OBJECT
+
+    friend class PartTransformUndoCommand;
+    friend class SettingValueUndoCommand;
 
   public:
     //! \brief Get the singleton instance of the MainWindow.
@@ -191,6 +201,21 @@ class MainWindow : public QMainWindow {
     //! \param key: the settings key
     void handleModifiedSetting(const QString key);
 
+    //! \brief Capture setting state before a row writes a user-initiated value.
+    void captureSettingChange(QString key, QList<QSharedPointer<SettingsBase>> settings_bases);
+
+    //! \brief Push an undo command after a captured setting changed.
+    void recordSettingChange(QString key);
+
+    //! \brief Track part transform changes for undo.
+    void recordPartTransform(QSharedPointer<PartMetaItem> item);
+
+    //! \brief Initialize tracked part transform state.
+    void initializePartTransform(QSharedPointer<PartMetaItem> item);
+
+    //! \brief Remove tracked part transform state.
+    void removePartTransform(QSharedPointer<PartMetaItem> item);
+
   private:
     //! \brief Struct to retain action information efficiently.
     struct menu_info {
@@ -204,6 +229,20 @@ class MainWindow : public QMainWindow {
         QKeySequence shortcut;
         //! \brief Action to execute.
         QAction* action;
+    };
+
+    //! \brief Snapshot of a part transform that can be restored by undo/redo.
+    struct PartTransformSnapshot {
+        QMatrix4x4 transformation;
+        uint scale_unit_index = 0;
+    };
+
+    //! \brief Snapshot of one settings value for one settings base.
+    struct SettingValueSnapshot {
+        QString key;
+        QSharedPointer<SettingsBase> settings_base;
+        bool existed = false;
+        fifojson value;
     };
 
     //! \brief Constructor
@@ -261,6 +300,26 @@ class MainWindow : public QMainWindow {
     //! \brief Performs initial startup once constructor has verified time
     void continueStartup();
 
+    //! \brief Takes a part transform snapshot from an item.
+    PartTransformSnapshot partTransformSnapshot(QSharedPointer<PartMetaItem> item) const;
+
+    //! \brief Applies a part transform snapshot as an undo/redo operation.
+    void applyPartTransformSnapshot(QSharedPointer<PartMetaItem> item, const PartTransformSnapshot& snapshot);
+
+    //! \brief Takes setting value snapshots for a set of target bases.
+    QVector<SettingValueSnapshot> settingValueSnapshots(
+        const QString& key, const QList<QSharedPointer<SettingsBase>>& settings_bases) const;
+
+    //! \brief Applies setting value snapshots as an undo/redo operation.
+    void applySettingValueSnapshots(const QVector<SettingValueSnapshot>& snapshots);
+
+    //! \brief Compares part snapshots.
+    bool partTransformSnapshotsEqual(const PartTransformSnapshot& lhs, const PartTransformSnapshot& rhs) const;
+
+    //! \brief Compares setting value snapshots.
+    bool settingValueSnapshotsEqual(const QVector<SettingValueSnapshot>& lhs,
+                                    const QVector<SettingValueSnapshot>& rhs) const;
+
     //! \brief Current window status.
     bool m_status;
 
@@ -272,6 +331,18 @@ class MainWindow : public QMainWindow {
 
     //! \brief Autosave timer.
     QTimer* m_timer;
+
+    //! \brief Undo stack for user-visible part transform and setting value changes.
+    QUndoStack* m_undo_stack;
+
+    //! \brief Avoid recording commands while undo/redo is applying state.
+    bool m_applying_undo_redo = false;
+
+    //! \brief Last known transform for each part item.
+    QMap<QSharedPointer<PartMetaItem>, PartTransformSnapshot> m_part_transform_snapshots;
+
+    //! \brief Pending setting snapshots captured before row writes.
+    QHash<QString, QVector<SettingValueSnapshot>> m_pending_setting_snapshots;
 
     //! \brief Singleton pointer. This must be a raw pointer to avoid double free on close.
     static MainWindow* m_singleton;

--- a/src/widgets/settings/setting_bar.cpp
+++ b/src/widgets/settings/setting_bar.cpp
@@ -53,6 +53,7 @@ SettingPane* SettingBar::getPane(QString major) {
 
     connect(PreferencesManager::getInstance().get(), &PreferencesManager::anyUnitChanged, m_panes[major],
             &SettingPane::reload);
+    connect(m_panes[major], &SettingPane::settingAboutToChange, this, &SettingBar::forwardSettingAboutToChange);
     connect(m_panes[major], &SettingPane::settingModified, this, &SettingBar::forwardModifiedSetting);
     connect(m_panes[major], &SettingPane::forwardHideTab, this, &SettingBar::forwardHideTab);
     connect(m_panes[major], &SettingPane::warnSettingBar, this, &SettingBar::barTabWarning);
@@ -286,8 +287,13 @@ void SettingBar::displayNewSetting(QStringList settingCategories, QString settin
     enableDependRows();
 }
 
+void SettingBar::forwardSettingAboutToChange(QString setting_key,
+                                             QList<QSharedPointer<SettingsBase>> settings_bases) {
+    emit settingAboutToChange(setting_key, settings_bases);
+}
+
 void SettingBar::forwardModifiedSetting(QString setting_key) {
-    if (m_syncing_radial_settings) {
+    if (m_syncing_radial_settings || m_restoring_settings) {
         return;
     }
 
@@ -315,6 +321,7 @@ QStringList SettingBar::syncRadialSlicingSettings(const QString& setting_key) {
         const GcodeSyntax syntax = sb->setting<GcodeSyntax>(PRS::MachineSetup::kSyntax);
         if ((slicer_type == SlicerType::kRadialSlice || slicer_type == SlicerType::kHelicalSlice) &&
             syntax != GcodeSyntax::kRadial3Plus2) {
+            emit settingAboutToChange(PRS::MachineSetup::kSyntax, QList<QSharedPointer<SettingsBase>>());
             sb->setSetting(PRS::MachineSetup::kSyntax, static_cast<int>(GcodeSyntax::kRadial3Plus2));
             reloadSettingRow(PRS::MachineSetup::kSyntax);
             synced_keys.push_back(PRS::MachineSetup::kSyntax);
@@ -325,6 +332,7 @@ QStringList SettingBar::syncRadialSlicingSettings(const QString& setting_key) {
         const SlicerType slicer_type = static_cast<SlicerType>(sb->setting<int>(PS::Slicing::kSlicerType));
         if (syntax == GcodeSyntax::kRadial3Plus2 && slicer_type != SlicerType::kRadialSlice &&
             slicer_type != SlicerType::kHelicalSlice) {
+            emit settingAboutToChange(PS::Slicing::kSlicerType, QList<QSharedPointer<SettingsBase>>());
             sb->setSetting(PS::Slicing::kSlicerType, static_cast<int>(SlicerType::kRadialSlice));
             reloadSettingRow(PS::Slicing::kSlicerType);
             synced_keys.push_back(PS::Slicing::kSlicerType);
@@ -351,6 +359,15 @@ void SettingBar::reloadSettingRow(const QString& setting_key) {
     if (!row.isNull()) {
         row->reloadValue();
     }
+}
+
+void SettingBar::restoreSettingValue(QString setting_key) {
+    m_restoring_settings = true;
+    reloadSettingRow(setting_key);
+    m_restoring_settings = false;
+
+    enableDependRows();
+    emit settingModified(setting_key);
 }
 
 void SettingBar::forwardHideTab(QString pane, QString category) { emit tabHidden(pane, category); }

--- a/src/widgets/settings/setting_pane.cpp
+++ b/src/widgets/settings/setting_pane.cpp
@@ -38,6 +38,7 @@ SettingTab* SettingPane::newTab(QString category, QIcon icon, bool isHidden) {
     if (!isHidden)
         m_scroll_layout->insertWidget(m_scroll_layout->count() - 1, m_tabs[category]);
 
+    connect(m_tabs[category], &SettingTab::settingAboutToChange, this, &SettingPane::forwardSettingAboutToChange);
     connect(m_tabs[category], &SettingTab::modified, this, &SettingPane::forwardModifiedSetting);
     connect(m_tabs[category], &SettingTab::removeTabFromList, this, &SettingPane::hideTab);
     connect(m_tabs[category], &SettingTab::warnPane, this, &SettingPane::paneWarning);
@@ -80,6 +81,11 @@ void SettingPane::paneWarning(int count) {
     else {
         emit warnSettingBar(0, m_name);
     }
+}
+
+void SettingPane::forwardSettingAboutToChange(QString setting_key,
+                                              QList<QSharedPointer<SettingsBase>> settings_bases) {
+    emit settingAboutToChange(setting_key, settings_bases);
 }
 
 void SettingPane::forwardModifiedSetting(QString setting_key) { emit settingModified(setting_key); }

--- a/src/widgets/settings/setting_row_base.cpp
+++ b/src/widgets/settings/setting_row_base.cpp
@@ -124,6 +124,14 @@ void SettingRowBase::setDependencyLogic(DependencyNode root) { m_dependency_logi
 
 void SettingRowBase::setSettingsBase(QSharedPointer<SettingsBase> sb) { m_sb = sb; }
 
+void SettingRowBase::setValueChangeCallback(ValueChangeCallback callback) { m_value_change_callback = callback; }
+
+void SettingRowBase::notifyValueAboutToChange(const QString& key) {
+    if (m_value_change_callback) {
+        m_value_change_callback(key, m_settings_bases);
+    }
+}
+
 bool SettingRowBase::checkLogic(DependencyNode root) {
     if (root.key == "AND") {
         return checkLogic(root.children[0]) && checkLogic(root.children[1]);

--- a/src/widgets/settings/setting_tab.cpp
+++ b/src/widgets/settings/setting_tab.cpp
@@ -147,6 +147,10 @@ void SettingTab::addRow(QString key, const fifojson& json, const fifojson& input
         }
 
         if (!newRow.isNull()) {
+            newRow->setValueChangeCallback([this](const QString& changed_key,
+                                                  const QList<QSharedPointer<SettingsBase>>& settings_bases) {
+                emit settingAboutToChange(changed_key, settings_bases);
+            });
             m_rows.insert(primary_key, newRow);
             for (std::size_t i = 1; i < components.size(); ++i)
                 m_row_aliases.insert(componentSetting(components.at(i)), newRow);
@@ -160,6 +164,10 @@ void SettingTab::addRow(QString key, const fifojson& json, const fifojson& input
         QSharedPointer<SettingRowBase>(m_creation_mapping[json.at(Constants::Settings::Master::kType)](
             this, m_sb, key, json, m_container_layout, m_size));
 
+    newRow->setValueChangeCallback([this](const QString& changed_key,
+                                          const QList<QSharedPointer<SettingsBase>>& settings_bases) {
+        emit settingAboutToChange(changed_key, settings_bases);
+    });
     m_rows.insert(key, newRow);
     ++m_size;
 }

--- a/src/widgets/settings/vector2_input_widget.cpp
+++ b/src/widgets/settings/vector2_input_widget.cpp
@@ -187,6 +187,8 @@ void Vector2InputWidget::updateSetting(const QString& key, double displayed_valu
     Distance base_value;
     base_value.from(displayed_value, PreferencesManager::getInstance()->getDistanceUnit());
 
+    notifyValueAboutToChange(key);
+
     if (m_settings_bases.size() != 0) {
         for (QSharedPointer<SettingsBase> range : m_settings_bases)
             range->setSetting(key, base_value());

--- a/src/widgets/settings/vector3_input_widget.cpp
+++ b/src/widgets/settings/vector3_input_widget.cpp
@@ -177,6 +177,8 @@ void Vector3InputWidget::ensureSetting(const QString& key, double default_value)
 }
 
 void Vector3InputWidget::updateSetting(const QString& key, double value) {
+    notifyValueAboutToChange(key);
+
     if (m_settings_bases.size() != 0) {
         for (QSharedPointer<SettingsBase> range : m_settings_bases)
             range->setSetting(key, value);

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -6,6 +6,7 @@
 #include <QSettings>
 #include <QStatusBar>
 #include <QTimer>
+#include <QUndoCommand>
 #include <qaction.h>
 #include <qapplication.h>
 #include <qcontainerfwd.h>
@@ -57,6 +58,8 @@
 #include "widgets/gcodebar.h"
 #include "widgets/layerbar.h"
 #include "widgets/main_toolbar.h"
+#include "widgets/part_widget/model/part_meta_item.h"
+#include "widgets/part_widget/model/part_meta_model.h"
 #include "widgets/part_widget/part_widget.h"
 #include "widgets/settings/setting_bar.h"
 #include "windows/about.h"
@@ -70,6 +73,96 @@
 #include "windows/xtrudecalc.h"
 
 namespace ORNL {
+constexpr int kPartTransformUndoCommandId = 1;
+constexpr int kSettingValueUndoCommandId = 2;
+
+class PartTransformUndoCommand : public QUndoCommand {
+  public:
+    PartTransformUndoCommand(MainWindow* window, QSharedPointer<PartMetaItem> item,
+                             const MainWindow::PartTransformSnapshot& before,
+                             const MainWindow::PartTransformSnapshot& after)
+        : m_window(window), m_item(item), m_before(before), m_after(after) {
+        setText("part position change");
+    }
+
+    int id() const override { return kPartTransformUndoCommandId; }
+
+    bool mergeWith(const QUndoCommand* command) override {
+        const auto* other = dynamic_cast<const PartTransformUndoCommand*>(command);
+        if (other == nullptr || other->m_window != m_window || other->m_item != m_item) {
+            return false;
+        }
+
+        m_after = other->m_after;
+        return true;
+    }
+
+    void undo() override { m_window->applyPartTransformSnapshot(m_item, m_before); }
+
+    void redo() override {
+        if (m_skip_first_redo) {
+            m_skip_first_redo = false;
+            return;
+        }
+
+        m_window->applyPartTransformSnapshot(m_item, m_after);
+    }
+
+  private:
+    MainWindow* m_window;
+    QSharedPointer<PartMetaItem> m_item;
+    MainWindow::PartTransformSnapshot m_before;
+    MainWindow::PartTransformSnapshot m_after;
+    bool m_skip_first_redo = true;
+};
+
+class SettingValueUndoCommand : public QUndoCommand {
+  public:
+    SettingValueUndoCommand(MainWindow* window, const QString& key,
+                            const QVector<MainWindow::SettingValueSnapshot>& before,
+                            const QVector<MainWindow::SettingValueSnapshot>& after)
+        : m_window(window), m_key(key), m_before(before), m_after(after) {
+        setText("setting change");
+    }
+
+    int id() const override { return kSettingValueUndoCommandId; }
+
+    bool mergeWith(const QUndoCommand* command) override {
+        const auto* other = dynamic_cast<const SettingValueUndoCommand*>(command);
+        if (other == nullptr || other->m_window != m_window || other->m_key != m_key ||
+            other->m_before.size() != m_before.size()) {
+            return false;
+        }
+
+        for (int i = 0, end = m_before.size(); i < end; ++i) {
+            if (m_before[i].settings_base != other->m_before[i].settings_base ||
+                m_before[i].key != other->m_before[i].key) {
+                return false;
+            }
+        }
+
+        m_after = other->m_after;
+        return true;
+    }
+
+    void undo() override { m_window->applySettingValueSnapshots(m_before); }
+
+    void redo() override {
+        if (m_skip_first_redo) {
+            m_skip_first_redo = false;
+            return;
+        }
+
+        m_window->applySettingValueSnapshots(m_after);
+    }
+
+  private:
+    MainWindow* m_window;
+    QString m_key;
+    QVector<MainWindow::SettingValueSnapshot> m_before;
+    QVector<MainWindow::SettingValueSnapshot> m_after;
+    bool m_skip_first_redo = true;
+};
 
 MainWindow* MainWindow::m_singleton = nullptr;
 
@@ -179,6 +272,8 @@ void MainWindow::setupClasses() {
     // Timer. This controls auto save.
     m_timer = new QTimer(this);
     m_timer->start(300000);
+
+    m_undo_stack = new QUndoStack(this);
 }
 
 void MainWindow::teardownClasses() {
@@ -411,8 +506,8 @@ void MainWindow::setupActions() {
     m_actions["exit"] = {"Exit", ":/icons/exit_black.png", false, QKeySequence(), nullptr};
 
     // Menu Edit
-    m_actions["undo"] = {"Undo", ":/icons/undo_black.png", false, QKeySequence(), nullptr};
-    m_actions["redo"] = {"Redo", ":/icons/redo_black.png", false, QKeySequence(), nullptr};
+    m_actions["undo"] = {"Undo", ":/icons/undo_black.png", false, QKeySequence(QKeySequence::Undo), nullptr};
+    m_actions["redo"] = {"Redo", ":/icons/redo_black.png", false, QKeySequence(QKeySequence::Redo), nullptr};
     m_actions["copy"] = {"Copy", ":/icons/copy_black.png", false, QKeySequence(tr("Ctrl+c")), nullptr};
     m_actions["paste"] = {"Paste", ":/icons/paste_black.png", false, QKeySequence(tr("Ctrl+v")), nullptr};
     m_actions["reload"] = {"Reload", ":/icons/file_refresh_black.png", false, QKeySequence(tr("Ctrl+r")), nullptr};
@@ -657,8 +752,8 @@ void MainWindow::setupEvents() {
     connect(m_actions["last_session"].action, &QAction::triggered, this, &MainWindow::autoLoad);
     connect(m_actions["screenshot"].action, &QAction::triggered, m_part_widget, &PartWidget::takeScreenshot);
 
-    connect(m_actions["undo"].action, &QAction::triggered, m_part_widget, &PartWidget::undo);
-    connect(m_actions["redo"].action, &QAction::triggered, m_part_widget, &PartWidget::redo);
+    connect(m_actions["undo"].action, &QAction::triggered, m_undo_stack, &QUndoStack::undo);
+    connect(m_actions["redo"].action, &QAction::triggered, m_undo_stack, &QUndoStack::redo);
     connect(m_actions["copy"].action, &QAction::triggered, this, [this]() {
         m_actions["paste"].action->setEnabled(true);
         m_part_widget->copy();
@@ -668,6 +763,8 @@ void MainWindow::setupEvents() {
     connect(m_actions["delete"].action, &QAction::triggered, m_part_widget, QOverload<>::of(&PartWidget::remove));
 
     m_actions["slice"].action->setEnabled(false);
+    m_actions["undo"].action->setEnabled(false);
+    m_actions["redo"].action->setEnabled(false);
     m_actions["copy"].action->setEnabled(false);
     m_actions["paste"].action->setEnabled(false);
     m_actions["reload"].action->setEnabled(false);
@@ -678,6 +775,9 @@ void MainWindow::setupEvents() {
     m_actions["sel_printer"].action->setEnabled(false);
     m_actions["python_int"].action->setEnabled(false);
     m_actions["debug"].action->setEnabled(true);
+
+    connect(m_undo_stack, &QUndoStack::canUndoChanged, m_actions["undo"].action, &QAction::setEnabled);
+    connect(m_undo_stack, &QUndoStack::canRedoChanged, m_actions["redo"].action, &QAction::setEnabled);
 
     connect(m_actions["zoom_in"].action, &QAction::triggered, m_part_widget, &PartWidget::zoomIn);
     connect(m_actions["zoom_out"].action, &QAction::triggered, m_part_widget, &PartWidget::zoomOut);
@@ -836,10 +936,17 @@ void MainWindow::setupEvents() {
                          "Scaling factors are reset to 100%\r\n");
     });
 
+    QSharedPointer<PartMetaModel> part_meta = m_part_widget->getPartMeta();
+    connect(part_meta.get(), &PartMetaModel::itemAddedUpdate, this, &MainWindow::initializePartTransform);
+    connect(part_meta.get(), &PartMetaModel::itemRemovedUpdate, this, &MainWindow::removePartTransform);
+    connect(part_meta.get(), &PartMetaModel::transformUpdate, this, &MainWindow::recordPartTransform);
+
     // Connect to timer.
     connect(m_timer, &QTimer::timeout, this, &MainWindow::autoSave);
 
     // Allow stuff to changed at runtime based upon user-modified settings
+    connect(m_settingbar, &SettingBar::settingAboutToChange, this, &MainWindow::captureSettingChange);
+    connect(m_settingbar, &SettingBar::settingModified, this, &MainWindow::recordSettingChange);
     connect(m_settingbar, &SettingBar::settingModified, m_part_widget, &PartWidget::handleModifiedSetting);
     connect(m_settingbar, &SettingBar::settingModified, m_gcode_widget, &GCodeWidget::handleModifiedSetting);
     connect(m_settingbar, &SettingBar::settingModified, m_layerbar, &LayerBar::handleModifiedSetting);
@@ -916,6 +1023,181 @@ void MainWindow::switchViews(int index) {
         QObject::disconnect(m_actions["zoom_reset"].action, &QAction::triggered, m_gcode_widget,
                             &GCodeWidget::resetZoom);
     }
+}
+
+MainWindow::PartTransformSnapshot MainWindow::partTransformSnapshot(QSharedPointer<PartMetaItem> item) const {
+    PartTransformSnapshot snapshot;
+    if (!item.isNull()) {
+        snapshot.transformation = item->transformation();
+        snapshot.scale_unit_index = item->scaleUnitIndex();
+    }
+    return snapshot;
+}
+
+void MainWindow::applyPartTransformSnapshot(QSharedPointer<PartMetaItem> item,
+                                            const PartTransformSnapshot& snapshot) {
+    if (item.isNull() || !m_part_transform_snapshots.contains(item)) {
+        return;
+    }
+
+    m_applying_undo_redo = true;
+    item->setTransformation(snapshot.transformation);
+    item->setScaleUnitIndex(snapshot.scale_unit_index);
+    m_part_transform_snapshots[item] = snapshot;
+    m_applying_undo_redo = false;
+}
+
+QVector<MainWindow::SettingValueSnapshot> MainWindow::settingValueSnapshots(
+    const QString& key, const QList<QSharedPointer<SettingsBase>>& settings_bases) const {
+    QList<QSharedPointer<SettingsBase>> targets = settings_bases;
+    if (targets.isEmpty()) {
+        targets.push_back(GSM->getGlobal());
+    }
+
+    QVector<SettingValueSnapshot> snapshots;
+    for (const QSharedPointer<SettingsBase>& settings_base : targets) {
+        if (settings_base.isNull()) {
+            continue;
+        }
+
+        SettingValueSnapshot snapshot;
+        snapshot.key = key;
+        snapshot.settings_base = settings_base;
+        snapshot.existed = settings_base->contains(key);
+        if (snapshot.existed) {
+            snapshot.value = settings_base->json()[0][key.toStdString()];
+        }
+
+        snapshots.push_back(snapshot);
+    }
+
+    return snapshots;
+}
+
+void MainWindow::applySettingValueSnapshots(const QVector<SettingValueSnapshot>& snapshots) {
+    if (snapshots.isEmpty()) {
+        return;
+    }
+
+    QSet<QString> restored_keys;
+
+    m_applying_undo_redo = true;
+    for (const SettingValueSnapshot& snapshot : snapshots) {
+        if (snapshot.settings_base.isNull()) {
+            continue;
+        }
+
+        fifojson& settings_json = snapshot.settings_base->json();
+        if (settings_json.empty()) {
+            settings_json.push_back(fifojson::object());
+        }
+
+        if (snapshot.existed) {
+            settings_json[0][snapshot.key.toStdString()] = snapshot.value;
+        }
+        else {
+            snapshot.settings_base->remove(snapshot.key);
+        }
+
+        restored_keys.insert(snapshot.key);
+    }
+
+    for (const QString& key : restored_keys) {
+        m_settingbar->restoreSettingValue(key);
+    }
+    m_applying_undo_redo = false;
+}
+
+bool MainWindow::partTransformSnapshotsEqual(const PartTransformSnapshot& lhs,
+                                             const PartTransformSnapshot& rhs) const {
+    return lhs.scale_unit_index == rhs.scale_unit_index && lhs.transformation == rhs.transformation;
+}
+
+bool MainWindow::settingValueSnapshotsEqual(const QVector<SettingValueSnapshot>& lhs,
+                                            const QVector<SettingValueSnapshot>& rhs) const {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+
+    for (int i = 0, end = lhs.size(); i < end; ++i) {
+        if (lhs[i].key != rhs[i].key || lhs[i].settings_base != rhs[i].settings_base ||
+            lhs[i].existed != rhs[i].existed) {
+            return false;
+        }
+
+        if (lhs[i].existed && lhs[i].value != rhs[i].value) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void MainWindow::captureSettingChange(QString key, QList<QSharedPointer<SettingsBase>> settings_bases) {
+    if (m_applying_undo_redo || m_pending_setting_snapshots.contains(key)) {
+        return;
+    }
+
+    m_pending_setting_snapshots[key] = settingValueSnapshots(key, settings_bases);
+}
+
+void MainWindow::recordSettingChange(QString key) {
+    if (m_applying_undo_redo || !m_pending_setting_snapshots.contains(key)) {
+        return;
+    }
+
+    QVector<SettingValueSnapshot> before = m_pending_setting_snapshots.take(key);
+    QStringList coupled_keys = m_pending_setting_snapshots.keys();
+    coupled_keys.sort();
+    for (const QString& coupled_key : coupled_keys) {
+        before.append(m_pending_setting_snapshots.take(coupled_key));
+    }
+
+    QVector<SettingValueSnapshot> after;
+    after.reserve(before.size());
+    for (const SettingValueSnapshot& snapshot : before) {
+        QList<QSharedPointer<SettingsBase>> settings_bases;
+        settings_bases.push_back(snapshot.settings_base);
+
+        const QVector<SettingValueSnapshot> current = settingValueSnapshots(snapshot.key, settings_bases);
+        if (!current.isEmpty()) {
+            after.push_back(current[0]);
+        }
+    }
+
+    if (settingValueSnapshotsEqual(before, after)) {
+        return;
+    }
+
+    m_undo_stack->push(new SettingValueUndoCommand(this, key, before, after));
+}
+
+void MainWindow::initializePartTransform(QSharedPointer<PartMetaItem> item) {
+    if (!item.isNull()) {
+        m_part_transform_snapshots[item] = partTransformSnapshot(item);
+    }
+}
+
+void MainWindow::removePartTransform(QSharedPointer<PartMetaItem> item) { m_part_transform_snapshots.remove(item); }
+
+void MainWindow::recordPartTransform(QSharedPointer<PartMetaItem> item) {
+    if (m_applying_undo_redo || item.isNull()) {
+        return;
+    }
+
+    const PartTransformSnapshot current = partTransformSnapshot(item);
+    if (!m_part_transform_snapshots.contains(item)) {
+        m_part_transform_snapshots[item] = current;
+        return;
+    }
+
+    const PartTransformSnapshot before = m_part_transform_snapshots[item];
+    if (partTransformSnapshotsEqual(before, current)) {
+        return;
+    }
+
+    m_undo_stack->push(new PartTransformUndoCommand(this, item, before, current));
+    m_part_transform_snapshots[item] = current;
 }
 
 void MainWindow::handleModifiedSetting(const QString key) {}


### PR DESCRIPTION
## Summary
- Wire the existing Undo/Redo actions to a shared `QUndoStack` with enabled-state updates and standard shortcuts.
- Add undo commands for part/object transform snapshots, including object position/transform and scale unit changes.
- Add pre-change setting snapshots for printer, material, profile, and experimental settings, including local selected settings bases and vector component rows.
- Refresh restored setting rows and dependent settings while suppressing recursive undo/redo recording during restoration.

## Why
The Undo and Redo buttons existed in the UI but did not perform any operation. Users could not revert object placement changes or setting edits without manually restoring values.

## Impact
Users can now undo and redo object transformation changes and supported setting value edits from the existing toolbar/menu actions.

## Validation
- `nix develop -c cmake --build build/generic-llvm-ninja -j2`