### PR TITLE
Localize initial extruder speed

### DIFF
--- a/include/gcode/writers/aml3d_writer.h
+++ b/include/gcode/writers/aml3d_writer.h
@@ -93,7 +93,8 @@ class AML3DWriter : public WriterBase {
     //! \brief Writes G-Code to disable the tamper
     QString writeTamperOff();
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm, int extruder_number);
+    QString writeExtruderOn(RegionType type, int rpm, int extruder_number,
+                            const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff(int extruder_number);
 

--- a/include/gcode/writers/cincinnati_writer.h
+++ b/include/gcode/writers/cincinnati_writer.h
@@ -90,7 +90,7 @@ class CincinnatiWriter : public WriterBase {
     //! \brief Writes G-Code to disable the tamper
     QString writeTamperOff();
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
     //! \brief Writes G-Code to update the acceleration value

--- a/include/gcode/writers/dmg_dmu_writer.h
+++ b/include/gcode/writers/dmg_dmu_writer.h
@@ -77,7 +77,7 @@ class DMGDMUWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
 

--- a/include/gcode/writers/gudel_writer.h
+++ b/include/gcode/writers/gudel_writer.h
@@ -77,7 +77,7 @@ class GudelWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
 

--- a/include/gcode/writers/haas_metric_no_comments_writer.h
+++ b/include/gcode/writers/haas_metric_no_comments_writer.h
@@ -77,7 +77,7 @@ class HaasMetricNoCommentsWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
 

--- a/include/gcode/writers/haas_writer.h
+++ b/include/gcode/writers/haas_writer.h
@@ -77,7 +77,7 @@ class HaasWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
 
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();

--- a/include/gcode/writers/hurco_writer.h
+++ b/include/gcode/writers/hurco_writer.h
@@ -77,7 +77,7 @@ class HurcoWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
 

--- a/include/gcode/writers/ingersoll_writer.h
+++ b/include/gcode/writers/ingersoll_writer.h
@@ -86,7 +86,8 @@ class IngersollWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, float rpm, int extruder_number);
+    QString writeExtruderOn(RegionType type, float rpm, int extruder_number,
+                            const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff(int extruder_number);
 

--- a/include/gcode/writers/juggerbot_writer.h
+++ b/include/gcode/writers/juggerbot_writer.h
@@ -78,7 +78,8 @@ class JuggerBotWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm, Distance bead_width, Distance bead_height);
+    QString writeExtruderOn(RegionType type, int rpm, Distance bead_width, Distance bead_height,
+                            const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
 

--- a/include/gcode/writers/meld_writer.h
+++ b/include/gcode/writers/meld_writer.h
@@ -77,7 +77,7 @@ class MeldWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
 

--- a/include/gcode/writers/mvp_writer.h
+++ b/include/gcode/writers/mvp_writer.h
@@ -76,7 +76,7 @@ class MVPWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
 

--- a/include/gcode/writers/ornl_writer.h
+++ b/include/gcode/writers/ornl_writer.h
@@ -81,7 +81,8 @@ class ORNLWriter : public WriterBase {
   private: //! \brief Defines the machine type - used to differentiate between polymer extrusion and wire-arc
     MachineType m_machine_type;
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType region_type, int rpm, int extruder_number);
+    QString writeExtruderOn(RegionType region_type, int rpm, int extruder_number,
+                            const QSharedPointer<SettingsBase>& params = nullptr);
 
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff(int extruder_number);

--- a/include/gcode/writers/romi_fanuc_writer.h
+++ b/include/gcode/writers/romi_fanuc_writer.h
@@ -77,7 +77,7 @@ class RomiFanucWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
 

--- a/include/gcode/writers/sandia_writer.h
+++ b/include/gcode/writers/sandia_writer.h
@@ -93,7 +93,8 @@ class SandiaWriter : public WriterBase {
     //! \brief Writes G-Code to disable the tamper
     QString writeTamperOff();
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm, int extruder_number);
+    QString writeExtruderOn(RegionType type, int rpm, int extruder_number,
+                            const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff(int extruder_number);
 

--- a/include/gcode/writers/thermwood_writer.h
+++ b/include/gcode/writers/thermwood_writer.h
@@ -77,7 +77,7 @@ class ThermwoodWriter : public WriterBase {
 
   private:
     //! \brief Writes G-Code to enable the extruder
-    QString writeExtruderOn(RegionType type, int rpm);
+    QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
     QString writeExtruderOff();
 

--- a/include/gcode/writers/writer_base.h
+++ b/include/gcode/writers/writer_base.h
@@ -135,6 +135,9 @@ class WriterBase {
     //! \brief gets a vector in the direction normal to the plane and of a length = travel lift height
     QVector3D getTravelLift();
 
+    //! \brief Gets the segment-local initial extruder speed, falling back to the global setting.
+    int getInitialExtruderSpeed(const QSharedPointer<SettingsBase>& params = nullptr) const;
+
     GcodeMeta m_meta;
 
     //! \brief The settings the region will use.

--- a/src/gcode/writers/adamantine_writer.cpp
+++ b/src/gcode/writers/adamantine_writer.cpp
@@ -63,7 +63,7 @@ QString AdamantineWriter::writeTravel(Point start_location, Point target_locatio
           QString::number(Distance(target_location.y()).to(m_meta.m_distance_unit), 'f', 5) % m_space %
           QString::number(Distance(target_location.z()).to(m_meta.m_distance_unit), 'f', 8) % m_space % "0" % m_space;
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
+    if (getInitialExtruderSpeed(params) > 0) {
         if (m_region_type == RegionType::kInset) {
             if (m_sb->setting<Time>(MS::Extruder::kOnDelayInset) >= 0)
                 rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOnDelayInset)) % "\n";

--- a/src/gcode/writers/aml3d_writer.cpp
+++ b/src/gcode/writers/aml3d_writer.cpp
@@ -215,7 +215,7 @@ QString AML3DWriter::writeLine(const Point& start_point, const Point& target_poi
     QString rv;
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0);
+        rv += writeExtruderOn(region_type, rpm, 0, params);
         setFeedrate(0);
     }
     if ((path_modifiers == PathModifiers::kForwardTipWipe || path_modifiers == PathModifiers::kReverseTipWipe ||
@@ -274,7 +274,7 @@ QString AML3DWriter::writeArc(const Point& start_point, const Point& end_point, 
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0);
+        rv += writeExtruderOn(region_type, rpm, 0, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -407,23 +407,24 @@ QString AML3DWriter::writeTamperOff() {
     return rv;
 }
 
-QString AML3DWriter::writeExtruderOn(RegionType type, int rpm, int extruder_number) {
+QString AML3DWriter::writeExtruderOn(RegionType type, int rpm, int extruder_number,
+                                     const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
     rv += writeTamperOn();
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
         // scale
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) == (int)ForceMinimumLayerTime::kSlow_Feedrate))
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/cincinnati_writer.cpp
+++ b/src/gcode/writers/cincinnati_writer.cpp
@@ -329,7 +329,9 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
     // Determine if travel length is short enough to keep extruder on
     Distance travel_distance = start_location.distance(target_location);
     if (!m_first_travel && travel_distance < m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
-        rv += writeExtruderOn(RegionType::kPerimeter, m_sb->setting<int>(PS::Perimeter::kExtruderSpeed));
+        int rpm = params->contains(SS::kExtruderSpeed) ? params->setting<int>(SS::kExtruderSpeed)
+                                                       : m_sb->setting<int>(PS::Perimeter::kExtruderSpeed);
+        rv += writeExtruderOn(rType == RegionType::kUnknown ? RegionType::kPerimeter : rType, rpm, params);
     }
 
     if (m_first_travel) {
@@ -546,7 +548,7 @@ QString CincinnatiWriter::writeLine(const Point& start_point, const Point& targe
     }
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
         setFeedrate(0);
     }
 
@@ -640,7 +642,7 @@ QString CincinnatiWriter::writeArc(const Point& start_point, const Point& end_po
     }
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     // Update extruder speed if not correct and if M3 S is desired rather than G* S which is issued later
@@ -810,21 +812,21 @@ QString CincinnatiWriter::writeTamperOff() {
     }
 }
 
-QString CincinnatiWriter::writeExtruderOn(RegionType type, int rpm) {
+QString CincinnatiWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
     rv += writeTamperOn();
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
+    if (initial_rpm > 0) {
         // Check settings, turn off extruder servoing, will turn back on at end
         if (m_sb->setting<int>(MS::Extruder::kServoToTravelSpeed)) {
             rv += m_M11 % m_space % commentLine("TURN OFF EXTRUDER SERVOING");
         }
 
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
@@ -832,7 +834,7 @@ QString CincinnatiWriter::writeExtruderOn(RegionType type, int rpm) {
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) ==
                   (int)ForceMinimumLayerTime::kSlow_Feedrate)) {
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
         }
 
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");

--- a/src/gcode/writers/dmg_dmu_writer.cpp
+++ b/src/gcode/writers/dmg_dmu_writer.cpp
@@ -178,7 +178,7 @@ QString DMGDMUWriter::writeLine(const Point& start_point, const Point& target_po
 
     // turn on the extruder if it isn't already on
     if (m_extruder_on == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += m_G1;
@@ -231,7 +231,7 @@ QString DMGDMUWriter::writeArc(const Point& start_point, const Point& end_point,
 
     // Turn on the extruder if it isn't already on
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -340,21 +340,21 @@ QString DMGDMUWriter::writeDwell(Time time) {
         return {};
 }
 
-QString DMGDMUWriter::writeExtruderOn(RegionType type, int rpm) {
+QString DMGDMUWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
         // scale
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) == (int)ForceMinimumLayerTime::kSlow_Feedrate))
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/gudel_writer.cpp
+++ b/src/gcode/writers/gudel_writer.cpp
@@ -174,7 +174,7 @@ QString GudelWriter::writeLine(const Point& start_point, const Point& target_poi
 
     // turn on the extruder if it isn't already on
     if (m_extruder_on == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += m_G1;
@@ -326,21 +326,21 @@ QString GudelWriter::writeDwell(Time time) {
         return {};
 }
 
-QString GudelWriter::writeExtruderOn(RegionType type, int rpm) {
+QString GudelWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
         // scale
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) == (int)ForceMinimumLayerTime::kSlow_Feedrate))
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/haas_metric_no_comments_writer.cpp
+++ b/src/gcode/writers/haas_metric_no_comments_writer.cpp
@@ -179,7 +179,7 @@ QString HaasMetricNoCommentsWriter::writeLine(const Point& start_point, const Po
 
     // turn on the extruder if it isn't already on
     if (m_extruder_on == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     // turn off extruder with an M5 before the line, rather than in-line with S0
@@ -233,7 +233,7 @@ QString HaasMetricNoCommentsWriter::writeArc(const Point& start_point, const Poi
 
     // Turn on the extruder if it isn't already on
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -345,21 +345,22 @@ QString HaasMetricNoCommentsWriter::writeDwell(Time time) {
         return {};
 }
 
-QString HaasMetricNoCommentsWriter::writeExtruderOn(RegionType type, int rpm) {
+QString HaasMetricNoCommentsWriter::writeExtruderOn(RegionType type, int rpm,
+                                                    const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
         // scale
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) == (int)ForceMinimumLayerTime::kSlow_Feedrate))
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm);
 

--- a/src/gcode/writers/haas_writer.cpp
+++ b/src/gcode/writers/haas_writer.cpp
@@ -188,7 +188,7 @@ QString HaasWriter::writeLine(const Point& start_point, const Point& target_poin
 
     // turn on the extruder if it isn't already on
     if (m_extruder_on == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     // turn off extruder with an M5 before the line, rather than in-line with S0
@@ -246,7 +246,7 @@ QString HaasWriter::writeArc(const Point& start_point, const Point& end_point, c
 
     // Turn on the extruder if it isn't already on
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -361,21 +361,21 @@ QString HaasWriter::writeDwell(Time time) {
         return {};
 }
 
-QString HaasWriter::writeExtruderOn(RegionType type, int rpm) {
+QString HaasWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
         // scale
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) == (int)ForceMinimumLayerTime::kSlow_Feedrate))
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm, 'f', 4) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/hurco_writer.cpp
+++ b/src/gcode/writers/hurco_writer.cpp
@@ -182,7 +182,7 @@ QString HurcoWriter::writeLine(const Point& start_point, const Point& target_poi
 
     // turn on the extruder if it isn't already on
     if (m_extruder_on == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += m_G1;
@@ -235,7 +235,7 @@ QString HurcoWriter::writeArc(const Point& start_point, const Point& end_point, 
 
     // Turn on the extruder if it isn't already on
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -350,21 +350,21 @@ QString HurcoWriter::writeDwell(Time time) {
         return {};
 }
 
-QString HurcoWriter::writeExtruderOn(RegionType type, int rpm) {
+QString HurcoWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
         // scale
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) == (int)ForceMinimumLayerTime::kSlow_Feedrate))
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/ingersoll_writer.cpp
+++ b/src/gcode/writers/ingersoll_writer.cpp
@@ -210,7 +210,7 @@ QString IngersollWriter::writeLine(const Point& start_point, const Point& target
     QString rv;
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0);
+        rv += writeExtruderOn(region_type, rpm, 0, params);
         m_current_rpm = rpm;
     }
     // Update extruder speed if needed
@@ -253,7 +253,7 @@ QString IngersollWriter::writeArc(const Point& start_point, const Point& end_poi
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0);
+        rv += writeExtruderOn(region_type, rpm, 0, params);
     }
     // Update extruder speed if needed
     if (m_extruder_on && rpm != m_current_rpm) {
@@ -359,18 +359,19 @@ QString IngersollWriter::writeDwell(Time time) {
         return {};
 }
 
-QString IngersollWriter::writeExtruderOn(RegionType type, float rpm, int extruder_number) {
+QString IngersollWriter::writeExtruderOn(RegionType type, float rpm, int extruder_number,
+                                         const QSharedPointer<SettingsBase>& params) {
     QString rv;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
     rv += commentLine("Bead Start");
 
     m_extruder_on = true;
 
     // write dwell and initial extruder turn on depending on region type
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<float>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         rv += "EXTRUDER(" % QString::number(output_rpm) % ")" % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/juggerbot_writer.cpp
+++ b/src/gcode/writers/juggerbot_writer.cpp
@@ -129,7 +129,15 @@ QString JuggerBotWriter::writeTravel(Point start_location, Point target_location
         rv += writeExtruderOff();
     }
     else if (travel_distance < m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
-        rv += writeExtruderOn(RegionType::kPerimeter, m_sb->setting<int>(PS::Perimeter::kExtruderSpeed), m_sb->setting<Distance>(PS::Perimeter::kBeadWidth), m_sb->setting<Distance>(PS::Layer::kLayerHeight));
+        RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+        int rpm = params->contains(SS::kExtruderSpeed) ? params->setting<int>(SS::kExtruderSpeed)
+                                                       : m_sb->setting<int>(PS::Perimeter::kExtruderSpeed);
+        Distance width = params->contains(SS::kWidth) ? params->setting<Distance>(SS::kWidth)
+                                                      : m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
+        Distance height = params->contains(SS::kHeight) ? params->setting<Distance>(SS::kHeight)
+                                                        : m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+        rv += writeExtruderOn(region_type == RegionType::kUnknown ? RegionType::kPerimeter : region_type, rpm, width,
+                              height, params);
     }
 
     Point new_start_location;
@@ -211,7 +219,7 @@ QString JuggerBotWriter::writeLine(const Point& start_point, const Point& target
 
     if (requiresWriteExtruderOn && rpm > 0) // && !m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight))
     {
-        rv += writeExtruderOn(region_type, rpm, width, height);
+        rv += writeExtruderOn(region_type, rpm, width, height, params);
         // m_current_rpm = rpm;
     }
 
@@ -279,7 +287,7 @@ QString JuggerBotWriter::writeArc(const Point& start_point, const Point& end_poi
     bool requiresWriteExtruderOn = !m_extruder_on;
 
     if (requiresWriteExtruderOn && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, width, height);
+        rv += writeExtruderOn(region_type, rpm, width, height, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -391,21 +399,21 @@ QString JuggerBotWriter::writeDwell(Time time) {
         return {};
 }
 
-QString JuggerBotWriter::writeExtruderOn(RegionType type, int rpm, Distance width, Distance height) {
+QString JuggerBotWriter::writeExtruderOn(RegionType type, int rpm, Distance width, Distance height,
+                                         const QSharedPointer<SettingsBase>& params) {
     m_extruder_on = true;
     QString rv;
     Area bead_area = (width - height) * height +
                     (pi() * (height / 2) * (height / 2)); // Rectangle with two half circles used as cross-section
+    int initial_rpm = getInitialExtruderSpeed(params);
 
     if (!m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight)) {
         float output_rpm;
 
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
-        if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-            output_rpm =
-                m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+        if (initial_rpm > 0) {
+            output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
             // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
             // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't
@@ -413,7 +421,7 @@ QString JuggerBotWriter::writeExtruderOn(RegionType type, int rpm, Distance widt
             if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
                   m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) ==
                       (int)ForceMinimumLayerTime::kSlow_Feedrate))
-                m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+                m_current_rpm = initial_rpm;
 
             rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/meld_writer.cpp
+++ b/src/gcode/writers/meld_writer.cpp
@@ -189,7 +189,7 @@ QString MeldWriter::writeLine(const Point& start_point, const Point& target_poin
 
     // turn on the extruder if it isn't already on
     if (m_extruder_on == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     if (rpm == 0 && m_extruder_on == true) {
@@ -230,7 +230,7 @@ QString MeldWriter::writeArc(const Point& start_point, const Point& end_point, c
 
     // Turn on the extruder if it isn't already on
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -350,11 +350,12 @@ QString MeldWriter::writeDwell(Time time) {
         return {};
 }
 
-QString MeldWriter::writeExtruderOn(RegionType type, int rpm) {
+QString MeldWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
-    output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    int initial_rpm = getInitialExtruderSpeed(params);
+    output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
     if (!m_sb->setting<int>(ES::FileOutput::kMeldDiscrete)) {
         rv += "M4" % m_s % QString::number(output_rpm) % " @714" % commentSpaceLine("TURN SPINDLE ON");
@@ -362,8 +363,8 @@ QString MeldWriter::writeExtruderOn(RegionType type, int rpm) {
         rv += "M54" % commentSpaceLine("HOLD FOR DEPOSITION START");
     }
     else {
-        if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+        if (initial_rpm > 0) {
+            m_current_rpm = initial_rpm;
 
             rv += "M24 S" % QString::number(output_rpm) % commentSpaceLine("TURN ACTUATOR ON");
 

--- a/src/gcode/writers/mvp_writer.cpp
+++ b/src/gcode/writers/mvp_writer.cpp
@@ -184,7 +184,7 @@ QString MVPWriter::writeLine(const Point& start_point, const Point& target_point
 
     // turn on the extruder if it isn't already on
     if (m_extruder_on == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     if (rpm != m_current_rpm && rpm == 0) {
@@ -295,18 +295,18 @@ QString MVPWriter::writeDwell(Time time) {
         return {};
 }
 
-QString MVPWriter::writeExtruderOn(RegionType type, int rpm) {
+QString MVPWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
     rv += "M52" % commentSpaceLine("TURN GUN ON");
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
-        m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+        m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/ornl_writer.cpp
+++ b/src/gcode/writers/ornl_writer.cpp
@@ -240,7 +240,7 @@ QString ORNLWriter::writeLine(const Point& start_point, const Point& target_poin
     QString rv;
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0);
+        rv += writeExtruderOn(region_type, rpm, 0, params);
         setFeedrate(0);
     }
 
@@ -298,7 +298,7 @@ QString ORNLWriter::writeArc(const Point& start_point, const Point& end_point, c
     Distance z_offset = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0);
+        rv += writeExtruderOn(region_type, rpm, 0, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -413,7 +413,8 @@ QString ORNLWriter::writeDwell(Time time) {
         return {};
 }
 
-QString ORNLWriter::writeExtruderOn(RegionType region_type, int rpm, int extruder_number) {
+QString ORNLWriter::writeExtruderOn(RegionType region_type, int rpm, int extruder_number,
+                                    const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
@@ -432,7 +433,7 @@ QString ORNLWriter::writeExtruderOn(RegionType region_type, int rpm, int extrude
     }
     else {
         // Retrieve relevant settings
-        int initial_speed = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+        int initial_speed = getInitialExtruderSpeed(params);
         float gear_ratio = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
         bool force_min_layer_time = m_sb->setting<bool>(MS::Cooling::kForceMinLayerTime);
         ForceMinimumLayerTime force_min_layer_time_method =

--- a/src/gcode/writers/romi_fanuc_writer.cpp
+++ b/src/gcode/writers/romi_fanuc_writer.cpp
@@ -182,7 +182,7 @@ QString RomiFanucWriter::writeLine(const Point& start_point, const Point& target
 
     // turn on the extruder if it isn't already on
     if (m_extruder_on == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += m_G1;
@@ -235,7 +235,7 @@ QString RomiFanucWriter::writeArc(const Point& start_point, const Point& end_poi
 
     // Turn on the extruder if it isn't already on
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -350,21 +350,21 @@ QString RomiFanucWriter::writeDwell(Time time) {
         return {};
 }
 
-QString RomiFanucWriter::writeExtruderOn(RegionType type, int rpm) {
+QString RomiFanucWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
         // scale
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) == (int)ForceMinimumLayerTime::kSlow_Feedrate))
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/sandia_writer.cpp
+++ b/src/gcode/writers/sandia_writer.cpp
@@ -191,7 +191,7 @@ QString SandiaWriter::writeLine(const Point& start_point, const Point& target_po
     QString rv;
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0);
+        rv += writeExtruderOn(region_type, rpm, 0, params);
         setFeedrate(0);
     }
 
@@ -244,7 +244,7 @@ QString SandiaWriter::writeArc(const Point& start_point, const Point& end_point,
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0);
+        rv += writeExtruderOn(region_type, rpm, 0, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -377,23 +377,24 @@ QString SandiaWriter::writeTamperOff() {
     return rv;
 }
 
-QString SandiaWriter::writeExtruderOn(RegionType type, int rpm, int extruder_number) {
+QString SandiaWriter::writeExtruderOn(RegionType type, int rpm, int extruder_number,
+                                      const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
     rv += writeTamperOn();
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
         // scale
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) == (int)ForceMinimumLayerTime::kSlow_Feedrate))
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/thermwood_writer.cpp
+++ b/src/gcode/writers/thermwood_writer.cpp
@@ -198,7 +198,7 @@ QString ThermwoodWriter::writeLine(const Point& start_point, const Point& target
 
     // turn on the extruder if it isn't already on
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += m_G1;
@@ -251,7 +251,7 @@ QString ThermwoodWriter::writeArc(const Point& start_point, const Point& end_poi
 
     // Turn on the extruder if it isn't already on
     if (!m_extruder_on && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
+        rv += writeExtruderOn(region_type, rpm, params);
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -361,21 +361,21 @@ QString ThermwoodWriter::writeDwell(Time time) {
         return {};
 }
 
-QString ThermwoodWriter::writeExtruderOn(RegionType type, int rpm) {
+QString ThermwoodWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
     m_extruder_on = true;
     float output_rpm;
+    int initial_rpm = getInitialExtruderSpeed(params);
 
-    if (m_sb->setting<int>(MS::Extruder::kInitialSpeed) > 0) {
-        output_rpm =
-            m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+    if (initial_rpm > 0) {
+        output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
         // Only update the current rpm if not using feedrate scaling. An updated rpm value here could prevent the S
         // parameter from being issued during the first G1 motion of the path and thus the extruder rate won't properly
         // scale
         if (!(m_sb->setting<int>(MS::Cooling::kForceMinLayerTime) &&
               m_sb->setting<int>(MS::Cooling::kForceMinLayerTimeMethod) == (int)ForceMinimumLayerTime::kSlow_Feedrate))
-            m_current_rpm = m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+            m_current_rpm = initial_rpm;
 
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("TURN EXTRUDER ON");
 

--- a/src/gcode/writers/writer_base.cpp
+++ b/src/gcode/writers/writer_base.cpp
@@ -78,6 +78,14 @@ QVector3D WriterBase::getTravelLift() {
     return lift_vector;
 }
 
+int WriterBase::getInitialExtruderSpeed(const QSharedPointer<SettingsBase>& params) const {
+    if (params != nullptr && params->contains(MS::Extruder::kInitialSpeed)) {
+        return params->setting<int>(MS::Extruder::kInitialSpeed);
+    }
+
+    return m_sb->setting<int>(MS::Extruder::kInitialSpeed);
+}
+
 QString WriterBase::writeSlicerHeader(const QString& syntax) {
     QString rv;
 

--- a/src/geometry/path_modifier.cpp
+++ b/src/geometry/path_modifier.cpp
@@ -24,10 +24,25 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
+namespace {
+void copyInitialExtruderSpeed(const QSharedPointer<SettingsBase>& destination,
+                              const QSharedPointer<SettingsBase>& source) {
+    if (source->contains(MS::Extruder::kInitialSpeed)) {
+        destination->setSetting(MS::Extruder::kInitialSpeed, source->setting<int>(MS::Extruder::kInitialSpeed));
+    }
+}
+} // namespace
 
 void PathModifierGenerator::GenerateTravel(Path& path, Point current_location, Velocity velocity) {
     QSharedPointer<TravelSegment> travel_segment =
         QSharedPointer<TravelSegment>::create(current_location, path.front()->start());
+    QSharedPointer<SettingsBase> next_segment_settings = path.front()->getSb();
+
+    copyInitialExtruderSpeed(travel_segment->getSb(), next_segment_settings);
+    travel_segment->getSb()->setSetting(SS::kRegionType,
+                                        next_segment_settings->setting<RegionType>(SS::kRegionType));
+    travel_segment->getSb()->setSetting(SS::kExtruderSpeed,
+                                        next_segment_settings->setting<AngularVelocity>(SS::kExtruderSpeed));
     travel_segment->getSb()->setSetting(SS::kSpeed, velocity);
 
     path.prepend(travel_segment);
@@ -46,6 +61,7 @@ void PathModifierGenerator::GenerateOpenLoopLeadIn(Path& path, Distance leadInDi
 
     QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(newStart, firstPoint);
 
+    copyInitialExtruderSpeed(segment->getSb(), path[0]->getSb());
     segment->getSb()->setSetting(SS::kWidth, path[0]->getSb()->setting<Distance>(SS::kWidth));
     segment->getSb()->setSetting(SS::kHeight, path[0]->getSb()->setting<Distance>(SS::kHeight));
     segment->getSb()->setSetting(SS::kSpeed, leadInSpeed);
@@ -91,6 +107,7 @@ void PathModifierGenerator::GenerateFlyingStart(Path& path, Distance flyingStart
             QSharedPointer<LineSegment> segment =
                 QSharedPointer<LineSegment>::create(path[currentIndex]->start(), path[currentIndex]->end());
 
+            copyInitialExtruderSpeed(segment->getSb(), path[currentIndex]->getSb());
             segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth));
             segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight));
             segment->getSb()->setSetting(SS::kSpeed, flyingStartSpeed);
@@ -115,6 +132,7 @@ void PathModifierGenerator::GenerateFlyingStart(Path& path, Distance flyingStart
 
             QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(newStart, end);
 
+            copyInitialExtruderSpeed(segment->getSb(), path[currentIndex]->getSb());
             segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth));
             segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight));
             segment->getSb()->setSetting(SS::kSpeed, flyingStartSpeed);
@@ -165,6 +183,7 @@ void PathModifierGenerator::GenerateInitialStartup(Path& path, Distance startDis
 
             QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(oldStart, end);
 
+            copyInitialExtruderSpeed(segment->getSb(), path[currentIndex]->getSb());
             segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth));
             segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight));
             segment->getSb()->setSetting(SS::kSpeed, startSpeed);
@@ -232,6 +251,7 @@ void PathModifierGenerator::GenerateInitialStartupWithRampUp(Path& path, Distanc
 
             QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(oldStart, end);
 
+            copyInitialExtruderSpeed(segment->getSb(), path[currentIndex]->getSb());
             segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth));
             segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight));
             segment->getSb()->setSetting(SS::kSpeed, startSpeed);
@@ -289,6 +309,7 @@ void PathModifierGenerator::GenerateInitialStartupWithRampUp(Path& path, Distanc
 
                 QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(oldStart, end);
 
+                copyInitialExtruderSpeed(segment->getSb(), path[currentIndex]->getSb());
                 segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth));
                 segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight));
                 segment->getSb()->setSetting(SS::kSpeed, currentSpeed);
@@ -370,6 +391,7 @@ void PathModifierGenerator::GenerateSlowdown(Path& path, Distance slowDownDistan
 
             QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(end, newEnd);
 
+            copyInitialExtruderSpeed(segment->getSb(), path[currentIndex]->getSb());
             segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth));
             segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight));
             segment->getSb()->setSetting(SS::kSpeed, slowDownSpeed);
@@ -422,6 +444,7 @@ void PathModifierGenerator::GenerateSlowdown(Path& path, Distance slowDownDistan
 
             QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(end, oldEnd);
 
+            copyInitialExtruderSpeed(segment->getSb(), path[currentIndex]->getSb());
             segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth));
             segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight));
             segment->getSb()->setSetting(SS::kSpeed, slowDownSpeed);
@@ -458,6 +481,7 @@ void PathModifierGenerator::GenerateLayerLeadIn(Path& path, const Point& leadIn,
 
         QSharedPointer<LineSegment> leadInSegment =
             QSharedPointer<LineSegment>::create(leadIn, firstBuildSegment->start());
+        copyInitialExtruderSpeed(leadInSegment->getSb(), firstBuildSegment->getSb());
         leadInSegment->getSb()->setSetting(SS::kWidth, firstBuildSegment->getSb()->setting<Distance>(SS::kWidth));
         leadInSegment->getSb()->setSetting(SS::kHeight, firstBuildSegment->getSb()->setting<Distance>(SS::kHeight));
         leadInSegment->getSb()->setSetting(SS::kSpeed, firstBuildSegment->getSb()->setting<Velocity>(SS::kSpeed));
@@ -770,6 +794,7 @@ void PathModifierGenerator::GenerateRamp(Path& path, bool& segmentSplitted, int 
             segment->setEnd(newP);
 
             QSharedPointer<LineSegment> newSegment = QSharedPointer<LineSegment>::create(newP, endP);
+            copyInitialExtruderSpeed(newSegment->getSb(), segment->getSb());
             newSegment->getSb()->setSetting(SS::kWidth, segment->getSb()->setting<Distance>(SS::kWidth));
             newSegment->getSb()->setSetting(SS::kHeight, segment->getSb()->setting<Distance>(SS::kHeight));
             newSegment->getSb()->setSetting(SS::kAccel, segment->getSb()->setting<Acceleration>(SS::kAccel));

--- a/src/step/layer/regions/brim.cpp
+++ b/src/step/layer/regions/brim.cpp
@@ -176,6 +176,9 @@ Path Brim::createPath(Polyline line) {
 
                 QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(start, point);
 
+                segment->getSb()->setSetting(
+                    MS::Extruder::kInitialSpeed,
+                    (is_settings_region ? start.getSettings() : m_sb)->setting<int>(MS::Extruder::kInitialSpeed));
                 segment->getSb()->setSetting(SS::kWidth, is_settings_region ? start.getSettings()->setting<Distance>(
                                                                                   MS::PlatformAdhesion::kBrimBeadWidth)
                                                                             : default_width);
@@ -204,6 +207,9 @@ Path Brim::createPath(Polyline line) {
 
         // Add final segment
         QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(start, end);
+        segment->getSb()->setSetting(
+            MS::Extruder::kInitialSpeed,
+            (is_settings_region ? start.getSettings() : m_sb)->setting<int>(MS::Extruder::kInitialSpeed));
         segment->getSb()->setSetting(SS::kWidth, is_settings_region ? start.getSettings()->setting<Distance>(
                                                                           MS::PlatformAdhesion::kBrimBeadWidth)
                                                                     : default_width);

--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -206,6 +206,8 @@ Path Infill::createPath(Polyline line) {
     for (int j = 0, polyEnd = line.size() - 1; j < polyEnd; ++j) {
         QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(line[j], line[j + 1]);
 
+        segment->getSb()->setSetting(MS::Extruder::kInitialSpeed,
+                                     m_sb->setting<int>(MS::Extruder::kInitialSpeed));
         segment->getSb()->setSetting(SS::kWidth, width);
         segment->getSb()->setSetting(SS::kHeight, height);
         segment->getSb()->setSetting(SS::kSpeed, speed);
@@ -221,6 +223,8 @@ Path Infill::createPath(Polyline line) {
     if (static_cast<InfillPatterns>(m_sb->setting<int>(PS::Infill::kPattern)) == InfillPatterns::kConcentric) {
         QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(line.last(), line.first());
 
+        segment->getSb()->setSetting(MS::Extruder::kInitialSpeed,
+                                     m_sb->setting<int>(MS::Extruder::kInitialSpeed));
         segment->getSb()->setSetting(SS::kWidth, width);
         segment->getSb()->setSetting(SS::kHeight, height);
         segment->getSb()->setSetting(SS::kSpeed, speed);

--- a/src/step/layer/regions/raft.cpp
+++ b/src/step/layer/regions/raft.cpp
@@ -118,6 +118,7 @@ Path Raft::createPath(Polyline line) {
     for (int i = 0, end = line.size() - 1; i < end; ++i) {
         QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(line[i], line[i + 1]);
 
+        segment->getSb()->setSetting(MS::Extruder::kInitialSpeed, m_sb->setting<int>(MS::Extruder::kInitialSpeed));
         segment->getSb()->setSetting(SS::kWidth, default_width);
         segment->getSb()->setSetting(SS::kHeight, default_height);
         segment->getSb()->setSetting(SS::kSpeed, default_speed);

--- a/src/step/layer/regions/region_base.cpp
+++ b/src/step/layer/regions/region_base.cpp
@@ -95,6 +95,7 @@ void RegionBase::calculateMultiMaterialTransition(Distance& transition_distance,
                     current_segments[j]->setEnd(end);
 
                     QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(end, old_end);
+                    segment->getSb()->populate(current_segments[j]->getSb());
                     segment->getSb()->setSetting(SS::kWidth,
                                                  current_segments[j]->getSb()->setting<Distance>(SS::kWidth));
                     segment->getSb()->setSetting(SS::kHeight,

--- a/src/step/layer/regions/skin.cpp
+++ b/src/step/layer/regions/skin.cpp
@@ -297,6 +297,8 @@ Path Skin::createPath(Polyline line) {
     for (int i = 0; i < line.size() - 1; i++) {
         QSharedPointer<LineSegment> line_segment = QSharedPointer<LineSegment>::create(line[i], line[i + 1]);
 
+        line_segment->getSb()->setSetting(MS::Extruder::kInitialSpeed,
+                                          m_sb->setting<int>(MS::Extruder::kInitialSpeed));
         line_segment->getSb()->setSetting(SS::kWidth, width);
         line_segment->getSb()->setSetting(SS::kHeight, height);
         line_segment->getSb()->setSetting(SS::kSpeed, speed);
@@ -312,6 +314,8 @@ Path Skin::createPath(Polyline line) {
     if (static_cast<InfillPatterns>(m_sb->setting<int>(PS::Skin::kPattern)) == InfillPatterns::kConcentric) {
         QSharedPointer<LineSegment> line_segment = QSharedPointer<LineSegment>::create(line.last(), line.first());
 
+        line_segment->getSb()->setSetting(MS::Extruder::kInitialSpeed,
+                                          m_sb->setting<int>(MS::Extruder::kInitialSpeed));
         line_segment->getSb()->setSetting(SS::kWidth, width);
         line_segment->getSb()->setSetting(SS::kHeight, height);
         line_segment->getSb()->setSetting(SS::kSpeed, speed);

--- a/src/step/layer/regions/skirt.cpp
+++ b/src/step/layer/regions/skirt.cpp
@@ -180,6 +180,9 @@ Path Skirt::createPath(Polyline line) {
 
                 QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(start, point);
 
+                segment->getSb()->setSetting(
+                    MS::Extruder::kInitialSpeed,
+                    (is_settings_region ? start.getSettings() : m_sb)->setting<int>(MS::Extruder::kInitialSpeed));
                 segment->getSb()->setSetting(SS::kWidth, is_settings_region ? start.getSettings()->setting<Distance>(
                                                                                   MS::PlatformAdhesion::kRaftBeadWidth)
                                                                             : default_width);
@@ -208,6 +211,9 @@ Path Skirt::createPath(Polyline line) {
 
         // Add final segment
         QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(start, end);
+        segment->getSb()->setSetting(
+            MS::Extruder::kInitialSpeed,
+            (is_settings_region ? start.getSettings() : m_sb)->setting<int>(MS::Extruder::kInitialSpeed));
         segment->getSb()->setSetting(SS::kWidth, is_settings_region ? start.getSettings()->setting<Distance>(
                                                                           MS::PlatformAdhesion::kRaftBeadWidth)
                                                                     : default_width);

--- a/src/step/layer/regions/support.cpp
+++ b/src/step/layer/regions/support.cpp
@@ -215,6 +215,7 @@ Path Support::createPath(Polyline line) {
 
     QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(line.first(), line.last());
 
+    segment->getSb()->setSetting(MS::Extruder::kInitialSpeed, m_sb->setting<int>(MS::Extruder::kInitialSpeed));
     segment->getSb()->setSetting(SS::kWidth, bead_width);
     segment->getSb()->setSetting(SS::kHeight, layer_height);
     segment->getSb()->setSetting(SS::kSpeed, speed);


### PR DESCRIPTION
## Summary

Fixes #58 by carrying initial extruder speed through segment-local settings and having writer startup logic prefer the segment value before falling back to the global machine setting.

## Root Cause

`MS::Extruder::kInitialSpeed` could be overridden at the part or layer setting level, but generated segments and writer `writeExtruderOn` calls generally read the global settings bag. That meant Cincinnati and other writers with initial-RPM startup logic could not honor part- or layer-specific initial speed values.

## Changes

- Add a shared writer helper for segment-local initial extruder speed lookup with global fallback.
- Thread segment settings into relevant `writeExtruderOn` calls across writers that already implement initial-speed behavior.
- Preserve initial extruder speed on generated travel, lead-in, ramp, startup, slowdown, and split segments.
- Stamp initial extruder speed into generated region segments for infill, skin, support, raft, brim, and skirt paths.

## Impact

Part- and layer-specific initial extruder speed overrides now reach the G-code writer startup path for Cincinnati and the other writers that support initial extruder speed, without changing behavior for writers that do not currently implement initial-RPM startup syntax.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `nix develop -c cmake --build --preset debug-generic-llvm-ninja -j 2`