### PR TITLE
Expanding capabilities of g-code text editor

### DIFF
--- a/src/widgets/gcodetextboxwidget.cpp
+++ b/src/widgets/gcodetextboxwidget.cpp
@@ -5,7 +5,6 @@
 
 #include <qcontainerfwd.h>
 #include <qevent.h>
-#include <qguiapplication.h>
 #include <qhash.h>
 #include <qlist.h>
 #include <qnamespace.h>
@@ -183,13 +182,24 @@ void GcodeTextBoxWidget::updateLineNumberDisplayArea(const QRect& rect, int heig
 void GcodeTextBoxWidget::mouseReleaseEvent(QMouseEvent* event) {
     int scrollPos = verticalScrollBar()->value();
 
+    QPlainTextEdit::mouseReleaseEvent(event);
+
+    if (event->button() != Qt::LeftButton)
+        return;
+
     m_manual_cursor_move = true;
+
+    Qt::KeyboardModifiers modifier = event->modifiers();
+    if (textCursor().hasSelection() && modifier == Qt::NoModifier) {
+        verticalScrollBar()->setValue(scrollPos);
+        return;
+    }
+
     if (m_previous_line == textCursor().blockNumber()) {
         return;
     }
 
     QList<int> linesToAdd, linesToRemove;
-    Qt::KeyboardModifiers modifier = QGuiApplication::queryKeyboardModifiers();
     if (modifier == Qt::ControlModifier) {
         if (m_selected_blocks.contains(textCursor().blockNumber()))
             linesToRemove.push_back(textCursor().blockNumber());
@@ -236,7 +246,9 @@ void GcodeTextBoxWidget::mouseReleaseEvent(QMouseEvent* event) {
     emit lineChange(linesToAdd, linesToRemove);
 
     verticalScrollBar()->setValue(scrollPos);
-    setTextCursor(QTextCursor(document()->findBlockByLineNumber(m_last_block_clicked_on)));
+    QTextBlock clicked_block = document()->findBlockByLineNumber(m_last_block_clicked_on);
+    if (clicked_block.isValid())
+        setTextCursor(QTextCursor(clicked_block));
 }
 
 void GcodeTextBoxWidget::keyPressEvent(QKeyEvent* event) {

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -17,6 +17,7 @@
 #include <qgridlayout.h>
 #include <qicon.h>
 #include <qkeysequence.h>
+#include <qlineedit.h>
 #include <qlist.h>
 #include <qlogging.h>
 #include <qmainwindow.h>
@@ -30,6 +31,7 @@
 #include <qobjectdefs.h>
 #include <qoverload.h>
 #include <qpaintdevice.h>
+#include <qplaintextedit.h>
 #include <qprogressbar.h>
 #include <qset.h>
 #include <qsharedpointer.h>
@@ -39,6 +41,7 @@
 #include <qstringliteral.h>
 #include <qtabbar.h>
 #include <qtabwidget.h>
+#include <qtextedit.h>
 #include <qurl.h>
 #include <qwidget.h>
 
@@ -763,10 +766,42 @@ void MainWindow::setupEvents() {
     connect(m_actions["undo"].action, &QAction::triggered, m_undo_stack, &QUndoStack::undo);
     connect(m_actions["redo"].action, &QAction::triggered, m_undo_stack, &QUndoStack::redo);
     connect(m_actions["copy"].action, &QAction::triggered, this, [this]() {
+        for (QWidget* widget = QApplication::focusWidget(); widget != nullptr; widget = widget->parentWidget()) {
+            if (auto line_edit = qobject_cast<QLineEdit*>(widget)) {
+                line_edit->copy();
+                return;
+            }
+            if (auto plain_text_edit = qobject_cast<QPlainTextEdit*>(widget)) {
+                plain_text_edit->copy();
+                return;
+            }
+            if (auto text_edit = qobject_cast<QTextEdit*>(widget)) {
+                text_edit->copy();
+                return;
+            }
+        }
+
         m_actions["paste"].action->setEnabled(true);
         m_part_widget->copy();
     });
-    connect(m_actions["paste"].action, &QAction::triggered, m_part_widget, &PartWidget::paste);
+    connect(m_actions["paste"].action, &QAction::triggered, this, [this]() {
+        for (QWidget* widget = QApplication::focusWidget(); widget != nullptr; widget = widget->parentWidget()) {
+            if (auto line_edit = qobject_cast<QLineEdit*>(widget)) {
+                line_edit->paste();
+                return;
+            }
+            if (auto plain_text_edit = qobject_cast<QPlainTextEdit*>(widget)) {
+                plain_text_edit->paste();
+                return;
+            }
+            if (auto text_edit = qobject_cast<QTextEdit*>(widget)) {
+                text_edit->paste();
+                return;
+            }
+        }
+
+        m_part_widget->paste();
+    });
     connect(m_actions["reload"].action, &QAction::triggered, m_part_widget, QOverload<>::of(&PartWidget::reload));
     connect(m_actions["delete"].action, &QAction::triggered, m_part_widget, QOverload<>::of(&PartWidget::remove));
 


### PR DESCRIPTION
## Summary

Expands the G-code text editor's basic text editing behavior, focused on issue #13.

## Details

- Preserves normal drag-selected text in the G-code editor instead of converting the selection into highlighted G-code lines on mouse release.
- Keeps existing line-highlight behavior for simple clicks and modifier-based line selection.
- Routes application-level Copy/Paste actions to the currently focused text widget when appropriate, so `Ctrl+C` and `Ctrl+V` work inside the G-code editor without being intercepted by object copy/paste actions.

## Root Cause

The G-code text box mouse-release handler treated every text selection as a set of G-code visualization line highlights, then reset the cursor to the clicked line. That collapsed normal multi-line text selection before users could copy it. The global Copy/Paste actions also always targeted part/object copy-paste, which could steal standard text editing shortcuts from the focused editor.

Closes #13.

## Validation

- `git diff --check`
- `nix develop -c cmake --preset generic-llvm-ninja`
- `nix develop -c cmake --build build/generic-llvm-ninja -j2`
- `nix develop -c ctest --test-dir build/generic-llvm-ninja -j2` returned no tests found for this build tree.