### PR TITLE
Highlight settings that differ from Global

### DIFF
--- a/include/widgets/layerbar.h
+++ b/include/widgets/layerbar.h
@@ -72,7 +72,9 @@ class LayerBar : public QWidget {
   signals:
     //! \brief Signal that the selection has been altered.
     //! \param name_and_bases: Label plus list of ranges currently selected
-    void setSelectedSettings(QPair<QString, QList<QSharedPointer<SettingsBase>>> name_and_bases);
+    //! \param inherited_bases: Parent settings for each selected base; null entries inherit Global directly
+    void setSelectedSettings(QPair<QString, QList<QSharedPointer<SettingsBase>>> name_and_bases,
+                             QList<QSharedPointer<SettingsBase>> inherited_bases);
 
     //! \brief Signal that the selected layer settings ranges changed.
     //! \param part: Part that owns the selected ranges, or null when no layer range is selected.

--- a/include/widgets/settings/setting_bar.h
+++ b/include/widgets/settings/setting_bar.h
@@ -95,8 +95,10 @@ class SettingBar : public QWidget {
     void filter(QString str);
 
     //!\brief Currently selected settings bases as provided
-    //! \param settings_bases: List of currently selected ranges
-    void settingsBasesSelected(QPair<QString, QList<QSharedPointer<SettingsBase>>> name_and_bases);
+    //! \param name_and_bases: Label plus list of currently selected settings bases
+    //! \param inherited_bases: Parent settings for each selected base; null entries inherit Global directly
+    void settingsBasesSelected(QPair<QString, QList<QSharedPointer<SettingsBase>>> name_and_bases,
+                               QList<QSharedPointer<SettingsBase>> inherited_bases);
 
     //! \brief Closes all tabs.
     void closeAll();

--- a/include/widgets/settings/setting_row_base.h
+++ b/include/widgets/settings/setting_row_base.h
@@ -135,6 +135,9 @@ class SettingRowBase {
     //! \brief Notify before a setting key is written by this row.
     void notifyValueAboutToChange(const QString& key);
 
+    //! \brief Returns the warning-count delta for a new row warning state.
+    int warningCountDelta(bool warning_active, bool& previous_warning_active);
+
     //! \brief Sets keys that should be checked when deciding whether this row is locally overridden.
     void setLocalOverrideKeys(QList<QString> keys);
 
@@ -249,6 +252,9 @@ class SettingRowBase {
 
     //! \brief Parent settings inherited by the corresponding selected settings bases.
     QList<QSharedPointer<SettingsBase>> m_inherited_settings_bases;
+
+    //! \brief Whether parent warning counters were reset for a newly selected set of bases.
+    bool m_warning_state_reset_pending = false;
 
     //! \brief Index of row
     int m_index;

--- a/include/widgets/settings/setting_row_base.h
+++ b/include/widgets/settings/setting_row_base.h
@@ -99,9 +99,11 @@ class SettingRowBase {
     //! \param row: row to add to depenendcy list
     void addRowToNotify(QSharedPointer<SettingRowBase> row);
 
-    //! \brief Set setting bases
-    //! \param bases: list of bases currently selected by the user
-    void setBases(QList<QSharedPointer<SettingsBase>> settings_bases);
+    //! \brief Set selected setting bases and the parent settings each base inherits.
+    //! \param settings_bases: list of bases currently selected by the user
+    //! \param inherited_bases: corresponding parent bases; null entries inherit Global directly
+    void setBases(QList<QSharedPointer<SettingsBase>> settings_bases,
+                  QList<QSharedPointer<SettingsBase>> inherited_bases);
 
     //! \brief Get the setting bases of a row
     //! \return Returns the current settings bases of a row
@@ -136,10 +138,31 @@ class SettingRowBase {
     //! \brief Sets keys that should be checked when deciding whether this row is locally overridden.
     void setLocalOverrideKeys(QList<QString> keys);
 
-    //! \brief Removes local overrides matching the current global value.
+    //! \brief Returns the value inherited by one selected settings base.
+    template <class T> T inheritedValueHelper(const QString& key, int index, const T& global_value) const {
+        if (index >= 0 && index < m_inherited_settings_bases.size()) {
+            const QSharedPointer<SettingsBase>& inherited_base = m_inherited_settings_bases[index];
+            if (!inherited_base.isNull() && inherited_base->contains(key))
+                return inherited_base->setting<T>(key);
+        }
+
+        return global_value;
+    }
+
+    //! \brief Returns the effective value for one selected settings base.
+    template <class T> T effectiveValueHelper(const QString& key, int index, const T& global_value) const {
+        if (index >= 0 && index < m_settings_bases.size() && m_settings_bases[index]->contains(key))
+            return m_settings_bases[index]->setting<T>(key);
+
+        return inheritedValueHelper<T>(key, index, global_value);
+    }
+
+    //! \brief Removes edited overrides matching the value inherited by each selected base.
     template <class T> void removeRedundantLocalOverrides(const QString& key, const T& global_value) {
-        for (QSharedPointer<SettingsBase> settings_base : m_settings_bases) {
-            if (settings_base->contains(key) && settings_base->setting<T>(key) == global_value)
+        for (int index = 0, end = m_settings_bases.size(); index < end; ++index) {
+            QSharedPointer<SettingsBase> settings_base = m_settings_bases[index];
+            const T inherited_value = inheritedValueHelper<T>(key, index, global_value);
+            if (settings_base->contains(key) && settings_base->setting<T>(key) == inherited_value)
                 settings_base->remove(key);
         }
     }
@@ -159,8 +182,8 @@ class SettingRowBase {
             m_sb->setSetting(m_key, value);
 
         if (m_settings_bases.size() != 0) {
-            const T global_value =
-                m_sb->contains(m_key) ? m_sb->setting<T>(m_key) : m_json[Constants::Settings::Master::kDefault].get<T>();
+            const T global_value = m_sb->contains(m_key) ? m_sb->setting<T>(m_key)
+                                                         : m_json[Constants::Settings::Master::kDefault].get<T>();
             removeRedundantLocalOverrides<T>(m_key, global_value);
         }
 
@@ -173,52 +196,20 @@ class SettingRowBase {
         checkDynamicDependencies();
     }
 
-    //! \brief Templated comparator for checking range list consistency
-    template <class T> bool areConsistent(QSharedPointer<SettingsBase> a, QSharedPointer<SettingsBase> b) {
-        if (a->contains(m_key) && m_sb->setting<T>(m_key) == a->setting<T>(m_key))
-            a->remove(m_key);
-
-        if (b->contains(m_key) && m_sb->setting<T>(m_key) == b->setting<T>(m_key))
-            b->remove(m_key);
-
-        bool containsA = a->contains(m_key);
-        bool containsB = b->contains(m_key);
-
-        // returns true
-        //     - if both settings bases do NOT contain the key
-        //     - if both settings bases contain the SAME VALUE for the key
-        // returns false otherwise
-
-        return (containsA == containsB) &&
-               ((containsA && (a->setting<T>(m_key) == b->setting<T>(m_key))) || !containsA);
-    }
-
     //! \brief Templated helper for all widget types when settings must be reloaded
     template <class T> T reloadValueHelper(bool& consistent) {
         T cur;
         if (m_settings_bases.size() > 0) {
-            const T global_value =
-                m_sb->contains(m_key) ? m_sb->setting<T>(m_key) : m_json[Constants::Settings::Master::kDefault].get<T>();
-            removeRedundantLocalOverrides<T>(m_key, global_value);
+            const T global_value = m_sb->contains(m_key) ? m_sb->setting<T>(m_key)
+                                                         : m_json[Constants::Settings::Master::kDefault].get<T>();
+            cur = effectiveValueHelper<T>(m_key, 0, global_value);
 
             bool all_bases_consistent = true;
-            for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
-                auto sb_1 = m_settings_bases[i - 1];
-                auto sb_2 = m_settings_bases[i];
-                all_bases_consistent = all_bases_consistent && areConsistent<T>(sb_1, sb_2);
-            }
+            for (int index = 1, end = m_settings_bases.size(); index < end; ++index)
+                all_bases_consistent =
+                    all_bases_consistent && effectiveValueHelper<T>(m_key, index, global_value) == cur;
 
             if (all_bases_consistent) {
-                // setting was consistent and either didn't exist or did exist and were equal
-                // So, if it exists, use it, otherwise grab the global
-                if (m_settings_bases[0]->contains(m_key))
-                    cur = m_settings_bases[0]->setting<T>(m_key);
-                else {
-                    if (m_sb->contains(m_key))
-                        cur = m_sb->setting<T>(m_key);
-                    else
-                        cur = m_json[Constants::Settings::Master::kDefault].get<T>();
-                }
                 clearNotification();
                 styleLabel(true);
             }
@@ -255,6 +246,9 @@ class SettingRowBase {
 
     //! \brief Pointers to settings bases when a user selects them for local settings
     QList<QSharedPointer<SettingsBase>> m_settings_bases;
+
+    //! \brief Parent settings inherited by the corresponding selected settings bases.
+    QList<QSharedPointer<SettingsBase>> m_inherited_settings_bases;
 
     //! \brief Index of row
     int m_index;

--- a/include/widgets/settings/setting_row_base.h
+++ b/include/widgets/settings/setting_row_base.h
@@ -7,6 +7,7 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QObject>
+#include <QToolButton>
 #include <QWidget>
 #include <qlist.h>
 #include <qscopedpointer.h>
@@ -132,6 +133,17 @@ class SettingRowBase {
     //! \brief Notify before a setting key is written by this row.
     void notifyValueAboutToChange(const QString& key);
 
+    //! \brief Sets keys that should be checked when deciding whether this row is locally overridden.
+    void setLocalOverrideKeys(QList<QString> keys);
+
+    //! \brief Removes local overrides matching the current global value.
+    template <class T> void removeRedundantLocalOverrides(const QString& key, const T& global_value) {
+        for (QSharedPointer<SettingsBase> settings_base : m_settings_bases) {
+            if (settings_base->contains(key) && settings_base->setting<T>(key) == global_value)
+                settings_base->remove(key);
+        }
+    }
+
     //! \brief Recursive check of dependencynode logic
     //! \param root: Dependency logic to check
     bool checkLogic(DependencyNode root);
@@ -145,6 +157,12 @@ class SettingRowBase {
                 range->setSetting(m_key, value);
         else
             m_sb->setSetting(m_key, value);
+
+        if (m_settings_bases.size() != 0) {
+            const T global_value =
+                m_sb->contains(m_key) ? m_sb->setting<T>(m_key) : m_json[Constants::Settings::Master::kDefault].get<T>();
+            removeRedundantLocalOverrides<T>(m_key, global_value);
+        }
 
         clearNotification();
         styleLabel(true);
@@ -179,6 +197,10 @@ class SettingRowBase {
     template <class T> T reloadValueHelper(bool& consistent) {
         T cur;
         if (m_settings_bases.size() > 0) {
+            const T global_value =
+                m_sb->contains(m_key) ? m_sb->setting<T>(m_key) : m_json[Constants::Settings::Master::kDefault].get<T>();
+            removeRedundantLocalOverrides<T>(m_key, global_value);
+
             bool all_bases_consistent = true;
             for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
                 auto sb_1 = m_settings_bases[i - 1];
@@ -258,6 +280,31 @@ class SettingRowBase {
 
     //! \brief Pointer to global setting base
     QSharedPointer<SettingsBase> m_sb;
+
+  protected:
+    //! \brief Returns the default tooltip from the row's master setting metadata.
+    QString baseToolTip() const;
+
+    //! \brief Returns whether any selected local settings base currently owns one of this row's keys.
+    bool hasLocalOverride() const;
+
+    //! \brief Applies visibility/enabled state to the local override reset button.
+    void updateResetButton();
+
+    //! \brief Remove this row's selected local overrides and reload the row.
+    void resetLocalOverrides();
+
+    //! \brief Keys that can make this row locally overridden.
+    QList<QString> m_local_override_keys;
+
+    //! \brief Button used to remove selected local overrides.
+    QScopedPointer<QToolButton> m_reset_button;
+
+    //! \brief Whether this row is currently visible.
+    bool m_row_visible;
+
+    //! \brief Whether this row is currently enabled.
+    bool m_row_enabled;
 
     //! \brief Master json that this row was constructed from
     fifojson m_json;

--- a/include/widgets/settings/setting_row_base.h
+++ b/include/widgets/settings/setting_row_base.h
@@ -285,8 +285,11 @@ class SettingRowBase {
     //! \brief Returns the default tooltip from the row's master setting metadata.
     QString baseToolTip() const;
 
-    //! \brief Returns whether any selected local settings base currently owns one of this row's keys.
+    //! \brief Returns whether any selected base differs from its inherited value for one of this row's keys.
     bool hasLocalOverride() const;
+
+    //! \brief Returns whether one selected key matches the value inherited by that settings base.
+    bool matchesInheritedValue(const QString& key, int index) const;
 
     //! \brief Applies visibility/enabled state to the local override reset button.
     void updateResetButton();

--- a/include/widgets/settings/setting_tab.h
+++ b/include/widgets/settings/setting_tab.h
@@ -50,6 +50,9 @@ class SettingTab : public QWidget {
     //! \brief Copy of settings bases, if applicable
     QList<QSharedPointer<SettingsBase>> m_settings_bases;
 
+    //! \brief Parent settings bases inherited by the corresponding selected bases.
+    QList<QSharedPointer<SettingsBase>> m_inherited_settings_bases;
+
     //! \brief Adds a row to this tab.
     void addRow(QString key, const fifojson& json, const fifojson& input = fifojson());
 
@@ -80,7 +83,9 @@ class SettingTab : public QWidget {
 
     //! \brief Settings bases currently selected to adjust setting
     //! \param settings_bases: settings bases to display for
-    void settingsBasesSelected(QList<QSharedPointer<SettingsBase>> settings_bases);
+    //! \param inherited_bases: parent settings for each selected base
+    void settingsBasesSelected(QList<QSharedPointer<SettingsBase>> settings_bases,
+                               QList<QSharedPointer<SettingsBase>> inherited_bases);
 
     //! \brief Tells the header what icon to display, based on if there is a warning from any settings in the tab
     //! \param count: Total number of warnings in this tab, should be a positive integer or zero.

--- a/include/widgets/settings/vector2_input_widget.h
+++ b/include/widgets/settings/vector2_input_widget.h
@@ -71,10 +71,6 @@ class Vector2InputWidget : public QWidget, public SettingRowBase {
     void ensureSetting(const QString& key, Distance default_value);
     void updateSetting(const QString& key, double displayed_value);
     Distance reloadDistanceValue(const QString& key, Distance default_value, bool& consistent);
-    bool areConsistent(const QString& key, QSharedPointer<SettingsBase> a, QSharedPointer<SettingsBase> b,
-                       Distance default_value);
-    Distance effectiveDistanceValue(const QString& key, QSharedPointer<SettingsBase> settings_base,
-                                    Distance default_value);
     bool hasConsistentEffectiveValues(const QString& key, Distance default_value);
     bool hasAnyInconsistentValue();
     void updateWarningStateAfterEdit();

--- a/include/widgets/settings/vector3_input_widget.h
+++ b/include/widgets/settings/vector3_input_widget.h
@@ -71,9 +71,6 @@ class Vector3InputWidget : public QWidget, public SettingRowBase {
     void ensureSetting(const QString& key, double default_value);
     void updateSetting(const QString& key, double value);
     double reloadDoubleValue(const QString& key, double default_value, bool& consistent);
-    bool areConsistent(const QString& key, QSharedPointer<SettingsBase> a, QSharedPointer<SettingsBase> b,
-                       double default_value);
-    double effectiveDoubleValue(const QString& key, QSharedPointer<SettingsBase> settings_base, double default_value);
     bool hasConsistentEffectiveValues(const QString& key, double default_value);
     bool hasAnyInconsistentValue();
     void updateWarningStateAfterEdit();

--- a/src/widgets/layerbar.cpp
+++ b/src/widgets/layerbar.cpp
@@ -245,11 +245,12 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
         // Set selected settings to be part
         QList<QSharedPointer<SettingsBase>> ranges;
         ranges.append(item->part()->getSb());
-        emit setSelectedSettings(qMakePair(item->part()->name(), ranges));
+        emit setSelectedSettings(qMakePair(item->part()->name(), ranges), {QSharedPointer<SettingsBase>()});
         emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
     else {
-        emit setSelectedSettings(qMakePair(QString(""), QList<QSharedPointer<SettingsBase>>()));
+        emit setSelectedSettings(qMakePair(QString(""), QList<QSharedPointer<SettingsBase>>()),
+                                 QList<QSharedPointer<SettingsBase>>());
         emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
     // Check if new part selected and if that part's template equals the currently selected template from drop down
@@ -271,7 +272,7 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
         loadTemplateLayers();
         QList<QSharedPointer<SettingsBase>> ranges;
         ranges.append(item->part()->getSb());
-        emit setSelectedSettings(qMakePair(item->part()->name(), ranges));
+        emit setSelectedSettings(qMakePair(item->part()->name(), ranges), {QSharedPointer<SettingsBase>()});
         emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
     updateLayerSettingsRangeAvailability();
@@ -372,11 +373,12 @@ void LayerBar::reselectPart() { // If no part selected
         // Set selected settings to be part
         QList<QSharedPointer<SettingsBase>> ranges;
         ranges.append(m_part->getSb());
-        emit setSelectedSettings(qMakePair(m_part->name(), ranges));
+        emit setSelectedSettings(qMakePair(m_part->name(), ranges), {QSharedPointer<SettingsBase>()});
         emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
     else {
-        emit setSelectedSettings(qMakePair(QString(""), QList<QSharedPointer<SettingsBase>>()));
+        emit setSelectedSettings(qMakePair(QString(""), QList<QSharedPointer<SettingsBase>>()),
+                                 QList<QSharedPointer<SettingsBase>>());
         emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
     // Check if new part selected and if that part's template equals the currently selected template from drop down menu
@@ -392,7 +394,7 @@ void LayerBar::reselectPart() { // If no part selected
         loadTemplateLayers();
         QList<QSharedPointer<SettingsBase>> ranges;
         ranges.append(m_part->getSb());
-        emit setSelectedSettings(qMakePair(m_part->name(), ranges));
+        emit setSelectedSettings(qMakePair(m_part->name(), ranges), {QSharedPointer<SettingsBase>()});
         emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
     }
     updateLayerSettingsRangeAvailability();
@@ -1674,7 +1676,8 @@ void LayerBar::updateLayerSettingsRangeAvailability() {
 
 void LayerBar::changeSelectedSettings() {
     if (m_part == nullptr) {
-        emit setSelectedSettings(qMakePair(QString(""), QList<QSharedPointer<SettingsBase>>()));
+        emit setSelectedSettings(qMakePair(QString(""), QList<QSharedPointer<SettingsBase>>()),
+                                 QList<QSharedPointer<SettingsBase>>());
         emit selectedLayerSettingsRangesChanged(nullptr, QList<QPair<int, int>>());
         updateLayerSettingsRangeAvailability();
         return;
@@ -1682,6 +1685,7 @@ void LayerBar::changeSelectedSettings() {
 
     QVector<QString> names;
     QList<QSharedPointer<SettingsBase>> settings_bases;
+    QList<QSharedPointer<SettingsBase>> inherited_bases;
     QList<QPair<int, int>> selected_layer_ranges;
 
     auto include_visual_layer_range = [&selected_layer_ranges](int low, int high) {
@@ -1708,6 +1712,7 @@ void LayerBar::changeSelectedSettings() {
             QString name = "Layers " + QString::number(low + 1) + " - " + QString::number(high + 1);
             names.append(name);
             settings_bases.append(range->getSb());
+            inherited_bases.append(m_part->getSb());
         }
         else if (dot->getGroup() != nullptr) {
             // get the dot group & its name
@@ -1724,6 +1729,7 @@ void LayerBar::changeSelectedSettings() {
             // so just get the sb of one dot
             auto range = m_part->getSettingsRange(dot->getLayer(), dot->getLayer());
             settings_bases.append(range->getSb());
+            inherited_bases.append(m_part->getSb());
 
             // remove all the dots in the group from selection copy
             for (int j = selected_copy.size() - 1; j > i; --j) {
@@ -1738,6 +1744,7 @@ void LayerBar::changeSelectedSettings() {
             QString name = "Layer " + QString::number(layer_num + 1);
             names.append(name);
             settings_bases.append(range->getSb());
+            inherited_bases.append(m_part->getSb());
         }
     }
 
@@ -1764,6 +1771,7 @@ void LayerBar::changeSelectedSettings() {
     {
         final = m_part->name();
         settings_bases.append(m_part->getSb());
+        inherited_bases.append(QSharedPointer<SettingsBase>());
     }
     else if (names.size() == 1) // just one selected range, display it
     {
@@ -1785,7 +1793,7 @@ void LayerBar::changeSelectedSettings() {
         final += " of " + m_part->name();
     }
 
-    emit setSelectedSettings(qMakePair(final, settings_bases));
+    emit setSelectedSettings(qMakePair(final, settings_bases), inherited_bases);
     emit selectedLayerSettingsRangesChanged(names.isEmpty() ? nullptr : m_part,
                                             names.isEmpty() ? QList<QPair<int, int>>() : merged_layer_ranges);
     updateLayerSettingsRangeAvailability();

--- a/src/widgets/settings/double_spin_subtypes/setting_accel_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_accel_spin_box.cpp
@@ -68,12 +68,6 @@ void SettingAccelSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_ang_vel_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_ang_vel_spin_box.cpp
@@ -75,12 +75,6 @@ void SettingAngVelSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_angle_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_angle_spin_box.cpp
@@ -69,12 +69,6 @@ void SettingAngleSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_area_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_area_spin_box.cpp
@@ -72,12 +72,6 @@ void SettingAreaSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_density_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_density_spin_box.cpp
@@ -67,12 +67,6 @@ void SettingDensitySpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_distance_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_distance_spin_box.cpp
@@ -75,12 +75,6 @@ void SettingDistanceSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_speed_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_speed_spin_box.cpp
@@ -66,12 +66,6 @@ void SettingSpeedSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_temperature_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_temperature_spin_box.cpp
@@ -76,12 +76,6 @@ void SettingTemperatureSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_time_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_time_spin_box.cpp
@@ -68,12 +68,6 @@ void SettingTimeSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_voltage_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_voltage_spin_box.cpp
@@ -68,12 +68,6 @@ void SettingVoltageSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // namespace ORNL

--- a/src/widgets/settings/setting_bar.cpp
+++ b/src/widgets/settings/setting_bar.cpp
@@ -137,14 +137,15 @@ void SettingBar::filter(QString str) {
     }
 }
 
-void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<SettingsBase>>> name_and_bases) {
+void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<SettingsBase>>> name_and_bases,
+                                       QList<QSharedPointer<SettingsBase>> inherited_bases) {
     auto settings_bases = name_and_bases.second;
 
     // here we clear any warnings if a new settings base has been selected, or do nothing if the settings base remains
     // the same
     for (SettingPane* cur_pane : m_panes) {
         for (SettingTab* cur_tab : cur_pane->getTabs()) {
-            if (cur_tab->m_settings_bases != settings_bases) {
+            if (cur_tab->m_settings_bases != settings_bases || cur_tab->m_inherited_settings_bases != inherited_bases) {
                 cur_pane->m_pane_warning = 0;
             }
         }
@@ -166,7 +167,7 @@ void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<Setti
             SettingPane* cur_pane = m_panes.value(key);
 
             for (SettingTab* cur_tab : cur_pane->getTabs()) {
-                cur_tab->settingsBasesSelected(settings_bases);
+                cur_tab->settingsBasesSelected(settings_bases, inherited_bases);
                 if (!hiddenSettings.contains(cur_tab->getName())) {
                     cur_tab->show();
                     for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows()) {
@@ -196,7 +197,7 @@ void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<Setti
                     if (settingsHidden == rows.size())
                         cur_tab->hide();
 
-                    cur_tab->settingsBasesSelected(settings_bases);
+                    cur_tab->settingsBasesSelected(settings_bases, inherited_bases);
                 }
             }
         }
@@ -317,8 +318,7 @@ void SettingBar::displayNewSetting(QStringList settingCategories, QString settin
     enableDependRows();
 }
 
-void SettingBar::forwardSettingAboutToChange(QString setting_key,
-                                             QList<QSharedPointer<SettingsBase>> settings_bases) {
+void SettingBar::forwardSettingAboutToChange(QString setting_key, QList<QSharedPointer<SettingsBase>> settings_bases) {
     emit settingAboutToChange(setting_key, settings_bases);
 }
 

--- a/src/widgets/settings/setting_check_box.cpp
+++ b/src/widgets/settings/setting_check_box.cpp
@@ -93,12 +93,6 @@ void SettingCheckBox::reloadValue() {
 
     this->blockSignals(false);
     emit modified(m_key);
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // Namespace ORNL

--- a/src/widgets/settings/setting_combo_box.cpp
+++ b/src/widgets/settings/setting_combo_box.cpp
@@ -110,13 +110,7 @@ void SettingComboBox::reloadValue() {
 
     this->blockSignals(false);
     emit modified(m_key);
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 
 void SettingComboBox::wheelEvent(QWheelEvent* event) {

--- a/src/widgets/settings/setting_double_spin_box.cpp
+++ b/src/widgets/settings/setting_double_spin_box.cpp
@@ -119,13 +119,7 @@ void SettingDoubleSpinBox::reloadValue() {
 
     this->blockSignals(false);
     emit modified(m_key);
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 
 void SettingDoubleSpinBox::wheelEvent(QWheelEvent* event) {

--- a/src/widgets/settings/setting_line_edit.cpp
+++ b/src/widgets/settings/setting_line_edit.cpp
@@ -94,12 +94,6 @@ void SettingLineEdit::reloadValue() {
 
     this->blockSignals(false);
     emit modified(m_key);
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // Namespace ORNL

--- a/src/widgets/settings/setting_numbered_list.cpp
+++ b/src/widgets/settings/setting_numbered_list.cpp
@@ -120,13 +120,7 @@ void SettingNumberedList::reloadValue() {
 
     this->blockSignals(false);
     emit modified(m_key);
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 
 void SettingNumberedList::setEntries(QList<QString> entries) {

--- a/src/widgets/settings/setting_plain_text_edit.cpp
+++ b/src/widgets/settings/setting_plain_text_edit.cpp
@@ -93,12 +93,6 @@ void SettingPlainTextEdit::reloadValue() {
 
     this->blockSignals(false);
     emit modified(m_key);
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 } // Namespace ORNL

--- a/src/widgets/settings/setting_row_base.cpp
+++ b/src/widgets/settings/setting_row_base.cpp
@@ -127,6 +127,7 @@ void SettingRowBase::addRowToNotify(QSharedPointer<SettingRowBase> row) { m_rows
 
 void SettingRowBase::setBases(QList<QSharedPointer<SettingsBase>> settings_bases,
                               QList<QSharedPointer<SettingsBase>> inherited_bases) {
+    m_warning_state_reset_pending = m_settings_bases != settings_bases || m_inherited_settings_bases != inherited_bases;
     m_settings_bases = settings_bases;
     m_inherited_settings_bases = inherited_bases;
     updateResetButton();
@@ -167,6 +168,17 @@ void SettingRowBase::notifyValueAboutToChange(const QString& key) {
     if (m_value_change_callback) {
         m_value_change_callback(key, m_settings_bases);
     }
+}
+
+int SettingRowBase::warningCountDelta(bool warning_active, bool& previous_warning_active) {
+    if (m_warning_state_reset_pending) {
+        previous_warning_active = false;
+        m_warning_state_reset_pending = false;
+    }
+
+    const int delta = static_cast<int>(warning_active) - static_cast<int>(previous_warning_active);
+    previous_warning_active = warning_active;
+    return delta;
 }
 
 void SettingRowBase::setLocalOverrideKeys(QList<QString> keys) { m_local_override_keys = keys; }

--- a/src/widgets/settings/setting_row_base.cpp
+++ b/src/widgets/settings/setting_row_base.cpp
@@ -42,7 +42,7 @@ SettingRowBase::SettingRowBase(QWidget* parent, QSharedPointer<SettingsBase> sb,
     m_reset_button->setIcon(QIcon(":/icons/revert.png"));
     m_reset_button->setAutoRaise(true);
     m_reset_button->setFixedSize(20, 20);
-    m_reset_button->setToolTip("Use global value");
+    m_reset_button->setToolTip("Use inherited value");
     m_reset_button->hide();
     QObject::connect(m_reset_button.get(), &QToolButton::clicked, m_reset_button.get(),
                      [this]() { resetLocalOverrides(); });
@@ -104,7 +104,7 @@ void SettingRowBase::styleLabel(bool isConsistent) {
             m_key_label->setStyleSheet(m_key_label->styleSheet() + "\nQLabel { color: " + accent_color +
                                        "; font-weight: 700; }");
             m_key_label->setToolTip(
-                "<html><body><p><b>Locally overridden.</b> Click the reset button to use the global value.</p><p>" +
+                "<html><body><p><b>Locally overridden.</b> Click the reset button to use the inherited value.</p><p>" +
                 QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) + "</p></body></html>");
         }
         else {
@@ -125,8 +125,10 @@ fifojson SettingRowBase::getDependencies() { return m_json[Constants::Settings::
 
 void SettingRowBase::addRowToNotify(QSharedPointer<SettingRowBase> row) { m_rows_to_notify.push_back(row); }
 
-void SettingRowBase::setBases(QList<QSharedPointer<SettingsBase>> settings_bases) {
+void SettingRowBase::setBases(QList<QSharedPointer<SettingsBase>> settings_bases,
+                              QList<QSharedPointer<SettingsBase>> inherited_bases) {
     m_settings_bases = settings_bases;
+    m_inherited_settings_bases = inherited_bases;
     updateResetButton();
 }
 

--- a/src/widgets/settings/setting_row_base.cpp
+++ b/src/widgets/settings/setting_row_base.cpp
@@ -2,7 +2,9 @@
 
 #include <QCheckBox>
 #include <QComboBox>
+#include <QIcon>
 #include <QSpinBox>
+#include <QToolButton>
 #include <qgridlayout.h>
 #include <qhashfunctions.h>
 #include <qlabel.h>
@@ -23,17 +25,29 @@ namespace ORNL {
 
 SettingRowBase::SettingRowBase(QWidget* parent, QSharedPointer<SettingsBase> sb, QString key, fifojson json,
                                QGridLayout* layout, int index)
-    : m_sb(sb), m_key(key), m_json(json), m_layout(layout), m_index(index) {
+    : m_index(index), m_layout(layout), m_key(key), m_sb(sb), m_row_visible(true), m_row_enabled(true), m_json(json) {
     m_theme_path = PreferencesManager::getInstance()->getTheme().getFolderPath();
+    m_local_override_keys = {m_key};
+
     m_key_label.reset(new QLabel());
     m_key_label->setText(json.at(Constants::Settings::Master::kDisplay));
-    m_key_label->setToolTip("<html><body><p>" + QString::fromStdString(json.at(Constants::Settings::Master::kToolTip)) +
-                            "</p></body></html>");
+    m_key_label->setToolTip(baseToolTip());
     m_key_label->setCursor(Qt::WhatsThisCursor);
     m_key_label->setMinimumHeight(25);
     m_key_label->setIndent(25);
     this->styleLabelFromFile(m_theme_path + "setting_rows_normal.qss");
     layout->addWidget(m_key_label.get(), index, 0);
+
+    m_reset_button.reset(new QToolButton(parent));
+    m_reset_button->setIcon(QIcon(":/icons/revert.png"));
+    m_reset_button->setAutoRaise(true);
+    m_reset_button->setFixedSize(20, 20);
+    m_reset_button->setToolTip("Use global value");
+    m_reset_button->hide();
+    QObject::connect(m_reset_button.get(), &QToolButton::clicked, m_reset_button.get(),
+                     [this]() { resetLocalOverrides(); });
+    layout->addWidget(m_reset_button.get(), index, 3);
+
     layout->setContentsMargins(0, 0, 20, 0);
 }
 
@@ -81,16 +95,28 @@ bool SettingRowBase::styleLabelFromFile(QString file) {
 }
 
 void SettingRowBase::styleLabel(bool isConsistent) {
+    const QString tooltip = baseToolTip();
+
     if (isConsistent) {
         this->styleLabelFromFile(m_theme_path + "setting_rows_normal.qss");
-        m_key_label->setToolTip("<html><body><p>" +
-                                QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) +
-                                "</p></body></html>");
+        if (hasLocalOverride()) {
+            const QString accent_color = PreferencesManager::getInstance()->getTheme().getDotPairedColor().name();
+            m_key_label->setStyleSheet(m_key_label->styleSheet() + "\nQLabel { color: " + accent_color +
+                                       "; font-weight: 700; }");
+            m_key_label->setToolTip(
+                "<html><body><p><b>Locally overridden.</b> Click the reset button to use the global value.</p><p>" +
+                QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) + "</p></body></html>");
+        }
+        else {
+            m_key_label->setToolTip(tooltip);
+        }
     }
     else {
         this->styleLabelFromFile(m_theme_path + "setting_rows_warning.qss");
-        m_key_label->setToolTip("Inconsistent settings between selected layers. <p>" % m_key_label->toolTip());
+        m_key_label->setToolTip("Inconsistent settings between selected items.<p>" + tooltip);
     }
+
+    updateResetButton();
 }
 
 bool SettingRowBase::isLocal() { return m_json[Constants::Settings::Master::kLocal]; }
@@ -99,25 +125,34 @@ fifojson SettingRowBase::getDependencies() { return m_json[Constants::Settings::
 
 void SettingRowBase::addRowToNotify(QSharedPointer<SettingRowBase> row) { m_rows_to_notify.push_back(row); }
 
-void SettingRowBase::setBases(QList<QSharedPointer<SettingsBase>> settings_bases) { m_settings_bases = settings_bases; }
+void SettingRowBase::setBases(QList<QSharedPointer<SettingsBase>> settings_bases) {
+    m_settings_bases = settings_bases;
+    updateResetButton();
+}
 
 QList<QSharedPointer<SettingsBase>> SettingRowBase::getBases() { return m_settings_bases; }
 
 void SettingRowBase::checkDependencies() { setEnabled(checkLogic(m_dependency_logic)); }
 
 void SettingRowBase::hide() {
+    m_row_visible = false;
     m_key_label->hide();
     m_unit_label->hide();
+    updateResetButton();
 }
 
 void SettingRowBase::show() {
+    m_row_visible = true;
     m_key_label->show();
     m_unit_label->show();
+    updateResetButton();
 }
 
 void SettingRowBase::setEnabled(bool enabled) {
+    m_row_enabled = enabled;
     m_key_label->setEnabled(enabled);
     m_unit_label->setEnabled(enabled);
+    updateResetButton();
 }
 
 void SettingRowBase::setDependencyLogic(DependencyNode root) { m_dependency_logic = root; }
@@ -130,6 +165,62 @@ void SettingRowBase::notifyValueAboutToChange(const QString& key) {
     if (m_value_change_callback) {
         m_value_change_callback(key, m_settings_bases);
     }
+}
+
+void SettingRowBase::setLocalOverrideKeys(QList<QString> keys) { m_local_override_keys = keys; }
+
+QString SettingRowBase::baseToolTip() const {
+    return "<html><body><p>" + QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) +
+           "</p></body></html>";
+}
+
+bool SettingRowBase::hasLocalOverride() const {
+    if (m_settings_bases.isEmpty())
+        return false;
+
+    for (const QSharedPointer<SettingsBase>& settings_base : m_settings_bases) {
+        for (const QString& key : m_local_override_keys) {
+            if (settings_base->contains(key))
+                return true;
+        }
+    }
+
+    return false;
+}
+
+void SettingRowBase::updateResetButton() {
+    if (m_reset_button.isNull())
+        return;
+
+    const bool should_show = m_row_visible && hasLocalOverride();
+    m_reset_button->setVisible(should_show);
+    m_reset_button->setEnabled(should_show && m_row_enabled);
+}
+
+void SettingRowBase::resetLocalOverrides() {
+    if (m_settings_bases.isEmpty())
+        return;
+
+    for (const QString& key : m_local_override_keys) {
+        bool key_removed = false;
+        for (QSharedPointer<SettingsBase> settings_base : m_settings_bases) {
+            if (settings_base->contains(key)) {
+                if (!key_removed) {
+                    notifyValueAboutToChange(key);
+                    key_removed = true;
+                }
+                settings_base->remove(key);
+            }
+        }
+    }
+
+    reloadValue();
+
+    for (QSharedPointer<SettingRowBase> row : m_rows_to_notify)
+        row->checkDependencies();
+
+    checkDynamicDependencies();
+    updateResetButton();
 }
 
 bool SettingRowBase::checkLogic(DependencyNode root) {

--- a/src/widgets/settings/setting_row_base.cpp
+++ b/src/widgets/settings/setting_row_base.cpp
@@ -192,12 +192,33 @@ bool SettingRowBase::hasLocalOverride() const {
     if (m_settings_bases.isEmpty())
         return false;
 
-    for (const QSharedPointer<SettingsBase>& settings_base : m_settings_bases) {
+    for (int index = 0, end = m_settings_bases.size(); index < end; ++index) {
+        const QSharedPointer<SettingsBase>& settings_base = m_settings_bases[index];
         for (const QString& key : m_local_override_keys) {
-            if (settings_base->contains(key))
+            if (settings_base->contains(key) && !matchesInheritedValue(key, index))
                 return true;
         }
     }
+
+    return false;
+}
+
+bool SettingRowBase::matchesInheritedValue(const QString& key, int index) const {
+    if (index < 0 || index >= m_settings_bases.size() || !m_settings_bases[index]->contains(key))
+        return true;
+
+    const fifojson local_value = m_settings_bases[index]->setting<fifojson>(key);
+    if (index < m_inherited_settings_bases.size()) {
+        const QSharedPointer<SettingsBase>& inherited_base = m_inherited_settings_bases[index];
+        if (!inherited_base.isNull() && inherited_base->contains(key))
+            return local_value == inherited_base->setting<fifojson>(key);
+    }
+
+    if (m_sb->contains(key))
+        return local_value == m_sb->setting<fifojson>(key);
+
+    if (key == m_key && m_json.contains(Constants::Settings::Master::kDefault))
+        return local_value == m_json[Constants::Settings::Master::kDefault];
 
     return false;
 }

--- a/src/widgets/settings/setting_spin_box.cpp
+++ b/src/widgets/settings/setting_spin_box.cpp
@@ -105,13 +105,7 @@ void SettingSpinBox::reloadValue() {
 
     this->blockSignals(false);
     emit modified(m_key);
-    // give (1) warning if there is a mismatch, otherwise give no (0) warning
-    if (!consistent) {
-        emit warnParent(1);
-        m_warn = true;
-    }
-    else
-        emit warnParent(0);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
 }
 
 void SettingSpinBox::wheelEvent(QWheelEvent* event) {

--- a/src/widgets/settings/setting_tab.cpp
+++ b/src/widgets/settings/setting_tab.cpp
@@ -147,10 +147,10 @@ void SettingTab::addRow(QString key, const fifojson& json, const fifojson& input
         }
 
         if (!newRow.isNull()) {
-            newRow->setValueChangeCallback([this](const QString& changed_key,
-                                                  const QList<QSharedPointer<SettingsBase>>& settings_bases) {
-                emit settingAboutToChange(changed_key, settings_bases);
-            });
+            newRow->setValueChangeCallback(
+                [this](const QString& changed_key, const QList<QSharedPointer<SettingsBase>>& settings_bases) {
+                    emit settingAboutToChange(changed_key, settings_bases);
+                });
             m_rows.insert(primary_key, newRow);
             for (std::size_t i = 1; i < components.size(); ++i)
                 m_row_aliases.insert(componentSetting(components.at(i)), newRow);
@@ -164,10 +164,10 @@ void SettingTab::addRow(QString key, const fifojson& json, const fifojson& input
         QSharedPointer<SettingRowBase>(m_creation_mapping[json.at(Constants::Settings::Master::kType)](
             this, m_sb, key, json, m_container_layout, m_size));
 
-    newRow->setValueChangeCallback([this](const QString& changed_key,
-                                          const QList<QSharedPointer<SettingsBase>>& settings_bases) {
-        emit settingAboutToChange(changed_key, settings_bases);
-    });
+    newRow->setValueChangeCallback(
+        [this](const QString& changed_key, const QList<QSharedPointer<SettingsBase>>& settings_bases) {
+            emit settingAboutToChange(changed_key, settings_bases);
+        });
     m_rows.insert(key, newRow);
     ++m_size;
 }
@@ -197,12 +197,14 @@ void SettingTab::reload() {
     }
 }
 
-void SettingTab::settingsBasesSelected(QList<QSharedPointer<SettingsBase>> settings_bases) {
-    if (m_settings_bases != settings_bases) {
+void SettingTab::settingsBasesSelected(QList<QSharedPointer<SettingsBase>> settings_bases,
+                                       QList<QSharedPointer<SettingsBase>> inherited_bases) {
+    if (m_settings_bases != settings_bases || m_inherited_settings_bases != inherited_bases) {
         m_warning_count = 0; // reset the count of warnings if a new settings base has been selected
         m_settings_bases = settings_bases;
+        m_inherited_settings_bases = inherited_bases;
         for (QSharedPointer<SettingRowBase> curr_row : m_rows) {
-            curr_row->setBases(m_settings_bases);
+            curr_row->setBases(m_settings_bases, m_inherited_settings_bases);
             curr_row->reloadValue();
         }
     }

--- a/src/widgets/settings/vector2_input_widget.cpp
+++ b/src/widgets/settings/vector2_input_widget.cpp
@@ -127,15 +127,12 @@ void Vector2InputWidget::reloadValue() {
     if (!all_consistent) {
         setNotification("Multiple Values");
         styleLabel(false);
-        m_warn = true;
-        emit warnParent(1);
     }
     else {
         clearNotification();
         styleLabel(true);
-        m_warn = false;
-        emit warnParent(0);
     }
+    emit warnParent(warningCountDelta(!all_consistent, m_warn));
 }
 
 bool Vector2InputWidget::eventFilter(QObject* watched, QEvent* event) {
@@ -257,24 +254,16 @@ bool Vector2InputWidget::hasAnyInconsistentValue() {
 }
 
 void Vector2InputWidget::updateWarningStateAfterEdit() {
-    if (hasAnyInconsistentValue()) {
+    const bool warning_active = hasAnyInconsistentValue();
+    if (warning_active) {
         setNotification("Multiple Values");
         styleLabel(false);
-        if (!m_warn)
-            emit warnParent(1);
-        else
-            emit warnParent(0);
-        m_warn = true;
     }
     else {
         clearNotification();
         styleLabel(true);
-        if (m_warn)
-            emit warnParent(-1);
-        else
-            emit warnParent(0);
-        m_warn = false;
     }
+    emit warnParent(warningCountDelta(warning_active, m_warn));
 }
 
 void Vector2InputWidget::setSpinBoxValue(QDoubleSpinBox* spin_box, const QString& key, Distance default_value,

--- a/src/widgets/settings/vector2_input_widget.cpp
+++ b/src/widgets/settings/vector2_input_widget.cpp
@@ -51,6 +51,8 @@ Vector2InputWidget::Vector2InputWidget(SettingTab* parent, QSharedPointer<Settin
       m_components {{{primary_key, new QDoubleSpinBox(this), primary_default},
                      {secondary_key, new QDoubleSpinBox(this), secondary_default}}},
       m_warn(false) {
+    setLocalOverrideKeys({primary_key, secondary_key});
+
     QHBoxLayout* vector_layout = new QHBoxLayout(this);
     vector_layout->setContentsMargins(0, 0, 0, 0);
     vector_layout->setSpacing(kComponentSpacing);
@@ -192,6 +194,9 @@ void Vector2InputWidget::updateSetting(const QString& key, double displayed_valu
     if (m_settings_bases.size() != 0) {
         for (QSharedPointer<SettingsBase> range : m_settings_bases)
             range->setSetting(key, base_value());
+
+        const Distance global_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : base_value;
+        removeRedundantLocalOverrides<Distance>(key, global_value);
     }
     else {
         m_sb->setSetting(key, base_value());
@@ -207,6 +212,9 @@ void Vector2InputWidget::updateSetting(const QString& key, double displayed_valu
 
 Distance Vector2InputWidget::reloadDistanceValue(const QString& key, Distance default_value, bool& consistent) {
     if (m_settings_bases.size() > 0) {
+        const Distance base_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : default_value;
+        removeRedundantLocalOverrides<Distance>(key, base_value);
+
         bool all_bases_consistent = true;
         for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
             auto sb_1 = m_settings_bases[i - 1];

--- a/src/widgets/settings/vector2_input_widget.cpp
+++ b/src/widgets/settings/vector2_input_widget.cpp
@@ -212,47 +212,20 @@ void Vector2InputWidget::updateSetting(const QString& key, double displayed_valu
 
 Distance Vector2InputWidget::reloadDistanceValue(const QString& key, Distance default_value, bool& consistent) {
     if (m_settings_bases.size() > 0) {
-        const Distance base_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : default_value;
-        removeRedundantLocalOverrides<Distance>(key, base_value);
+        const Distance global_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : default_value;
+        const Distance first_value = effectiveValueHelper<Distance>(key, 0, global_value);
 
         bool all_bases_consistent = true;
-        for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
-            auto sb_1 = m_settings_bases[i - 1];
-            auto sb_2 = m_settings_bases[i];
-            all_bases_consistent = all_bases_consistent && areConsistent(key, sb_1, sb_2, default_value);
-        }
+        for (int index = 1, end = m_settings_bases.size(); index < end; ++index)
+            all_bases_consistent =
+                all_bases_consistent && effectiveValueHelper<Distance>(key, index, global_value) == first_value;
 
         if (all_bases_consistent)
-            return effectiveDistanceValue(key, m_settings_bases[0], default_value);
+            return first_value;
 
         consistent = false;
         return default_value;
     }
-
-    return effectiveDistanceValue(key, m_sb, default_value);
-}
-
-bool Vector2InputWidget::areConsistent(const QString& key, QSharedPointer<SettingsBase> a,
-                                       QSharedPointer<SettingsBase> b, Distance default_value) {
-    const Distance base_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : default_value;
-
-    if (a->contains(key) && base_value == a->setting<Distance>(key))
-        a->remove(key);
-
-    if (b->contains(key) && base_value == b->setting<Distance>(key))
-        b->remove(key);
-
-    bool containsA = a->contains(key);
-    bool containsB = b->contains(key);
-
-    return (containsA == containsB) &&
-           ((containsA && (a->setting<Distance>(key) == b->setting<Distance>(key))) || !containsA);
-}
-
-Distance Vector2InputWidget::effectiveDistanceValue(const QString& key, QSharedPointer<SettingsBase> settings_base,
-                                                    Distance default_value) {
-    if (settings_base->contains(key))
-        return settings_base->setting<Distance>(key);
 
     if (m_sb->contains(key))
         return m_sb->setting<Distance>(key);
@@ -264,9 +237,10 @@ bool Vector2InputWidget::hasConsistentEffectiveValues(const QString& key, Distan
     if (m_settings_bases.size() <= 1)
         return true;
 
-    Distance first_value = effectiveDistanceValue(key, m_settings_bases[0], default_value);
-    for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
-        if (effectiveDistanceValue(key, m_settings_bases[i], default_value) != first_value)
+    const Distance global_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : default_value;
+    const Distance first_value = effectiveValueHelper<Distance>(key, 0, global_value);
+    for (int index = 1, end = m_settings_bases.size(); index < end; ++index) {
+        if (effectiveValueHelper<Distance>(key, index, global_value) != first_value)
             return false;
     }
 

--- a/src/widgets/settings/vector3_input_widget.cpp
+++ b/src/widgets/settings/vector3_input_widget.cpp
@@ -202,47 +202,20 @@ void Vector3InputWidget::updateSetting(const QString& key, double value) {
 
 double Vector3InputWidget::reloadDoubleValue(const QString& key, double default_value, bool& consistent) {
     if (m_settings_bases.size() > 0) {
-        const double base_value = m_sb->contains(key) ? m_sb->setting<double>(key) : default_value;
-        removeRedundantLocalOverrides<double>(key, base_value);
+        const double global_value = m_sb->contains(key) ? m_sb->setting<double>(key) : default_value;
+        const double first_value = effectiveValueHelper<double>(key, 0, global_value);
 
         bool all_bases_consistent = true;
-        for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
-            auto sb_1 = m_settings_bases[i - 1];
-            auto sb_2 = m_settings_bases[i];
-            all_bases_consistent = all_bases_consistent && areConsistent(key, sb_1, sb_2, default_value);
-        }
+        for (int index = 1, end = m_settings_bases.size(); index < end; ++index)
+            all_bases_consistent =
+                all_bases_consistent && effectiveValueHelper<double>(key, index, global_value) == first_value;
 
         if (all_bases_consistent)
-            return effectiveDoubleValue(key, m_settings_bases[0], default_value);
+            return first_value;
 
         consistent = false;
         return default_value;
     }
-
-    return effectiveDoubleValue(key, m_sb, default_value);
-}
-
-bool Vector3InputWidget::areConsistent(const QString& key, QSharedPointer<SettingsBase> a,
-                                       QSharedPointer<SettingsBase> b, double default_value) {
-    const double base_value = m_sb->contains(key) ? m_sb->setting<double>(key) : default_value;
-
-    if (a->contains(key) && base_value == a->setting<double>(key))
-        a->remove(key);
-
-    if (b->contains(key) && base_value == b->setting<double>(key))
-        b->remove(key);
-
-    bool containsA = a->contains(key);
-    bool containsB = b->contains(key);
-
-    return (containsA == containsB) &&
-           ((containsA && (a->setting<double>(key) == b->setting<double>(key))) || !containsA);
-}
-
-double Vector3InputWidget::effectiveDoubleValue(const QString& key, QSharedPointer<SettingsBase> settings_base,
-                                                double default_value) {
-    if (settings_base->contains(key))
-        return settings_base->setting<double>(key);
 
     if (m_sb->contains(key))
         return m_sb->setting<double>(key);
@@ -254,9 +227,10 @@ bool Vector3InputWidget::hasConsistentEffectiveValues(const QString& key, double
     if (m_settings_bases.size() <= 1)
         return true;
 
-    double first_value = effectiveDoubleValue(key, m_settings_bases[0], default_value);
-    for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
-        if (effectiveDoubleValue(key, m_settings_bases[i], default_value) != first_value)
+    const double global_value = m_sb->contains(key) ? m_sb->setting<double>(key) : default_value;
+    const double first_value = effectiveValueHelper<double>(key, 0, global_value);
+    for (int index = 1, end = m_settings_bases.size(); index < end; ++index) {
+        if (effectiveValueHelper<double>(key, index, global_value) != first_value)
             return false;
     }
 

--- a/src/widgets/settings/vector3_input_widget.cpp
+++ b/src/widgets/settings/vector3_input_widget.cpp
@@ -124,15 +124,12 @@ void Vector3InputWidget::reloadValue() {
     if (!all_consistent) {
         setNotification("Multiple Values");
         styleLabel(false);
-        m_warn = true;
-        emit warnParent(1);
     }
     else {
         clearNotification();
         styleLabel(true);
-        m_warn = false;
-        emit warnParent(0);
     }
+    emit warnParent(warningCountDelta(!all_consistent, m_warn));
 }
 
 bool Vector3InputWidget::eventFilter(QObject* watched, QEvent* event) {
@@ -247,24 +244,16 @@ bool Vector3InputWidget::hasAnyInconsistentValue() {
 }
 
 void Vector3InputWidget::updateWarningStateAfterEdit() {
-    if (hasAnyInconsistentValue()) {
+    const bool warning_active = hasAnyInconsistentValue();
+    if (warning_active) {
         setNotification("Multiple Values");
         styleLabel(false);
-        if (!m_warn)
-            emit warnParent(1);
-        else
-            emit warnParent(0);
-        m_warn = true;
     }
     else {
         clearNotification();
         styleLabel(true);
-        if (m_warn)
-            emit warnParent(-1);
-        else
-            emit warnParent(0);
-        m_warn = false;
     }
+    emit warnParent(warningCountDelta(warning_active, m_warn));
 }
 
 void Vector3InputWidget::setSpinBoxValue(QDoubleSpinBox* spin_box, const QString& key, double default_value,

--- a/src/widgets/settings/vector3_input_widget.cpp
+++ b/src/widgets/settings/vector3_input_widget.cpp
@@ -51,6 +51,8 @@ Vector3InputWidget::Vector3InputWidget(SettingTab* parent, QSharedPointer<Settin
                      {secondary_key, new QDoubleSpinBox(this), secondary_default},
                      {tertiary_key, new QDoubleSpinBox(this), tertiary_default}}},
       m_warn(false) {
+    setLocalOverrideKeys({primary_key, secondary_key, tertiary_key});
+
     QHBoxLayout* vector_layout = new QHBoxLayout(this);
     vector_layout->setContentsMargins(0, 0, 0, 0);
     vector_layout->setSpacing(kComponentSpacing);
@@ -182,6 +184,9 @@ void Vector3InputWidget::updateSetting(const QString& key, double value) {
     if (m_settings_bases.size() != 0) {
         for (QSharedPointer<SettingsBase> range : m_settings_bases)
             range->setSetting(key, value);
+
+        const double global_value = m_sb->contains(key) ? m_sb->setting<double>(key) : value;
+        removeRedundantLocalOverrides<double>(key, global_value);
     }
     else {
         m_sb->setSetting(key, value);
@@ -197,6 +202,9 @@ void Vector3InputWidget::updateSetting(const QString& key, double value) {
 
 double Vector3InputWidget::reloadDoubleValue(const QString& key, double default_value, bool& consistent) {
     if (m_settings_bases.size() > 0) {
+        const double base_value = m_sb->contains(key) ? m_sb->setting<double>(key) : default_value;
+        removeRedundantLocalOverrides<double>(key, base_value);
+
         bool all_bases_consistent = true;
         for (int i = 1, end = m_settings_bases.size(); i < end; ++i) {
             auto sb_1 = m_settings_bases[i - 1];


### PR DESCRIPTION
## Summary

- Highlight settings that are locally overridden with an accent-colored, bold label.
- Add a reset control that removes the selected local override and restores the global value.
- Remove redundant local overrides when their values match Global, including all components of vector settings.

## Why

STL-specific, layer-specific, and settings-mesh overrides were visually indistinguishable from values inherited from Global. This made local configuration difficult to audit and reset.

## Impact

Users can now identify local overrides at a glance and return an overridden setting to its Global value directly from the settings row.

## Validation

- `nix develop -c ninja -C build/generic-llvm-ninja`
- `git diff --check`

Closes #78