### PR TITLE
Create visual representation of layer specific settings affected area

### DIFF
--- a/include/graphics/objects/cube/plane_object.h
+++ b/include/graphics/objects/cube/plane_object.h
@@ -20,6 +20,13 @@ class PlaneObject : public CubeObject {
     //! \param color: Plane color.
     PlaneObject(BaseView* view, float length, float width, QColor color = QColor(127, 0, 255, 102));
 
+    //! \brief Constructor
+    //! \param length: Plane length.
+    //! \param width: Plane width.
+    //! \param height: Plane thickness.
+    //! \param color: Plane color.
+    PlaneObject(BaseView* view, float length, float width, float height, QColor color);
+
     //! \brief Sets the rotation of the plane.
     //! \param rotation: New rotation quaternion.
     void setLockedRotationQuaternion(const QQuaternion& rotation);
@@ -30,6 +37,9 @@ class PlaneObject : public CubeObject {
     //! \brief Scales the plane to an new length/width.
     void updateDimensions(float length, float width);
 
+    //! \brief Scales the plane to a new length/width/thickness.
+    void updateDimensions(float length, float width, float height);
+
   protected:
     //! \brief Handles plane rotation locking.
     void transformationCallback();
@@ -38,6 +48,7 @@ class PlaneObject : public CubeObject {
     //! \brief Starting dims.
     float m_starting_length;
     float m_starting_width;
+    float m_starting_height;
 
     //! \brief Color
     QColor m_color;

--- a/include/graphics/objects/part_object.h
+++ b/include/graphics/objects/part_object.h
@@ -7,6 +7,7 @@
 #include <qset.h>
 #include <qsharedpointer.h>
 #include <qtypes.h>
+#include <qvector.h>
 
 #include "graphics/graphics_object.h"
 #include "units/unit.h"
@@ -67,6 +68,10 @@ class PartObject : public GraphicsObject {
     QSharedPointer<AxesObject> axes();
     //! \brief Gets the plane object.
     QSharedPointer<PlaneObject> plane();
+    //! \brief Gets a layer settings range plane object.
+    QSharedPointer<PlaneObject> layerSettingsRangePlane(int index = 0);
+    //! \brief Gets all layer settings range plane objects.
+    QVector<QSharedPointer<PlaneObject>> layerSettingsRangePlanes() const;
 
     //! \brief Sets if overhangs are shown.
     void showOverhang(bool show);
@@ -103,6 +108,9 @@ class PartObject : public GraphicsObject {
 
     //! \brief Repaints the feature-edge overlay to match the current part transparency.
     void updateFeatureEdgeAppearance();
+    //! \brief Creates a layer settings range plane object.
+    QSharedPointer<PlaneObject> createLayerSettingsRangePlane();
+
     //! \brief Part pointer.
     QSharedPointer<Part> m_part;
 
@@ -114,6 +122,7 @@ class PartObject : public GraphicsObject {
     QSharedPointer<TextObject> m_label_object;
     QSharedPointer<AxesObject> m_axes_object;
     QSharedPointer<PlaneObject> m_plane_object;
+    QVector<QSharedPointer<PlaneObject>> m_layer_settings_range_objects;
     //! \brief Optional overlay that draws silhouette and sharp feature edges over shaded parts.
     QSharedPointer<GraphicsObject> m_feature_edge_object;
 

--- a/include/graphics/view/part_view.h
+++ b/include/graphics/view/part_view.h
@@ -4,6 +4,7 @@
 #include <qhashfunctions.h>
 #include <qlist.h>
 #include <qmap.h>
+#include <qpair.h>
 #include <qpoint.h>
 #include <qquaternion.h>
 #include <qset.h>
@@ -59,6 +60,12 @@ class PartView : public BaseView {
 
     //! \brief Shows or hides part slicing planes.
     void showSlicingPlanes(bool show);
+
+    //! \brief Shows or hides selected layer settings range plane.
+    void showLayerSettingsRange(bool show);
+
+    //! \brief Sets the selected layer settings range plane targets.
+    void setLayerSettingsRanges(QSharedPointer<Part> part, QList<QPair<int, int>> layer_ranges);
 
     //! \brief Shows or hides overhangs.
     void showOverhang(bool show);
@@ -231,6 +238,15 @@ class PartView : public BaseView {
         //! \brief If slicing planes are shown.
         bool planes_shown = false;
 
+        //! \brief If selected layer settings range plane is shown.
+        bool layer_settings_range_shown = false;
+
+        //! \brief Part whose selected layer settings range should be shown.
+        QSharedPointer<Part> layer_settings_range_part = nullptr;
+
+        //! \brief Selected layer settings range indices.
+        QList<QPair<int, int>> layer_settings_ranges;
+
         //! \brief If name plates are shown.
         bool names_shown = false;
 
@@ -256,6 +272,19 @@ class PartView : public BaseView {
     //! \param name: Name to find.
     //! \todo This should be removed when center part uses selection.
     QSharedPointer<PartObject> findObject(QString name);
+
+    //! \brief Finds an object based on its part pointer.
+    QSharedPointer<PartObject> findObject(QSharedPointer<Part> part);
+
+    //! \brief Updates the selected layer settings range plane visibility and placement.
+    void updateLayerSettingsRangePlane();
+
+    //! \brief Hides all layer settings range planes.
+    void hideLayerSettingsRangePlanes();
+
+    //! \brief Calculates selected layer settings range geometry for display.
+    bool layerSettingsRangeGeometry(QSharedPointer<PartObject> gop, int low_layer, int high_layer,
+                                    QVector3D& center, float& thickness) const;
 
     //! \brief Blocks the model from modifying the view. Useful when making model changes in the view to prevent
     //! feedback.

--- a/include/widgets/layerbar.h
+++ b/include/widgets/layerbar.h
@@ -21,6 +21,7 @@
 #include <QWidget>
 #include <qcontainerfwd.h>
 #include <qlist.h>
+#include <qpair.h>
 #include <qsharedpointer.h>
 #include <qsize.h>
 #include <qtmetamacros.h>
@@ -72,6 +73,15 @@ class LayerBar : public QWidget {
     //! \brief Signal that the selection has been altered.
     //! \param name_and_bases: Label plus list of ranges currently selected
     void setSelectedSettings(QPair<QString, QList<QSharedPointer<SettingsBase>>> name_and_bases);
+
+    //! \brief Signal that the selected layer settings ranges changed.
+    //! \param part: Part that owns the selected ranges, or null when no layer range is selected.
+    //! \param layer_ranges: Selected layer index ranges.
+    void selectedLayerSettingsRangesChanged(QSharedPointer<Part> part, QList<QPair<int, int>> layer_ranges);
+
+    //! \brief Signal that layer-specific settings availability changed for the current part.
+    //! \param available: if the current part has layer-specific settings that can be visualized.
+    void layerSettingsRangeAvailabilityChanged(bool available);
 
     //! \brief Signal that a settings range needs to be deleted
     void deleteDot(LayerDot* dot);
@@ -248,6 +258,9 @@ class LayerBar : public QWidget {
 
     //! \brief determines what ranges are selected and emits accordingly
     void changeSelectedSettings();
+
+    //! \brief emits if the current part has any layer-specific settings
+    void updateLayerSettingsRangeAvailability();
 
     //! \brief Select a given dot and its group/range
     void selectDot(LayerDot* dot);

--- a/include/widgets/main_toolbar.h
+++ b/include/widgets/main_toolbar.h
@@ -36,6 +36,10 @@ class MainToolbar : public QToolBar {
     //! \param checked: if the planes should be displayed
     void showSlicingPlanes(bool checked);
 
+    //! \brief signals when the selected layer settings range plane should/ shouldn't be displayed
+    //! \param checked: if the selected layer settings range plane should be displayed
+    void showLayerSettingsRange(bool checked);
+
     //! \brief signals when the overhang should/ shouldn't be displayed
     //! \param checked: if overhang should be displayed
     void showOverhang(bool checked);
@@ -83,6 +87,10 @@ class MainToolbar : public QToolBar {
     //! \brief enables/ disables the export Gcode button
     //! \param status: if the export button is enabled
     void setExportAbility(bool status);
+
+    //! \brief enables/ disables the layer settings range button
+    //! \param status: if any layer-specific settings are available for display
+    void setLayerSettingsRangeAbility(bool status);
 
     //! \brief updates seams button from settings
     //! \param setting_key: the new settings
@@ -139,6 +147,7 @@ class MainToolbar : public QToolBar {
     QToolButton* m_add_btn;
     QToolButton* m_shape_btn;
     QToolButton* m_slicing_planes_btn;
+    QToolButton* m_layer_settings_range_btn;
     QToolButton* m_seam_btn;
     QToolButton* m_overhang_button;
     QToolButton* m_billboarding_button;
@@ -147,5 +156,8 @@ class MainToolbar : public QToolBar {
     QToolButton* m_show_ghosts_btn;
     QToolButton* m_export_gcode_btn;
     QToolButton* m_slice_btn;
+
+    //! \brief if selected part has layer-specific settings available for visualization
+    bool m_layer_settings_range_available = false;
 };
 } // namespace ORNL

--- a/include/widgets/part_widget/part_widget.h
+++ b/include/widgets/part_widget/part_widget.h
@@ -11,6 +11,7 @@
 #include <QWidget>
 #include <qlist.h>
 #include <qobject.h>
+#include <qpair.h>
 #include <qset.h>
 #include <qsharedpointer.h>
 #include <qsize.h>
@@ -127,6 +128,15 @@ class PartWidget : public QWidget {
     //! \brief enables/ disables showing slicing planes
     //! \param show enables/ disables
     void showSlicingPlanes(bool show);
+
+    //! \brief enables/ disables showing the selected layer settings range
+    //! \param show enables/ disables
+    void showLayerSettingsRange(bool show);
+
+    //! \brief sets the layer settings range visualization targets
+    //! \param part part that owns the selected range
+    //! \param layer_ranges selected layer ranges
+    void setLayerSettingsRanges(QSharedPointer<Part> part, QList<QPair<int, int>> layer_ranges);
 
     //! \brief enables/ disables showing labels
     //! \param show enables/ disables

--- a/src/graphics/objects/cube/plane_object.cpp
+++ b/src/graphics/objects/cube/plane_object.cpp
@@ -9,9 +9,13 @@
 
 namespace ORNL {
 PlaneObject::PlaneObject(BaseView* view, float length, float width, QColor color)
-    : CubeObject(view, length, width, 0.01, color) {
+    : PlaneObject(view, length, width, 0.01f, color) {}
+
+PlaneObject::PlaneObject(BaseView* view, float length, float width, float height, QColor color)
+    : CubeObject(view, length, width, height, color) {
     m_starting_length = length;
     m_starting_width = width;
+    m_starting_height = height;
     m_color = color;
 }
 
@@ -23,7 +27,12 @@ void PlaneObject::setLockedRotationQuaternion(const QQuaternion& rotation) {
 void PlaneObject::setLockedRotation(bool lock) { m_rotation_toggle = lock; }
 
 void PlaneObject::updateDimensions(float length, float width) {
-    this->scaleAbsolute(QVector3D(length / m_starting_length, width / m_starting_width, 1));
+    updateDimensions(length, width, m_starting_height);
+}
+
+void PlaneObject::updateDimensions(float length, float width, float height) {
+    this->scaleAbsolute(
+        QVector3D(length / m_starting_length, width / m_starting_width, height / m_starting_height));
 }
 
 void PlaneObject::transformationCallback() {

--- a/src/graphics/objects/part_object.cpp
+++ b/src/graphics/objects/part_object.cpp
@@ -306,6 +306,8 @@ PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mod
     this->adoptChild(gos);
     m_plane_object = gos;
 
+    this->createLayerSettingsRangePlane();
+
     // Object translation happens last since it will callback (see translationCallback()) this object and everything
     // needs to be setup first.
     QVector3D trans;
@@ -450,6 +452,42 @@ QSharedPointer<TextObject> PartObject::label() { return m_label_object; }
 QSharedPointer<AxesObject> PartObject::axes() { return m_axes_object; }
 
 QSharedPointer<PlaneObject> PartObject::plane() { return m_plane_object; }
+
+QSharedPointer<PlaneObject> PartObject::layerSettingsRangePlane(int index) {
+    index = std::max(index, 0);
+
+    while (m_layer_settings_range_objects.size() <= index) {
+        this->createLayerSettingsRangePlane();
+    }
+
+    return m_layer_settings_range_objects[index];
+}
+
+QVector<QSharedPointer<PlaneObject>> PartObject::layerSettingsRangePlanes() const {
+    return m_layer_settings_range_objects;
+}
+
+QSharedPointer<PlaneObject> PartObject::createLayerSettingsRangePlane() {
+    float length = this->maximum().x() - this->minimum().x();
+    float width = this->maximum().y() - this->minimum().y();
+    float depth = this->maximum().z() - this->minimum().z();
+    float max_dim = std::fmax(length, std::fmax(width, depth));
+    max_dim += max_dim * 0.20f;
+    max_dim = std::fmax(max_dim, 1.0f);
+
+    QColor layer_settings_range_color = Constants::Colors::kOrange;
+    layer_settings_range_color.setAlpha(80);
+
+    auto range_plane =
+        QSharedPointer<PlaneObject>::create(this->view(), max_dim, max_dim, 1.0f, layer_settings_range_color);
+    range_plane->setLockedRotation(true);
+    range_plane->hide();
+
+    this->adoptChild(range_plane);
+    m_layer_settings_range_objects.append(range_plane);
+
+    return range_plane;
+}
 
 void PartObject::showOverhang(bool show) {
     m_overhang_shown = show;

--- a/src/graphics/view/part_view.cpp
+++ b/src/graphics/view/part_view.cpp
@@ -25,6 +25,7 @@
 #include <qtypes.h>
 #include <qvectornd.h>
 
+#include "configs/settings_range.h"
 #include "graphics/graphics_object.h"
 #include "graphics/objects/axes_object.h"
 #include "graphics/objects/cube/plane_object.h"
@@ -47,6 +48,10 @@
 #include "widgets/part_widget/right_click_menu.h"
 
 namespace ORNL {
+namespace {
+constexpr float kMinimumLayerSettingsRangeThickness = 0.01f;
+} // namespace
+
 PartView::PartView(QSharedPointer<SettingsBase> sb) {
     m_menu = new RightClickMenu(this);
     m_sb = sb;
@@ -108,6 +113,17 @@ void PartView::showSlicingPlanes(bool show) {
     m_state.planes_shown = show;
 
     this->update();
+}
+
+void PartView::showLayerSettingsRange(bool show) {
+    m_state.layer_settings_range_shown = show;
+    updateLayerSettingsRangePlane();
+}
+
+void PartView::setLayerSettingsRanges(QSharedPointer<Part> part, QList<QPair<int, int>> layer_ranges) {
+    m_state.layer_settings_range_part = part;
+    m_state.layer_settings_ranges = layer_ranges;
+    updateLayerSettingsRangePlane();
 }
 
 void PartView::showOverhang(bool show) {
@@ -349,7 +365,12 @@ void PartView::updateSlicingSettings(QSharedPointer<SettingsBase> sb) {
 
     for (auto& gop : m_part_objects) {
         gop->plane()->setLockedRotationQuaternion(rotation);
+        for (auto& range_plane : gop->layerSettingsRangePlanes()) {
+            range_plane->setLockedRotationQuaternion(rotation);
+        }
     }
+
+    updateLayerSettingsRangePlane();
 
     // Changing the plane affects the overhang angle
     updateOverhangSettings(sb);
@@ -807,6 +828,7 @@ void PartView::modelAdditionUpdate(QSharedPointer<PartMetaItem> pm) {
         gop->plane()->show();
     if (m_state.names_shown)
         gop->label()->show();
+    updateLayerSettingsRangePlane();
 
     this->blockModel();
     m_model->lookupByGraphic(gop)->setTranslation(gop->translation());
@@ -854,6 +876,8 @@ void PartView::modelRemovalUpdate(QSharedPointer<PartMetaItem> pm) {
 
     if (m_state.highlighted_part == gop)
         m_state.highlighted_part = nullptr;
+
+    updateLayerSettingsRangePlane();
 
     this->update();
 }
@@ -914,6 +938,8 @@ void PartView::modelTranformUpdate(QSharedPointer<PartMetaItem> pm) {
     }
 
     this->postTransformCheck();
+
+    updateLayerSettingsRangePlane();
 
     this->update();
 }
@@ -1066,6 +1092,206 @@ QSharedPointer<PartObject> PartView::findObject(QString name) {
     }
 
     return gop;
+}
+
+QSharedPointer<PartObject> PartView::findObject(QSharedPointer<Part> part) {
+    if (part.isNull())
+        return nullptr;
+
+    for (auto& go : m_part_objects) {
+        if (go->part() == part)
+            return go;
+    }
+
+    return nullptr;
+}
+
+void PartView::updateLayerSettingsRangePlane() {
+    hideLayerSettingsRangePlanes();
+
+    if (!m_state.layer_settings_range_shown || m_state.layer_settings_range_part.isNull() ||
+        m_state.layer_settings_ranges.isEmpty()) {
+        this->update();
+        return;
+    }
+
+    QSharedPointer<PartObject> gop = findObject(m_state.layer_settings_range_part);
+    if (gop.isNull()) {
+        this->update();
+        return;
+    }
+
+    QVector3D slicing_vector = {m_sb->setting<float>(PS::Slicing::kSlicingVectorX),
+                                m_sb->setting<float>(PS::Slicing::kSlicingVectorY),
+                                m_sb->setting<float>(PS::Slicing::kSlicingVectorZ)};
+    if (slicing_vector.isNull()) {
+        this->update();
+        return;
+    }
+    slicing_vector.normalize();
+
+    float length = gop->maximum().x() - gop->minimum().x();
+    float width = gop->maximum().y() - gop->minimum().y();
+    float depth = gop->maximum().z() - gop->minimum().z();
+    float max_dim = std::fmax(length, std::fmax(width, depth));
+    max_dim += max_dim * 0.20f;
+
+    int visible_plane_index = 0;
+    for (const QPair<int, int>& layer_range : m_state.layer_settings_ranges) {
+        QVector3D center;
+        float thickness = 0.0f;
+        if (!layerSettingsRangeGeometry(gop, layer_range.first, layer_range.second, center, thickness))
+            continue;
+
+        QSharedPointer<PlaneObject> range_plane = gop->layerSettingsRangePlane(visible_plane_index);
+        range_plane->updateDimensions(max_dim, max_dim, thickness);
+        range_plane->setLockedRotationQuaternion(QQuaternion::fromDirection(slicing_vector, QVector3D(0, 0, 1)));
+        range_plane->translateAbsolute(center);
+        range_plane->show();
+
+        ++visible_plane_index;
+    }
+
+    this->update();
+}
+
+void PartView::hideLayerSettingsRangePlanes() {
+    for (auto& gop : m_part_objects) {
+        for (auto& range_plane : gop->layerSettingsRangePlanes()) {
+            range_plane->hide();
+        }
+    }
+}
+
+bool PartView::layerSettingsRangeGeometry(QSharedPointer<PartObject> gop, int low_layer, int high_layer,
+                                          QVector3D& center, float& thickness) const {
+    if (gop.isNull() || gop->part().isNull() || gop->part()->rootMesh().isNull())
+        return false;
+
+    const int low = qMin(low_layer, high_layer);
+    const int high = qMax(low_layer, high_layer);
+    if (low < 0 || high < low)
+        return false;
+
+    QVector3D slicing_vector = {m_sb->setting<float>(PS::Slicing::kSlicingVectorX),
+                                m_sb->setting<float>(PS::Slicing::kSlicingVectorY),
+                                m_sb->setting<float>(PS::Slicing::kSlicingVectorZ)};
+    if (slicing_vector.isNull())
+        return false;
+    slicing_vector.normalize();
+
+    std::vector<Triangle> triangles = gop->triangles();
+    if (triangles.empty())
+        return false;
+
+    bool initialized = false;
+    double min_projection = 0.0;
+    double max_projection = 0.0;
+
+    for (const Triangle& triangle : triangles) {
+        const QVector3D points[] = {triangle.a, triangle.b, triangle.c};
+        for (const QVector3D& point : points) {
+            const double projection = QVector3D::dotProduct(point, slicing_vector);
+
+            if (!initialized || projection < min_projection) {
+                min_projection = projection;
+            }
+
+            if (!initialized || projection > max_projection) {
+                max_projection = projection;
+            }
+
+            initialized = true;
+        }
+    }
+
+    if (!initialized)
+        return false;
+
+    const double part_height = max_projection - min_projection;
+    if (part_height <= 0.0)
+        return false;
+
+    Distance base_layer_height;
+    if (gop->part()->getSb()->contains(PS::Layer::kLayerHeight))
+        base_layer_height = gop->part()->getSb()->setting<Distance>(PS::Layer::kLayerHeight);
+    else
+        base_layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+
+    const auto normal_height = [](Distance layer_height) {
+        return layer_height() * Constants::OpenGL::kObjectToView;
+    };
+
+    const double base_layer_normal_height = normal_height(base_layer_height);
+    if (base_layer_normal_height <= 0.0)
+        return false;
+
+    const QMap<uint, QSharedPointer<SettingsRange>> ranges = gop->part()->getSettingsRanges();
+    const auto layer_normal_height = [&ranges, &normal_height, base_layer_normal_height](int layer) {
+        QSharedPointer<SettingsRange> selected_range;
+        for (auto i = ranges.begin(), end = ranges.end(); i != end; ++i) {
+            QSharedPointer<SettingsRange> range = i.value();
+            if (!range->includesIndex(layer))
+                continue;
+
+            if (selected_range.isNull()) {
+                selected_range = range;
+                continue;
+            }
+
+            if (range->isSingle() || range->low() > selected_range->low() ||
+                (range->low() == selected_range->low() && range->high() < selected_range->high())) {
+                selected_range = range;
+            }
+        }
+
+        if (!selected_range.isNull() && selected_range->getSb()->contains(PS::Layer::kLayerHeight))
+            return normal_height(selected_range->getSb()->setting<Distance>(PS::Layer::kLayerHeight));
+
+        return base_layer_normal_height;
+    };
+
+    double current_height = 0.0;
+    double selected_start_height = 0.0;
+    double selected_end_height = 0.0;
+    bool found_start = false;
+    bool found_end = false;
+
+    for (int layer = 0; layer <= high; ++layer) {
+        if (layer == low) {
+            selected_start_height = current_height;
+            found_start = true;
+        }
+
+        current_height += layer_normal_height(layer);
+
+        if (layer == high) {
+            selected_end_height = current_height;
+            found_end = true;
+            break;
+        }
+
+        if (current_height > part_height && layer < low)
+            return false;
+    }
+
+    if (!found_start || !found_end)
+        return false;
+
+    selected_start_height = std::min(selected_start_height, part_height);
+    selected_end_height = std::min(selected_end_height, part_height);
+    if (selected_end_height <= selected_start_height)
+        return false;
+
+    const double center_height = (selected_start_height + selected_end_height) / 2.0;
+    const double center_projection = min_projection + center_height;
+
+    center = gop->center();
+    center += slicing_vector * (center_projection - QVector3D::dotProduct(center, slicing_vector));
+    thickness = static_cast<float>(selected_end_height - selected_start_height);
+    thickness = std::max(thickness, kMinimumLayerSettingsRangeThickness);
+
+    return true;
 }
 
 void PartView::blockModel() {

--- a/src/widgets/layerbar.cpp
+++ b/src/widgets/layerbar.cpp
@@ -87,17 +87,21 @@ void LayerBar::addSingle(int layer) {
 
     LayerDot* new_dot = addDot(layer, false);  // visually add dot. Not from template
     m_part->createSettingsRange(layer, layer); // add range to part
+    updateLayerSettingsRangeAvailability();
     selectDot(new_dot);
     m_last_clicked_dot = new_dot;
+    changeSelectedSettings();
     update();
 }
 
 void LayerBar::addSingleFromTemplate(int layer, QSharedPointer<SettingsBase> sb) {
     LayerDot* new_dot = addDot(layer, true);       // visually add dot. From template
     m_part->createSettingsRange(layer, layer, sb); // add range to part with settings base
+    updateLayerSettingsRangeAvailability();
     new_dot->isFromTemplate();
     selectDot(new_dot);
     m_last_clicked_dot = new_dot;
+    changeSelectedSettings();
     update();
 }
 
@@ -114,6 +118,7 @@ void LayerBar::addRange(int lower, int upper) {
         b->setRange(range);
 
         m_part->createSettingsRange(lower, upper);
+        updateLayerSettingsRangeAvailability();
 
         update();
     }
@@ -135,6 +140,7 @@ void LayerBar::addRangeFromTemplate(int lower, int upper, QSharedPointer<Setting
         b->setRange(range);
 
         m_part->createSettingsRange(lower, upper, sb);
+        updateLayerSettingsRangeAvailability();
 
         update();
     }
@@ -240,9 +246,11 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
         QList<QSharedPointer<SettingsBase>> ranges;
         ranges.append(item->part()->getSb());
         emit setSelectedSettings(qMakePair(item->part()->name(), ranges));
+        emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
     else {
         emit setSelectedSettings(qMakePair(QString(""), QList<QSharedPointer<SettingsBase>>()));
+        emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
     // Check if new part selected and if that part's template equals the currently selected template from drop down
     // menu. If need to change part template.
@@ -264,7 +272,9 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
         QList<QSharedPointer<SettingsBase>> ranges;
         ranges.append(item->part()->getSb());
         emit setSelectedSettings(qMakePair(item->part()->name(), ranges));
+        emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
+    updateLayerSettingsRangeAvailability();
     update();
 }
 
@@ -282,6 +292,7 @@ void LayerBar::reselectPart() { // If no part selected
         m_part->setCurrentPartTemplate("<no template selected>");
         m_part->clearSettingsRanges();
         clearTemplate();
+        updateLayerSettingsRangeAvailability();
         return;
     }
 
@@ -362,9 +373,12 @@ void LayerBar::reselectPart() { // If no part selected
         QList<QSharedPointer<SettingsBase>> ranges;
         ranges.append(m_part->getSb());
         emit setSelectedSettings(qMakePair(m_part->name(), ranges));
+        emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
-    else
+    else {
         emit setSelectedSettings(qMakePair(QString(""), QList<QSharedPointer<SettingsBase>>()));
+        emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
+    }
     // Check if new part selected and if that part's template equals the currently selected template from drop down menu
     if (!(m_part->getCurrentPartTemplate() == GSM->getCurrentTemplate())) {
         m_part->clearSettingsRanges();
@@ -379,7 +393,9 @@ void LayerBar::reselectPart() { // If no part selected
         QList<QSharedPointer<SettingsBase>> ranges;
         ranges.append(m_part->getSb());
         emit setSelectedSettings(qMakePair(m_part->name(), ranges));
+        emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
+    updateLayerSettingsRangeAvailability();
     update();
 }
 
@@ -404,6 +420,7 @@ void LayerBar::removePart(QSharedPointer<Part> part) {
     clearSelection();
     qDeleteAll(m_position);
     m_part = nullptr;
+    updateLayerSettingsRangeAvailability();
 }
 
 void LayerBar::deleteSelection() {
@@ -655,6 +672,7 @@ void LayerBar::addPair() {
                 // make new combined range
                 m_part->createSettingsRange(a->getLayer(), b->getLayer());
 
+                updateLayerSettingsRangeAvailability();
                 clearSelection();
                 update();
             }
@@ -770,6 +788,7 @@ void LayerBar::addGroup() {
                 m_part->createSettingsRange(dot->getLayer(), dot->getLayer(), group_name);
             }
         }
+        updateLayerSettingsRangeAvailability();
     }
 }
 
@@ -794,6 +813,7 @@ void LayerBar::groupDots() {
         }
     }
 
+    updateLayerSettingsRangeAvailability();
     clearSelection();
 }
 
@@ -875,6 +895,7 @@ void LayerBar::makePair() {
     // make new combined range
     m_part->createSettingsRange(a->getLayer(), b->getLayer());
 
+    updateLayerSettingsRangeAvailability();
     clearSelection();
     update();
 }
@@ -1318,6 +1339,8 @@ void LayerBar::deleteSingle(LayerDot* dot) {
     {
         m_part->removeSettingsRange(dot->getLayer(), dot->getLayer());
     }
+
+    updateLayerSettingsRangeAvailability();
 }
 
 void LayerBar::removeFromGrp(LayerDot* dot) {
@@ -1530,12 +1553,14 @@ void LayerBar::clear() {
     m_position.clear();
     m_part = nullptr;
 
+    updateLayerSettingsRangeAvailability();
     update();
 }
 
 void LayerBar::clearTemplate() {
     // m_position.clear();
     m_deleted_ranges.clear();
+    updateLayerSettingsRangeAvailability();
 }
 
 void LayerBar::deleteRange(LayerBar::dot_range* range) {
@@ -1546,6 +1571,7 @@ void LayerBar::deleteRange(LayerBar::dot_range* range) {
     m_part->removeSettingsRange(range->a->getLayer(), range->b->getLayer());
 
     delete range;
+    updateLayerSettingsRangeAvailability();
 }
 
 void LayerBar::splitRange(LayerBar::dot_range* range) {
@@ -1555,12 +1581,23 @@ void LayerBar::splitRange(LayerBar::dot_range* range) {
     m_part->splitSettingsRange(range->a->getLayer(), range->b->getLayer());
 
     delete range;
+    updateLayerSettingsRangeAvailability();
 }
 
 void LayerBar::handleModifiedSetting(QString key) {
     if (key == PS::Layer::kLayerHeight || key == PS::Slicing::kSlicingVectorX || key == PS::Slicing::kSlicingVectorY ||
         key == PS::Slicing::kSlicingVectorZ) {
         updateLayers();
+
+        for (int i = m_selection.size() - 1; i >= 0; --i) {
+            LayerDot* dot = m_selection[i];
+            if (dot == nullptr || dot->getLayer() < 0 || dot->getLayer() >= m_position.size() ||
+                m_position[dot->getLayer()] != dot) {
+                m_selection.removeAt(i);
+            }
+        }
+
+        changeSelectedSettings();
     }
 }
 
@@ -1631,9 +1668,25 @@ bool LayerBar::onLayer(LayerDot* dot, int layer) {
     return layer > 0 && layer <= m_layers && m_position[layer] == dot;
 }
 
+void LayerBar::updateLayerSettingsRangeAvailability() {
+    emit layerSettingsRangeAvailabilityChanged(!m_part.isNull() && !m_part->getSettingsRanges().isEmpty());
+}
+
 void LayerBar::changeSelectedSettings() {
+    if (m_part == nullptr) {
+        emit setSelectedSettings(qMakePair(QString(""), QList<QSharedPointer<SettingsBase>>()));
+        emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
+        updateLayerSettingsRangeAvailability();
+        return;
+    }
+
     QVector<QString> names;
     QList<QSharedPointer<SettingsBase>> settings_bases;
+    QList<QPair<int, int>> selected_layer_ranges;
+
+    auto include_visual_layer_range = [&selected_layer_ranges](int low, int high) {
+        selected_layer_ranges.append(qMakePair(qMin(low, high), qMax(low, high)));
+    };
 
     QVector<LayerDot*> selected_copy = m_selection;
     // sort from low to high, so that low value is always found first
@@ -1645,8 +1698,9 @@ void LayerBar::changeSelectedSettings() {
         LayerDot* dot = selected_copy[i];
 
         if (dot->getRange() != nullptr) {
-            int low = dot->getLayer();
-            int high = dot->getPair()->getLayer();
+            int low = qMin(dot->getLayer(), dot->getPair()->getLayer());
+            int high = qMax(dot->getLayer(), dot->getPair()->getLayer());
+            include_visual_layer_range(low, high);
 
             selected_copy.removeAt(selected_copy.indexOf(dot->getPair()));
 
@@ -1662,6 +1716,10 @@ void LayerBar::changeSelectedSettings() {
             QString name = dot_group->group_name;
             names.append(name);
 
+            for (LayerDot* grouped_dot : dot_group->grouped) {
+                include_visual_layer_range(grouped_dot->getLayer(), grouped_dot->getLayer());
+            }
+
             // dots in the same group share a pointer to the same settings base
             // so just get the sb of one dot
             auto range = m_part->getSettingsRange(dot->getLayer(), dot->getLayer());
@@ -1675,11 +1733,30 @@ void LayerBar::changeSelectedSettings() {
         }
         else {
             int layer_num = dot->getLayer();
+            include_visual_layer_range(layer_num, layer_num);
             auto range = m_part->getSettingsRange(layer_num, layer_num);
             QString name = "Layer " + QString::number(layer_num + 1);
             names.append(name);
             settings_bases.append(range->getSb());
         }
+    }
+
+    std::sort(selected_layer_ranges.begin(), selected_layer_ranges.end(),
+              [](const QPair<int, int>& a, const QPair<int, int>& b) {
+                  if (a.first == b.first)
+                      return a.second < b.second;
+
+                  return a.first < b.first;
+              });
+
+    QList<QPair<int, int>> merged_layer_ranges;
+    for (const QPair<int, int>& layer_range : selected_layer_ranges) {
+        if (merged_layer_ranges.isEmpty() || layer_range.first > merged_layer_ranges.last().second + 1) {
+            merged_layer_ranges.append(layer_range);
+            continue;
+        }
+
+        merged_layer_ranges.last().second = qMax(merged_layer_ranges.last().second, layer_range.second);
     }
 
     QString final;
@@ -1709,6 +1786,9 @@ void LayerBar::changeSelectedSettings() {
     }
 
     emit setSelectedSettings(qMakePair(final, settings_bases));
+    emit selectedLayerSettingsRangesChanged(names.isEmpty() ? nullptr : m_part,
+                                            names.isEmpty() ? QList<QPair<int, int>>() : merged_layer_ranges);
+    updateLayerSettingsRangeAvailability();
 }
 
 void LayerBar::clearSelection() {

--- a/src/widgets/main_toolbar.cpp
+++ b/src/widgets/main_toolbar.cpp
@@ -86,6 +86,15 @@ void MainToolbar::setupSubWidgets() {
     connect(m_slicing_planes_btn, &QToolButton::toggled, this,
             [this](bool checked) { emit showSlicingPlanes(checked); });
 
+    // Layer Settings Range Button
+    m_layer_settings_range_btn =
+        buildIconButton(":/icons/layers_black.png", "Show selected layer settings height", true);
+    m_layer_settings_range_btn->setEnabled(false);
+    m_layer_settings_range_btn->setToolTip("No layer-specific settings to show");
+    this->addWidget(m_layer_settings_range_btn);
+    connect(m_layer_settings_range_btn, &QToolButton::toggled, this,
+            [this](bool checked) { emit showLayerSettingsRange(checked); });
+
     // Seam buttons
     m_seam_btn = buildIconButton(":/icons/map_markers_black.png", "Show optimization points", true);
     handleModifiedSetting("");
@@ -384,6 +393,7 @@ void MainToolbar::enableCorrectOptions() {
         m_add_btn->setEnabled(false);
         m_shape_btn->setEnabled(false);
         m_slicing_planes_btn->setEnabled(false);
+        m_layer_settings_range_btn->setEnabled(false);
         m_overhang_button->setEnabled(false);
         m_billboarding_button->setEnabled(false);
         m_seam_btn->setEnabled(false);
@@ -396,6 +406,7 @@ void MainToolbar::enableCorrectOptions() {
         m_add_btn->setEnabled(true);
         m_shape_btn->setEnabled(true);
         m_slicing_planes_btn->setEnabled(true);
+        m_layer_settings_range_btn->setEnabled(m_layer_settings_range_available);
         m_overhang_button->setEnabled(true);
         m_billboarding_button->setEnabled(true);
         m_segment_info_button->setEnabled(false);
@@ -491,6 +502,20 @@ void MainToolbar::resize(QSize new_size) {
 void MainToolbar::setSliceAbility(bool status) { m_slice_btn->setEnabled(status); }
 
 void MainToolbar::setExportAbility(bool status) { m_export_gcode_btn->setEnabled(status); }
+
+void MainToolbar::setLayerSettingsRangeAbility(bool status) {
+    m_layer_settings_range_available = status;
+
+    if (!status) {
+        m_layer_settings_range_btn->setToolTip("No layer-specific settings to show");
+        m_layer_settings_range_btn->setChecked(false);
+    }
+    else {
+        m_layer_settings_range_btn->setToolTip("Show selected layer settings height");
+    }
+
+    enableCorrectOptions();
+}
 
 void MainToolbar::handleModifiedSetting(const QString& setting_key) {
     IslandOrderOptimization islandOrder =

--- a/src/widgets/part_widget/part_widget.cpp
+++ b/src/widgets/part_widget/part_widget.cpp
@@ -191,6 +191,12 @@ void PartWidget::preSliceUpdate() {
 
 void PartWidget::showSlicingPlanes(bool show) { m_part_view->showSlicingPlanes(show); }
 
+void PartWidget::showLayerSettingsRange(bool show) { m_part_view->showLayerSettingsRange(show); }
+
+void PartWidget::setLayerSettingsRanges(QSharedPointer<Part> part, QList<QPair<int, int>> layer_ranges) {
+    m_part_view->setLayerSettingsRanges(part, layer_ranges);
+}
+
 void PartWidget::showLabels(bool show) { m_part_view->showLabels(show); }
 
 void PartWidget::showSeams(bool show) { m_part_view->showSeams(show); }

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -903,6 +903,10 @@ void MainWindow::setupEvents() {
 
     // Connect layerbar to settingbar
     connect(m_layerbar, &LayerBar::setSelectedSettings, m_settingbar, &SettingBar::settingsBasesSelected);
+    connect(m_layerbar, &LayerBar::selectedLayerSettingsRangesChanged, m_part_widget,
+            &PartWidget::setLayerSettingsRanges);
+    connect(m_layerbar, &LayerBar::layerSettingsRangeAvailabilityChanged, m_main_toolbar,
+            &MainToolbar::setLayerSettingsRangeAbility);
 
     // Part widget connection
     connect(m_part_widget, &PartWidget::selected, this,
@@ -962,6 +966,8 @@ void MainWindow::setupEvents() {
     // Toolbar -> Part Widget
     connect(m_main_toolbar, &MainToolbar::slice, m_part_widget, &PartWidget::preSliceUpdate);
     connect(m_main_toolbar, &MainToolbar::showSlicingPlanes, m_part_widget, &PartWidget::showSlicingPlanes);
+    connect(m_main_toolbar, &MainToolbar::showLayerSettingsRange, m_part_widget,
+            &PartWidget::showLayerSettingsRange);
     connect(m_main_toolbar, &MainToolbar::showLabels, m_part_widget, &PartWidget::showLabels);
     connect(m_main_toolbar, &MainToolbar::showSeams, m_part_widget, &PartWidget::showSeams);
     connect(m_main_toolbar, &MainToolbar::showOverhang, m_part_widget, &PartWidget::showOverhang);


### PR DESCRIPTION
## Summary
- Add a toolbar toggle for visualizing layer-specific settings regions in the part view.
- Render translucent range planes at the affected layer heights, including separate planes for non-consecutive selected ranges.
- Disable the visualization toggle when the selected part has no layer-specific settings.

## Impact
This gives users immediate visual feedback for which portion of a part is affected while editing layer-specific settings, without showing a misleading plane when no layer settings exist.

## Validation
- `nix develop -c cmake --build build/generic-llvm-ninja -j2`
- `git diff --check`

Addresses #157.