### PR TITLE
Save project warning for issue #17

### DIFF
--- a/include/managers/preferences_manager.h
+++ b/include/managers/preferences_manager.h
@@ -127,6 +127,9 @@ class PreferencesManager : public QObject {
     //! \return if true widths should be used
     bool getUseTrueWidthsPreference();
 
+    //! \brief Return the user preference for warning about unsaved projects when closing
+    bool getWarnUnsavedProjectOnClosePreference();
+
     //! \brief Return the window preference for maximization
     bool getWindowMaximizedPreference();
 
@@ -339,6 +342,9 @@ class PreferencesManager : public QObject {
     //! \param use if true widths should be used
     void setUseTrueWidthsPreference(bool use);
 
+    //! \brief Sets the preference for warning about unsaved projects when closing
+    void setWarnUnsavedProjectOnClosePreference(bool warn);
+
     //! \brief Sets the unit used for rotation
     void setRotationUnit(QString unit);
 
@@ -406,6 +412,7 @@ class PreferencesManager : public QObject {
     bool m_hide_travel_preference;
     bool m_hide_support_preference;
     bool m_use_true_widths_preference;
+    bool m_warn_unsaved_project_on_close_preference;
 
     //! \brief Preferences for window size and position
     bool m_is_maximized;

--- a/include/widgets/settings/setting_bar.h
+++ b/include/widgets/settings/setting_bar.h
@@ -76,6 +76,12 @@ class SettingBar : public QWidget {
      */
     void settingModified(QString setting_key);
 
+    /*!
+     * \brief Signals that the selected settings base has been changed.
+     * \param setting_base Name of the newly selected settings base.
+     */
+    void settingsBaseChanged(QString setting_base);
+
     //! \brief Signal for main window to notify that a setting tab has been hidden
     //! \param pane Pane that setting is contained in
     //! \param category Setting header to add

--- a/include/windows/main_window.h
+++ b/include/windows/main_window.h
@@ -216,6 +216,29 @@ class MainWindow : public QMainWindow {
     //! \brief Remove tracked part transform state.
     void removePartTransform(QSharedPointer<PartMetaItem> item);
 
+    //! \brief Save the current session through a project file dialog.
+    //! \param notifyOnSuccess Whether to show the existing save-success notification.
+    //! \param waitForSave Whether to wait for the save thread to finish before returning.
+    //! \param selectedFile Optional destination for the selected project file path.
+    //! \return True if the user selected a file and the save was started.
+    bool saveSessionToSelectedFile(bool notifyOnSuccess, bool waitForSave = false, QString* selectedFile = nullptr);
+
+    //! \brief Ask the user whether unsaved project changes should be saved before closing.
+    //! \return True if the close should continue.
+    bool confirmProjectClose();
+
+    //! \brief Create a comparable snapshot of the project data that is saved to .s2p files.
+    QString projectStateSnapshot();
+
+    //! \brief Store the current project state as the last saved/loaded state.
+    void updateSavedProjectState();
+
+    //! \brief Mark the project as having user-originated changes.
+    void markProjectModified();
+
+    //! \brief Check whether the project has unsaved changes.
+    bool hasUnsavedProjectChanges();
+
   private:
     //! \brief Struct to retain action information efficiently.
     struct menu_info {
@@ -322,6 +345,12 @@ class MainWindow : public QMainWindow {
 
     //! \brief Current window status.
     bool m_status;
+
+    //! \brief Last explicit saved/loaded project state.
+    QString m_saved_project_state;
+
+    //! \brief Whether a user action has changed saveable project state since the last save/load.
+    bool m_project_modified = false;
 
     //! \brief Temporary stuff here
     uint m_object_count = 0;

--- a/include/windows/preferences_window.h
+++ b/include/windows/preferences_window.h
@@ -92,6 +92,7 @@ class PreferencesWindow : public QMainWindow {
     QComboBox* m_mass_unit_combobox;
     QComboBox* m_rotation_unit_combobox;
     QComboBox* m_theme_combobox;
+    QCheckBox* m_warn_unsaved_project_on_close_checkbox;
 
     //! \brief List of groupboxes that hold radio buttons for various preferences
     QList<QGroupBox*> m_boxes;

--- a/src/managers/preferences_manager.cpp
+++ b/src/managers/preferences_manager.cpp
@@ -87,10 +87,10 @@ PreferencesManager::PreferencesManager()
       m_mass_unit(kg), m_project_shift_preference(PreferenceChoice::kAsk),
       m_file_shift_preference(PreferenceChoice::kPerformAutomatically), m_align_preference(PreferenceChoice::kAsk),
       m_hide_travel_preference(false), m_hide_support_preference(false), m_use_true_widths_preference(true),
-      m_themeName(ThemeName::kLightMode), m_theme(static_cast<int>(m_themeName)),
-      m_rotation_unit(RotationUnit::kPitchRollYaw), m_dirty(false), m_is_maximized(false), m_window_size(-1, -1),
-      m_window_pos(-1, -1), m_use_implicit_transforms(false), m_always_drop_parts(false), m_layer_lag(100),
-      m_segment_lag(10) {
+      m_warn_unsaved_project_on_close_preference(true), m_themeName(ThemeName::kLightMode),
+      m_theme(static_cast<int>(m_themeName)), m_rotation_unit(RotationUnit::kPitchRollYaw), m_dirty(false),
+      m_is_maximized(false), m_window_size(-1, -1), m_window_pos(-1, -1), m_use_implicit_transforms(false),
+      m_always_drop_parts(false), m_layer_lag(100), m_segment_lag(10) {
     m_hidden_settings["Printer"] = std::list<std::string>();
     m_hidden_settings["Material"] = std::list<std::string>();
     m_hidden_settings["Profile"] = std::list<std::string>();
@@ -233,6 +233,9 @@ void PreferencesManager::importPreferences(QString filepath) {
         if (j.contains("use_true_widths"))
             setUseTrueWidthsPreference(j["use_true_widths"]);
 
+        if (j.contains("warn_unsaved_project_on_close"))
+            setWarnUnsavedProjectOnClosePreference(j["warn_unsaved_project_on_close"]);
+
         std::unordered_map<std::string, std::string> visualizationColorsHex;
         if (j.find("visualization_colors") != j.end())
             visualizationColorsHex = j.at("visualization_colors").get<std::unordered_map<std::string, std::string>>();
@@ -277,6 +280,7 @@ fifojson PreferencesManager::json() {
     j["hide_travel"] = m_hide_travel_preference;
     j["hide_support"] = m_hide_support_preference;
     j["use_true_widths"] = m_use_true_widths_preference;
+    j["warn_unsaved_project_on_close"] = m_warn_unsaved_project_on_close_preference;
     j["hidden_settings"] = m_hidden_settings;
     j["rotation"] = m_rotation_unit;
     j["invert_camera"] = m_invert_camera;
@@ -346,6 +350,10 @@ bool PreferencesManager::getHideTravelPreference() { return m_hide_travel_prefer
 bool PreferencesManager::getHideSupportPreference() { return m_hide_support_preference; }
 
 bool PreferencesManager::getUseTrueWidthsPreference() { return m_use_true_widths_preference; }
+
+bool PreferencesManager::getWarnUnsavedProjectOnClosePreference() {
+    return m_warn_unsaved_project_on_close_preference;
+}
 
 bool PreferencesManager::getWindowMaximizedPreference() { return m_is_maximized; }
 
@@ -565,6 +573,11 @@ void PreferencesManager::setHideSupportPreference(bool hide) {
 
 void PreferencesManager::setUseTrueWidthsPreference(bool use) {
     m_use_true_widths_preference = use;
+    m_dirty = true;
+}
+
+void PreferencesManager::setWarnUnsavedProjectOnClosePreference(bool warn) {
+    m_warn_unsaved_project_on_close_preference = warn;
     m_dirty = true;
 }
 

--- a/src/widgets/settings/setting_bar.cpp
+++ b/src/widgets/settings/setting_bar.cpp
@@ -284,6 +284,7 @@ void SettingBar::updateSettings(QString text) {
         mostRecentSetting[paneMapping[m_tab_widget->currentIndex()]] = text;
         CSM->setMostRecentSettingHistory(paneMapping[m_tab_widget->currentIndex()], text);
         enableDependRows();
+        emit settingsBaseChanged(text);
     }
 }
 

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -1532,6 +1532,9 @@ bool MainWindow::hasUnsavedProjectChanges() {
 }
 
 bool MainWindow::confirmProjectClose() {
+    if (!PreferencesManager::getInstance()->getWarnUnsavedProjectOnClosePreference())
+        return true;
+
     if (!hasUnsavedProjectChanges())
         return true;
 

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -53,6 +53,7 @@
 #include "threading/session_loader.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
+#include "utilities/qt_json_conversion.h"
 #include "widgets/cmd_widget.h"
 #include "widgets/gcode_widget.h"
 #include "widgets/gcodebar.h"
@@ -210,6 +211,7 @@ void MainWindow::continueStartup() {
     GSM->loadLayerBarTemplate(CSM->getMostRecentLayerBarSettingFolderLocation());
     this->setupClasses();
     this->setupUi();
+    this->updateSavedProjectState();
 }
 
 MainWindow::~MainWindow() {
@@ -226,6 +228,11 @@ MainWindow::~MainWindow() {
 }
 
 void MainWindow::closeEvent(QCloseEvent* event) {
+    if (!confirmProjectClose()) {
+        event->ignore();
+        return;
+    }
+
     if (PreferencesManager::getInstance()->getWindowMaximizedPreference() != this->isMaximized())
         PreferencesManager::getInstance()->setWindowMaximizedPreference(this->isMaximized());
     if (PreferencesManager::getInstance()->getWindowSizePreference() != this->size())
@@ -233,6 +240,7 @@ void MainWindow::closeEvent(QCloseEvent* event) {
     if (PreferencesManager::getInstance()->getWindowPosPreference() != this->pos())
         PreferencesManager::getInstance()->setWindowPosPreference(this->pos());
 
+    event->accept();
     QApplication::quit();
 }
 
@@ -939,6 +947,16 @@ void MainWindow::setupEvents() {
         m_cmdbar->append("\r\nScaling applied permenantly to current transformation\r\n"
                          "Scaling factors are reset to 100%\r\n");
     });
+    connect(m_part_widget->getPartMeta().get(), &PartMetaModel::itemAddedUpdate, this,
+            [this](QSharedPointer<PartMetaItem>) { this->markProjectModified(); });
+    connect(m_part_widget->getPartMeta().get(), &PartMetaModel::itemReloadUpdate, this,
+            [this](QSharedPointer<PartMetaItem>) { this->markProjectModified(); });
+    connect(m_part_widget->getPartMeta().get(), &PartMetaModel::itemRemovedUpdate, this,
+            [this](QSharedPointer<PartMetaItem>) { this->markProjectModified(); });
+    connect(m_part_widget->getPartMeta().get(), &PartMetaModel::parentingUpdate, this,
+            [this](QSharedPointer<PartMetaItem>) { this->markProjectModified(); });
+    connect(m_part_widget->getPartMeta().get(), &PartMetaModel::transformUpdate, this,
+            [this](QSharedPointer<PartMetaItem>) { this->markProjectModified(); });
 
     QSharedPointer<PartMetaModel> part_meta = m_part_widget->getPartMeta();
     connect(part_meta.get(), &PartMetaModel::itemAddedUpdate, this, &MainWindow::initializePartTransform);
@@ -956,6 +974,8 @@ void MainWindow::setupEvents() {
     connect(m_settingbar, &SettingBar::settingModified, m_layerbar, &LayerBar::handleModifiedSetting);
     connect(m_settingbar, &SettingBar::settingModified, m_main_toolbar, &MainToolbar::handleModifiedSetting);
     connect(m_settingbar, &SettingBar::settingModified, this, &MainWindow::handleModifiedSetting);
+    connect(m_settingbar, &SettingBar::settingsBaseChanged, this,
+            [this](QString) { this->markProjectModified(); });
     connect(m_settingbar, &SettingBar::tabHidden, this, &MainWindow::addHiddenSetting);
     connect(GSM.get(), &SettingsManager::globalLoaded, this, &MainWindow::updateSettings);
 
@@ -1206,7 +1226,10 @@ void MainWindow::recordPartTransform(QSharedPointer<PartMetaItem> item) {
     m_part_transform_snapshots[item] = current;
 }
 
-void MainWindow::handleModifiedSetting(const QString key) {}
+void MainWindow::handleModifiedSetting(const QString key) {
+    Q_UNUSED(key);
+    markProjectModified();
+}
 
 QList<QAction*> MainWindow::setupSettingActions(QMenu* submenu, QString panel) {
     QList<QAction*> actions;
@@ -1437,7 +1460,7 @@ void MainWindow::updateStatus(QString status) {
     m_statusbar->showMessage(status);
 }
 
-void MainWindow::saveSession() {
+bool MainWindow::saveSessionToSelectedFile(bool notifyOnSuccess, bool waitForSave, QString* selectedFile) {
     QFileDialog save_dialog;
     save_dialog.setWindowTitle("Save project");
     save_dialog.setDirectory(CSM->getMostRecentProjectLocation());
@@ -1445,18 +1468,91 @@ void MainWindow::saveSession() {
     save_dialog.setNameFilters(QStringList() << "ORNLSlicer Project File (*.s2p)" << "Any Files (*)");
     save_dialog.setDefaultSuffix("s2p");
     if (!save_dialog.exec())
-        return;
+        return false;
 
     QString filename = save_dialog.selectedFiles().first();
     if (filename.isEmpty())
-        return;
+        return false;
+    if (selectedFile != nullptr)
+        *selectedFile = filename;
 
-    CSM->saveSession(filename, true, true);
+    SessionLoader* loader = CSM->saveSession(filename, true, notifyOnSuccess);
+    if (waitForSave)
+        loader->wait();
+
     CSM->saveSession(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/_lastsession.s2p", false);
+    updateSavedProjectState();
 
     this->setTitleInfo(QFileInfo(filename).fileName());
+    return true;
+}
+
+void MainWindow::saveSession() {
+    QString filename;
+    if (!saveSessionToSelectedFile(true, false, &filename))
+        return;
+
     m_statusbar->showMessage("Session saved");
     m_cmdbar->append("Session saved: " + filename);
+}
+
+QString MainWindow::projectStateSnapshot() {
+    if (m_part_widget != nullptr)
+        m_part_widget->updatePartTransformations();
+
+    fifojson snapshot;
+    snapshot[Constants::Settings::Session::Files::kSession] = CSM->partsJson();
+    snapshot[Constants::Settings::Session::Files::kGlobal] = GSM->globalJson();
+
+    fifojson local_settings = fifojson::array();
+    for (auto& part : CSM->parts()) {
+        fifojson part_json;
+        part_json[Constants::Settings::Session::LocalFile::kName] = part->name();
+        part_json[Constants::Settings::Session::LocalFile::kSettings] = part->getSb()->json();
+        part_json[Constants::Settings::Session::LocalFile::kRanges] = part->SettingsRangesToJson();
+        local_settings.push_back(part_json);
+    }
+    snapshot[Constants::Settings::Session::Files::kLocal] = local_settings;
+
+    return QString::fromStdString(snapshot.dump());
+}
+
+void MainWindow::updateSavedProjectState() {
+    m_saved_project_state = projectStateSnapshot();
+    m_project_modified = false;
+}
+
+void MainWindow::markProjectModified() { m_project_modified = true; }
+
+bool MainWindow::hasUnsavedProjectChanges() {
+    if (!m_project_modified)
+        return false;
+
+    return projectStateSnapshot() != m_saved_project_state;
+}
+
+bool MainWindow::confirmProjectClose() {
+    if (!hasUnsavedProjectChanges())
+        return true;
+
+    QMessageBox dialog(this);
+    dialog.setIcon(QMessageBox::Warning);
+    dialog.setWindowTitle("Save Project");
+    dialog.setText("The current project has unsaved changes.");
+    dialog.setInformativeText("Do you want to save the project before closing?");
+    dialog.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+    dialog.setDefaultButton(QMessageBox::Save);
+    dialog.setEscapeButton(QMessageBox::Cancel);
+
+    switch (static_cast<QMessageBox::StandardButton>(dialog.exec())) {
+        case QMessageBox::Save:
+            return saveSessionToSelectedFile(false, true);
+        case QMessageBox::Discard:
+            return true;
+        case QMessageBox::Cancel:
+        default:
+            return false;
+    }
 }
 
 void MainWindow::loadSession() {
@@ -1486,7 +1582,10 @@ void MainWindow::loadSession() {
 
 SessionLoader* MainWindow::loadASession(const QString& filename) {
     m_part_widget->clear();
-    return CSM->loadSession(true, filename);
+    SessionLoader* loader = CSM->loadSession(true, filename);
+    if (loader != nullptr)
+        connect(loader, &SessionLoader::loadSucceeded, this, &MainWindow::updateSavedProjectState);
+    return loader;
 }
 
 void MainWindow::updateSettings(const QString& name) {
@@ -1547,6 +1646,7 @@ void MainWindow::saveTemplate() {
     GSM->loadGlobalJson(dialog.filename());
     QFileInfo fileInfo(dialog.filename());
     updateSettings(fileInfo.baseName());
+    markProjectModified();
 }
 
 void MainWindow::loadTemplate() {
@@ -1579,6 +1679,7 @@ void MainWindow::loadTemplate() {
             tabs.removeAt(i);
     }
     m_settingbar->displayNewSetting(tabs, actualFilename);
+    markProjectModified();
 }
 
 void MainWindow::setSettingFolder() {

--- a/src/windows/preferences_window.cpp
+++ b/src/windows/preferences_window.cpp
@@ -191,6 +191,19 @@ void PreferencesWindow::setupLayout() {
     m_notifications_tab_layout->addWidget(fileshiftBox, 1, 0);
     m_boxes.push_back(fileshiftBox);
 
+    QGroupBox* unsavedProjectCloseBox = new QGroupBox("Close Project");
+    QVBoxLayout* unsavedProjectCloseLayout = new QVBoxLayout();
+    m_warn_unsaved_project_on_close_checkbox = new QCheckBox("Warn before closing unsaved projects");
+    m_warn_unsaved_project_on_close_checkbox->setChecked(
+        m_preferences_manager->getWarnUnsavedProjectOnClosePreference());
+    unsavedProjectCloseLayout->addWidget(m_warn_unsaved_project_on_close_checkbox);
+    unsavedProjectCloseLayout->addStretch(1);
+    unsavedProjectCloseBox->setLayout(unsavedProjectCloseLayout);
+    unsavedProjectCloseBox->setToolTip("Controls whether unsaved project changes show a warning when closing");
+    m_notifications_tab_layout->addWidget(unsavedProjectCloseBox, 1, 1);
+    connect(m_warn_unsaved_project_on_close_checkbox, &QCheckBox::clicked, m_preferences_manager.get(),
+            &PreferencesManager::setWarnUnsavedProjectOnClosePreference);
+
     // Camera tab
     QWidget* cameraWidget = new QWidget(m_tab_widget);
     m_tab_widget->addTab(cameraWidget, "Camera");
@@ -407,6 +420,8 @@ void PreferencesWindow::importPreferences() {
         setPreferenceValue(m_boxes[0], m_preferences_manager->getProjectShiftPreference());
         setPreferenceValue(m_boxes[1], m_preferences_manager->getAlignPreference());
         setPreferenceValue(m_boxes[2], m_preferences_manager->getFileShiftPreference());
+        m_warn_unsaved_project_on_close_checkbox->setChecked(
+            m_preferences_manager->getWarnUnsavedProjectOnClosePreference());
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a close-time save warning for unsaved project changes.

## Details

- Captures a saved/loaded project snapshot for comparison when closing.
- Prompts users to Save, Discard, or Cancel if user-originated changes are still unsaved.
- Tracks project dirty state from part add/remove/reload/parenting/transform actions, setting value edits, settings-base dropdown changes, and template changes.
- Resets the dirty state after successful project save/load so a freshly opened untouched session can close without a false warning.

## Root Cause

The app previously closed without checking whether saveable project state had changed. The first implementation compared snapshots directly, but startup/default UI state could make a freshly opened untouched session appear modified. This version gates the snapshot comparison behind actual project-changing user actions.

Closes #17.

## Validation

- `git diff --check`
- `nix develop -c cmake --build build/generic-llvm-ninja -j2`
- `nix develop -c ctest --test-dir build/generic-llvm-ninja -j2` returned no tests found for this build tree.