### PR TITLE
Layer height changes for layer specific settings

### DIFF
--- a/include/widgets/layerbar.h
+++ b/include/widgets/layerbar.h
@@ -249,6 +249,9 @@ class LayerBar : public QWidget {
     //! \brief Move dot to layer specified.
     bool moveDotToLayer(LayerDot* dot, int layer);
 
+    //! \brief Moves an out-of-bounds range endpoint to the new top layer when possible.
+    bool clampRangeToLayerCount(LayerDot* dot, int layer_count);
+
     //! \brief Finds the next available layer and inserts the dot there.
     bool moveDotToNextLayer(LayerDot* dot);
 
@@ -260,6 +263,9 @@ class LayerBar : public QWidget {
 
     //! \brief determines what ranges are selected and emits accordingly
     void changeSelectedSettings();
+
+    //! \brief Removes selected dots that are no longer valid after a layer count update.
+    void removeInvalidSelections();
 
     //! \brief emits if the current part has any layer-specific settings
     void updateLayerSettingsRangeAvailability();

--- a/src/part/part.cpp
+++ b/src/part/part.cpp
@@ -116,7 +116,7 @@ void Part::createSettingsRange(int low, int high, QSharedPointer<SettingsBase> s
 QSharedPointer<SettingsRange> Part::getSettingsRange(int low, int high) {
     int min = qMin(low, high);
     int max = qMax(low, high);
-    return m_ranges[MathUtils::cantorPair(min, max)];
+    return m_ranges.value(MathUtils::cantorPair(min, max));
 }
 
 bool Part::getTemplateApplied() { return m_template_applied; }
@@ -134,10 +134,15 @@ bool Part::currentPartTemplateEqualToSetTemplate(QString set_template) {
 void Part::removeSettingsRange(int low, int high) {
     int min = qMin(low, high);
     int max = qMax(low, high);
-    m_ranges.remove(MathUtils::cantorPair(min, max));
+    const uint key = MathUtils::cantorPair(min, max);
+    m_ranges.remove(key);
+    m_range_from_template.remove(key);
 }
 
-void Part::clearSettingsRanges() { m_ranges.clear(); }
+void Part::clearSettingsRanges() {
+    m_ranges.clear();
+    m_range_from_template.clear();
+}
 
 json Part::SettingsRangesToJson() {
     json output;
@@ -156,6 +161,7 @@ json Part::SettingsRangesToJson() {
 
 void Part::loadRangesFromJson(json input) {
     m_ranges.clear();
+    m_range_from_template.clear();
     for (auto& range_json : input) {
         int low = range_json[Constants::Settings::Session::Range::kLow];
         int high = range_json[Constants::Settings::Session::Range::kHigh];
@@ -186,15 +192,24 @@ void Part::updateSettingsRangeLimits(int old_low, int old_high, int new_low, int
     // get the old one, to use its sb and group name
     int old_min = qMin(old_low, old_high);
     int old_max = qMax(old_low, old_high);
+    const uint old_key = MathUtils::cantorPair(old_min, old_max);
     QSharedPointer<SettingsRange> old = getSettingsRange(old_min, old_max);
+    if (old.isNull())
+        return;
 
     // make a new range at the new location
     int min = qMin(new_low, new_high);
     int max = qMax(new_low, new_high);
-    createSettingsRange(min, max, old->getSb(), old->groupName());
+    if (old_min == min && old_max == max)
+        return;
 
-    // delete the old range
+    const bool was_from_template = m_range_from_template.value(old_key, false);
+    QSharedPointer<SettingsBase> sb = old->getSb();
+    QString group_name = old->groupName();
     removeSettingsRange(old_min, old_max);
+    const uint new_key = MathUtils::cantorPair(min, max);
+    m_ranges[new_key] = QSharedPointer<SettingsRange>::create(min, max, group_name, sb);
+    m_range_from_template[new_key] = was_from_template;
 }
 
 void Part::setRootMesh(QSharedPointer<MeshBase> mesh) { m_root_mesh = mesh; }

--- a/src/widgets/layerbar.cpp
+++ b/src/widgets/layerbar.cpp
@@ -465,6 +465,8 @@ void LayerBar::setLayer() {
 void LayerBar::setPairLayers() {
     LayerDot* first_layer = m_selection.back();
     LayerDot* second_layer = m_selection.front();
+    if (first_layer->getLayer() > second_layer->getLayer())
+        std::swap(first_layer, second_layer);
 
     // Dialog prompt to get user input for range start and end
     QDialog dialog(this);
@@ -508,12 +510,20 @@ void LayerBar::setPairLayers() {
             break;
         }
 
-        if ((this->layerValid(first_val) || m_position[first_val] == first_layer) &&
+        if (first_val < second_val &&
+            !m_part->getSettingsRange(first_layer->getLayer(), second_layer->getLayer()).isNull() &&
+            (this->layerValid(first_val) || m_position[first_val] == first_layer) &&
             (this->layerValid(second_val) || m_position[second_val] == second_layer)) {
             m_part->updateSettingsRangeLimits(first_layer->getLayer(), second_layer->getLayer(), first_val, second_val);
 
-            this->moveDotToLayer(first_layer, first_val);
-            this->moveDotToLayer(second_layer, second_val);
+            if (first_layer->getLayer() != first_val)
+                this->moveDotToLayer(first_layer, first_val);
+
+            if (second_layer->getLayer() != second_val)
+                this->moveDotToLayer(second_layer, second_val);
+
+            updateLayers();
+            removeInvalidSelections();
             break;
         }
 
@@ -1488,6 +1498,10 @@ void LayerBar::updateLayers() {
     if (layer_count < m_position.size()) {
         for (int i = m_position.size() - 1; i >= layer_count; --i) {
             if (m_position[i] != nullptr) {
+                if (clampRangeToLayerCount(m_position[i], layer_count)) {
+                    continue;
+                }
+
                 int layer_num = m_position[i]->getLayer();
                 LayerDot* dot = m_position[i]->getPair();
                 if (dot == nullptr) {
@@ -1591,13 +1605,7 @@ void LayerBar::handleModifiedSetting(QString key) {
         key == PS::Slicing::kSlicingVectorZ) {
         updateLayers();
 
-        for (int i = m_selection.size() - 1; i >= 0; --i) {
-            LayerDot* dot = m_selection[i];
-            if (dot == nullptr || dot->getLayer() < 0 || dot->getLayer() >= m_position.size() ||
-                m_position[dot->getLayer()] != dot) {
-                m_selection.removeAt(i);
-            }
-        }
+        removeInvalidSelections();
 
         changeSelectedSettings();
     }
@@ -1644,6 +1652,40 @@ bool LayerBar::moveDotToLayer(LayerDot* dot, int layer) {
 }
 
 bool LayerBar::moveDotToNextLayer(LayerDot* dot) { return moveDotToNextLayer(dot, getLayerFromPosition(dot->y())); }
+
+void LayerBar::removeInvalidSelections() {
+    for (int i = m_selection.size() - 1; i >= 0; --i) {
+        LayerDot* dot = m_selection[i];
+        if (dot == nullptr || dot->getLayer() < 0 || dot->getLayer() >= m_position.size() ||
+            m_position[dot->getLayer()] != dot) {
+            m_selection.removeAt(i);
+        }
+    }
+}
+
+bool LayerBar::clampRangeToLayerCount(LayerDot* dot, int layer_count) {
+    if (dot == nullptr || dot->getRange() == nullptr || layer_count <= 0)
+        return false;
+
+    LayerDot* pair = dot->getPair();
+    if (pair == nullptr || pair->getLayer() >= layer_count)
+        return false;
+
+    const int last_layer = layer_count - 1;
+    const int old_low = qMin(dot->getLayer(), pair->getLayer());
+    const int old_high = qMax(dot->getLayer(), pair->getLayer());
+    const int new_low = qMin(pair->getLayer(), last_layer);
+    const int new_high = last_layer;
+
+    if (new_low >= new_high || m_position[new_high] != nullptr)
+        return false;
+
+    if (!moveDotToLayer(dot, new_high))
+        return false;
+
+    m_part->updateSettingsRangeLimits(old_low, old_high, new_low, new_high);
+    return true;
+}
 
 bool LayerBar::moveDotToNextLayer(LayerDot* dot, int layer) {
     int check_dist = 0;


### PR DESCRIPTION
## Summary

Fixes layer-specific settings ranges when a layer-height override reduces the total layer count.

- Clamp out-of-bounds range endpoints to the new final valid layer instead of deleting the endpoint and collapsing the range unexpectedly.
- Recalculate the layer count immediately after manually editing a layer range, so changing the start of a larger-height range cannot leave a stale high endpoint selected.
- Make settings range lookup and limit remapping more defensive, and keep template/user range metadata in sync when ranges are removed or remapped.

## Root Cause

Layer-height changes can reduce the number of valid layers. The layer bar previously deleted dots whose layer index no longer existed, which turned a two-ended range into a single-layer range. A follow-up manual range edit could move the override earlier, reducing the total layer count again while leaving stale visual/model state behind.

## Validation

- `git diff --check`
- `nix develop -c cmake --build build/generic-llvm-ninja --target ornlslicer`