### PR TITLE
Optimization Point Improvements

### DIFF
--- a/include/graphics/objects/printer/printer_object.h
+++ b/include/graphics/objects/printer/printer_object.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QMatrix4x4>
+#include <QPointF>
+#include <QString>
 #include <qlist.h>
 #include <qsharedpointer.h>
 #include <qvectornd.h>
@@ -20,6 +23,15 @@ class SeamObject;
  */
 class PrinterObject : public GraphicsObject {
   public:
+    //! \brief Pick result for draggable optimization point graphics.
+    struct OptimizationPointPick {
+        QSharedPointer<SeamObject> object;
+        QString x_setting;
+        QString y_setting;
+
+        bool isValid() const { return !object.isNull(); }
+    };
+
     //! \brief Update this printer using new settings.
     //! \param sb: Settings to use.
     void updateFromSettings(QSharedPointer<SettingsBase> sb);
@@ -33,6 +45,24 @@ class PrinterObject : public GraphicsObject {
 
     //! \brief Shows or hides seams.
     void setSeamsHidden(bool hide);
+
+    //! \brief Picks an optimization point graphic under the cursor.
+    //! \param projection: View projection matrix.
+    //! \param view: View matrix.
+    //! \param mouse_ndc_pos: Mouse position in normalized device coordinates.
+    //! \param ortho: If the view uses orthographic projection.
+    OptimizationPointPick pickOptimizationPoint(const QMatrix4x4& projection, const QMatrix4x4& view,
+                                                QPointF mouse_ndc_pos, bool ortho = false);
+
+    //! \brief Intersects the cursor ray with this printer's bed plane.
+    //! \param projection: View projection matrix.
+    //! \param view: View matrix.
+    //! \param mouse_ndc_pos: Mouse position in normalized device coordinates.
+    //! \param intersection: Output bed-plane intersection in view coordinates.
+    //! \param ortho: If the view uses orthographic projection.
+    //! \return If an intersection was found.
+    bool bedIntersection(const QMatrix4x4& projection, const QMatrix4x4& view, QPointF mouse_ndc_pos,
+                         QVector3D& intersection, bool ortho = false);
 
     //! \brief gets the default zoom level for the printer
     //! \return the default zoom in OpenGL space

--- a/include/graphics/view/gcode_view.h
+++ b/include/graphics/view/gcode_view.h
@@ -22,6 +22,7 @@
 namespace ORNL {
 // Forward
 class PrinterObject;
+class SeamObject;
 
 /*!
  * \brief View that displays generated GCode and provides interactivity with it.
@@ -76,6 +77,13 @@ class GCodeView : public BaseView {
     //! \param sb: New settings object.
     void updatePrinterSettings(QSharedPointer<SettingsBase> sb);
 
+    //! \brief Shows or hides optimization point graphics.
+    void showSeams(bool show);
+
+    //! \brief Updates optimization point graphics based on changes to the settings.
+    //! \param sb: New settings object.
+    void updateOptimizationSettings(QSharedPointer<SettingsBase> sb);
+
     //! \brief Sets the lowest layer to show.
     void setLowLayer(uint low_layer);
     //! \brief Sets the highest layer to show.
@@ -107,6 +115,15 @@ class GCodeView : public BaseView {
     virtual void resetCamera() override;
 
   signals:
+    //! \brief Notification that a draggable optimization point setting edit has started.
+    void optimizationPointDragStarted(QString x_setting, QString y_setting);
+
+    //! \brief Notification that a draggable optimization point setting edit has changed.
+    void optimizationPointDragged(QString x_setting, double x, QString y_setting, double y);
+
+    //! \brief Notification that a draggable optimization point setting edit has finished.
+    void optimizationPointDragFinished(QString x_setting, double x, QString y_setting, double y);
+
     //! \brief Signal that the passed lines were selected/deselected
     //! \param linesToAdd: lines to select
     //! \param lineToRemove: lines to deselect
@@ -137,6 +154,12 @@ class GCodeView : public BaseView {
     //! \brief Handles the following: Segment deselection
     void handleLeftClick(QPointF mouse_ndc_pos) override;
 
+    //! \brief Handles the following: Optimization point drag
+    void handleLeftMove(QPointF mouse_ndc_pos) override;
+
+    //! \brief Handles the following: Optimization point drag finalization
+    void handleLeftRelease(QPointF mouse_ndc_pos) override;
+
     //! \brief Handles the following: Segment selection
     void handleLeftDoubleClick(QPointF mouse_ndc_pos) override;
 
@@ -165,6 +188,15 @@ class GCodeView : public BaseView {
 
     //! \brief Refreshes camera-dependent segment info display.
     void updateSegmentInfoViewMatrix();
+
+    //! \brief Begins dragging an optimization point if the cursor is over one.
+    bool beginOptimizationPointDrag(QPointF mouse_ndc_pos);
+
+    //! \brief Updates an active optimization point drag.
+    bool updateOptimizationPointDrag(QPointF mouse_ndc_pos, bool finish);
+
+    //! \brief Finishes an active optimization point drag.
+    void finishOptimizationPointDrag(QPointF mouse_ndc_pos);
 
     //! \brief Settings for the view.
     QSharedPointer<SettingsBase> m_sb;
@@ -200,6 +232,24 @@ class GCodeView : public BaseView {
 
         //! \brief If ghosted models are currently being displayed
         bool showing_ghosts = false;
+
+        //! \brief If optimization point graphics are shown.
+        bool seams_shown = false;
+
+        //! \brief If an optimization point is being dragged.
+        bool dragging_seam = false;
+
+        //! \brief Optimization point currently being dragged.
+        QSharedPointer<SeamObject> dragged_seam;
+
+        //! \brief X setting controlled by the dragged optimization point.
+        QString dragged_seam_x_setting;
+
+        //! \brief Y setting controlled by the dragged optimization point.
+        QString dragged_seam_y_setting;
+
+        //! \brief Cursor-to-point offset retained during optimization point drag.
+        QVector3D dragged_seam_offset;
 
         //! \brief Hidden segment types.
         SegmentDisplayType hidden_type = SegmentDisplayType::kNone;

--- a/include/graphics/view/part_view.h
+++ b/include/graphics/view/part_view.h
@@ -24,6 +24,7 @@ class PrinterObject;
 class PlaneObject;
 class GridObject;
 class SphereObject;
+class SeamObject;
 class PartMetaModel;
 class PartMetaItem;
 class RightClickMenu;
@@ -114,6 +115,15 @@ class PartView : public BaseView {
     //! \brief Notification of parts that are outside and/or not aligned. Emitted after translations.
     void positioningIssues(QList<QSharedPointer<Part>> opl, QList<QSharedPointer<Part>> fpl);
 
+    //! \brief Notification that a draggable optimization point setting edit has started.
+    void optimizationPointDragStarted(QString x_setting, QString y_setting);
+
+    //! \brief Notification that a draggable optimization point setting edit has changed.
+    void optimizationPointDragged(QString x_setting, double x, QString y_setting, double y);
+
+    //! \brief Notification that a draggable optimization point setting edit has finished.
+    void optimizationPointDragFinished(QString x_setting, double x, QString y_setting, double y);
+
   protected:
     //! \brief Initalizes the view with the printer and the associated objects.
     void initView() override;
@@ -165,6 +175,15 @@ class PartView : public BaseView {
     //! \brief shifts a graphics part to not intersect with other parts
     //! \param gop the graphics part object
     void shiftPart(QSharedPointer<PartObject> gop);
+
+    //! \brief Begins dragging an optimization point if the cursor is over one.
+    bool beginOptimizationPointDrag(QPointF mouse_ndc_pos);
+
+    //! \brief Updates an active optimization point drag.
+    bool updateOptimizationPointDrag(QPointF mouse_ndc_pos, bool finish);
+
+    //! \brief Finishes an active optimization point drag.
+    void finishOptimizationPointDrag(QPointF mouse_ndc_pos);
 
   private slots:
     //! \brief Recieves updates from model about selections.
@@ -234,6 +253,21 @@ class PartView : public BaseView {
 
         //! \brief If opt points are shown.
         bool seams_shown = false;
+
+        //! \brief If an optimization point is being dragged.
+        bool dragging_seam = false;
+
+        //! \brief Optimization point currently being dragged.
+        QSharedPointer<SeamObject> dragged_seam;
+
+        //! \brief X setting controlled by the dragged optimization point.
+        QString dragged_seam_x_setting;
+
+        //! \brief Y setting controlled by the dragged optimization point.
+        QString dragged_seam_y_setting;
+
+        //! \brief Cursor-to-point offset retained during optimization point drag.
+        QVector3D dragged_seam_offset;
 
         //! \brief If slicing planes are shown.
         bool planes_shown = false;

--- a/include/widgets/gcode_widget.h
+++ b/include/widgets/gcode_widget.h
@@ -53,6 +53,10 @@ class GCodeWidget : public QWidget {
     //! \param status show/ hide ghost
     void showGhosts(bool status);
 
+    //! \brief enables/ disables showing optimization points
+    //! \param show enables/ disables
+    void showSeams(bool show);
+
     //! \brief sets the style of the widget according to current theme
     void setupStyle();
 

--- a/include/widgets/part_widget/part_widget.h
+++ b/include/widgets/part_widget/part_widget.h
@@ -46,6 +46,9 @@ class PartWidget : public QWidget {
     //! \return string of name
     QString getFirstPartName();
 
+    //! \brief Get the view for this widget.
+    PartView* view();
+
   signals:
     //! \brief Signal of parts that have been selected.
     void selected(QSet<QSharedPointer<Part>> pl, QSharedPointer<Part> mp);

--- a/include/widgets/settings/setting_bar.h
+++ b/include/widgets/settings/setting_bar.h
@@ -143,6 +143,16 @@ class SettingBar : public QWidget {
     //! \brief Reloads a restored setting row and forwards normal modified-setting notifications.
     void restoreSettingValue(QString setting_key);
 
+    //! \brief Starts a paired global setting edit driven by a view interaction.
+    void beginPairedGlobalSettingChange(QString first_key, QString second_key);
+
+    //! \brief Updates paired global setting values without committing a modified-setting notification.
+    void updatePairedGlobalSetting(QString first_key, double first_value, QString second_key, double second_value);
+
+    //! \brief Finishes a paired global setting edit and emits normal modified-setting notifications.
+    void finishPairedGlobalSettingChange(QString first_key, double first_value, QString second_key,
+                                         double second_value);
+
   private slots:
     /*!
      * \brief Re-emits a signal that a setting is about to be modified.

--- a/src/graphics/objects/printer/printer_object.cpp
+++ b/src/graphics/objects/printer/printer_object.cpp
@@ -2,12 +2,19 @@
 
 #include <math.h>
 
+#include <limits>
+#include <tuple>
+
+#include <QMatrix4x4>
+#include <QPointF>
+#include <QVector>
 #include <qmath.h>
 #include <qsharedpointer.h>
 #include <qvectornd.h>
 
 #include "configs/settings_base.h"
 #include "graphics/objects/sphere/seam_object.h"
+#include "graphics/support/part_picker.h"
 #include "managers/preferences_manager.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
@@ -25,6 +32,56 @@ void PrinterObject::setSeamsHidden(bool hide) {
     m_seams_shown = !hide;
 
     this->updateSeams();
+}
+
+PrinterObject::OptimizationPointPick PrinterObject::pickOptimizationPoint(const QMatrix4x4& projection,
+                                                                          const QMatrix4x4& view, QPointF mouse_ndc_pos,
+                                                                          bool ortho) {
+    QVector<OptimizationPointPick> candidates;
+    candidates.push_back({m_seams.custom_island_opt, PS::Optimizations::kCustomIslandXLocation,
+                          PS::Optimizations::kCustomIslandYLocation});
+    candidates.push_back({m_seams.custom_path_opt, PS::Optimizations::kCustomPathXLocation,
+                          PS::Optimizations::kCustomPathYLocation});
+    candidates.push_back({m_seams.custom_point_opt, PS::Optimizations::kCustomPointXLocation,
+                          PS::Optimizations::kCustomPointYLocation});
+    candidates.push_back({m_seams.custom_point_second_opt, PS::Optimizations::kCustomPointSecondXLocation,
+                          PS::Optimizations::kCustomPointSecondYLocation});
+
+    float nearest = std::numeric_limits<float>::infinity();
+    OptimizationPointPick picked;
+    for (const OptimizationPointPick& candidate : candidates) {
+        if (!candidate.isValid() || candidate.object->hidden()) {
+            continue;
+        }
+
+        const float distance =
+            PartPicker::pickDistance(projection, view, mouse_ndc_pos, candidate.object->triangles(), ortho);
+        if (distance < nearest) {
+            nearest = distance;
+            picked = candidate;
+        }
+    }
+
+    return picked;
+}
+
+bool PrinterObject::bedIntersection(const QMatrix4x4& projection, const QMatrix4x4& view, QPointF mouse_ndc_pos,
+                                    QVector3D& intersection, bool ortho) {
+    QVector3D start;
+    QVector3D direction;
+    std::tie(start, direction) = PartPicker::getDirectionAndStart(projection, mouse_ndc_pos, view, ortho);
+
+    if (qFuzzyIsNull(direction.z())) {
+        return false;
+    }
+
+    const float distance = (this->printerCenter().z() - start.z()) / direction.z();
+    if (distance < 0.0f) {
+        return false;
+    }
+
+    intersection = start + (distance * direction);
+    return true;
 }
 
 float PrinterObject::getDefaultZoom() {
@@ -56,13 +113,14 @@ void PrinterObject::updateSeams() {
     PointOrderOptimization pointOrder =
         static_cast<PointOrderOptimization>(m_sb->setting<int>(PS::Optimizations::kPointOrder));
     bool secondPointEnabled = m_sb->setting<bool>(PS::Optimizations::kEnableSecondCustomLocation);
+    float bed_z = this->printerCenter().z() * Constants::OpenGL::kViewToObject;
 
     if (islandOrder == IslandOrderOptimization::kCustomPoint) {
         QVector3D translation(m_sb->setting<double>(PS::Optimizations::kCustomIslandXLocation),
 
                               m_sb->setting<double>(PS::Optimizations::kCustomIslandYLocation),
 
-                              .0f);
+                              bed_z);
 
         translation *= Constants::OpenGL::kObjectToView;
 
@@ -78,7 +136,7 @@ void PrinterObject::updateSeams() {
 
                               m_sb->setting<double>(PS::Optimizations::kCustomPathYLocation),
 
-                              .0f);
+                              bed_z);
 
         translation *= Constants::OpenGL::kObjectToView;
 
@@ -94,7 +152,7 @@ void PrinterObject::updateSeams() {
 
                               m_sb->setting<double>(PS::Optimizations::kCustomPointYLocation),
 
-                              .0f);
+                              bed_z);
 
         translation *= Constants::OpenGL::kObjectToView;
 
@@ -106,7 +164,7 @@ void PrinterObject::updateSeams() {
 
                                         m_sb->setting<double>(PS::Optimizations::kCustomPointSecondYLocation),
 
-                                        .0f);
+                                        bed_z);
 
             secondTranslation *= Constants::OpenGL::kObjectToView;
 
@@ -119,6 +177,7 @@ void PrinterObject::updateSeams() {
     }
     else {
         m_seams.custom_point_opt->hide();
+        m_seams.custom_point_second_opt->hide();
     }
 }
 

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -5,6 +5,7 @@
 #include <tuple>
 
 #include <qcontainerfwd.h>
+#include <qcursor.h>
 #include <qlist.h>
 #include <qmatrix4x4.h>
 #include <qpoint.h>
@@ -21,6 +22,7 @@
 #include "graphics/objects/part_object.h"
 #include "graphics/objects/printer/cartesian_printer_object.h"
 #include "graphics/objects/printer/cylindrical_printer_object.h"
+#include "graphics/objects/sphere/seam_object.h"
 #include "graphics/support/part_picker.h"
 #include "managers/preferences_manager.h"
 #include "utilities/constants.h"
@@ -196,6 +198,81 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     updateSegmentInfoViewMatrix();
 }
 
+bool GCodeView::beginOptimizationPointDrag(QPointF mouse_ndc_pos) {
+    auto picked =
+        m_printer->pickOptimizationPoint(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, m_state.ortho);
+    if (!picked.isValid()) {
+        return false;
+    }
+
+    QVector3D bed_intersection;
+    if (!m_printer->bedIntersection(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, bed_intersection,
+                                    m_state.ortho)) {
+        return false;
+    }
+
+    m_state.dragging_seam = true;
+    m_state.dragged_seam = picked.object;
+    m_state.dragged_seam_x_setting = picked.x_setting;
+    m_state.dragged_seam_y_setting = picked.y_setting;
+    m_state.dragged_seam_offset = picked.object->translation() - bed_intersection;
+
+    emit optimizationPointDragStarted(picked.x_setting, picked.y_setting);
+
+    this->setCursor(QCursor(Qt::ClosedHandCursor));
+    return true;
+}
+
+bool GCodeView::updateOptimizationPointDrag(QPointF mouse_ndc_pos, bool finish) {
+    if (!m_state.dragging_seam || m_state.dragged_seam.isNull()) {
+        return false;
+    }
+
+    QVector3D bed_intersection;
+    if (!m_printer->bedIntersection(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, bed_intersection,
+                                    m_state.ortho)) {
+        return false;
+    }
+
+    QVector3D translation = bed_intersection + m_state.dragged_seam_offset;
+    translation.setZ(m_printer->printerCenter().z());
+    m_state.dragged_seam->translateAbsolute(translation);
+
+    const double x = translation.x() * Constants::OpenGL::kViewToObject;
+    const double y = translation.y() * Constants::OpenGL::kViewToObject;
+    if (finish) {
+        emit optimizationPointDragFinished(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y);
+    }
+    else {
+        emit optimizationPointDragged(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y);
+    }
+
+    this->update();
+    return true;
+}
+
+void GCodeView::finishOptimizationPointDrag(QPointF mouse_ndc_pos) {
+    if (!m_state.dragging_seam) {
+        return;
+    }
+
+    if (!updateOptimizationPointDrag(mouse_ndc_pos, true) && !m_state.dragged_seam.isNull()) {
+        const QVector3D translation = m_state.dragged_seam->translation();
+        emit optimizationPointDragFinished(m_state.dragged_seam_x_setting,
+                                           translation.x() * Constants::OpenGL::kViewToObject,
+                                           m_state.dragged_seam_y_setting,
+                                           translation.y() * Constants::OpenGL::kViewToObject);
+    }
+
+    m_state.dragging_seam = false;
+    m_state.dragged_seam.reset();
+    m_state.dragged_seam_x_setting.clear();
+    m_state.dragged_seam_y_setting.clear();
+    m_state.dragged_seam_offset = QVector3D();
+    this->setCursor(QCursor(Qt::ArrowCursor));
+    this->update();
+}
+
 void GCodeView::hideSegmentType(SegmentDisplayType type, bool hidden) {
     m_state.hidden_type = (hidden) ? (m_state.hidden_type | type) : (m_state.hidden_type & ~type);
 
@@ -258,6 +335,10 @@ void GCodeView::initView() {
 }
 
 void GCodeView::handleLeftClick(QPointF mouse_ndc_pos) {
+    if (beginOptimizationPointDrag(mouse_ndc_pos)) {
+        return;
+    }
+
     if (m_gcode_object.isNull())
         return;
 
@@ -278,11 +359,37 @@ void GCodeView::handleLeftClick(QPointF mouse_ndc_pos) {
     this->update();
 }
 
+void GCodeView::handleLeftMove(QPointF mouse_ndc_pos) {
+    if (m_state.dragging_seam) {
+        updateOptimizationPointDrag(mouse_ndc_pos, false);
+    }
+}
+
+void GCodeView::handleLeftRelease(QPointF mouse_ndc_pos) {
+    if (m_state.dragging_seam) {
+        finishOptimizationPointDrag(mouse_ndc_pos);
+    }
+}
+
 void GCodeView::handleLeftDoubleClick(QPointF mouse_ndc_pos) {
     // NOP
 }
 
 void GCodeView::handleMouseMove(QPointF mouse_ndc_pos) {
+    auto picked_seam =
+        m_printer->pickOptimizationPoint(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, m_state.ortho);
+    if (picked_seam.isValid()) {
+        if (!m_gcode_object.isNull()) {
+            m_gcode_object->highlightSegment(0);
+        }
+
+        this->setCursor(QCursor(Qt::OpenHandCursor));
+        this->update();
+        return;
+    }
+
+    this->setCursor(QCursor(Qt::ArrowCursor));
+
     if (m_gcode_object.isNull())
         return;
 
@@ -452,6 +559,8 @@ void GCodeView::updatePrinterSettings(QSharedPointer<SettingsBase> sb) {
         this->removeObject(m_printer);
         this->addObject(new_printer);
 
+        new_printer->setSeamsHidden(!m_state.seams_shown);
+
         m_printer = new_printer;
     }
     else {
@@ -460,6 +569,22 @@ void GCodeView::updatePrinterSettings(QSharedPointer<SettingsBase> sb) {
 
     m_camera->setDefaultZoom(m_printer->getDefaultZoom());
     this->resetCamera();
+}
+
+void GCodeView::showSeams(bool show) {
+    m_printer->setSeamsHidden(!show);
+
+    m_state.seams_shown = show;
+
+    this->update();
+}
+
+void GCodeView::updateOptimizationSettings(QSharedPointer<SettingsBase> sb) {
+    m_sb = sb;
+
+    m_printer->updateFromSettings(m_sb);
+
+    this->update();
 }
 
 void GCodeView::setLowLayer(uint low_layer) {

--- a/src/graphics/view/part_view.cpp
+++ b/src/graphics/view/part_view.cpp
@@ -34,6 +34,7 @@
 #include "graphics/objects/printer/cartesian_printer_object.h"
 #include "graphics/objects/printer/cylindrical_printer_object.h"
 #include "graphics/objects/printer/printer_object.h"
+#include "graphics/objects/sphere/seam_object.h"
 #include "graphics/objects/text_object.h"
 #include "graphics/support/part_picker.h"
 #include "managers/preferences_manager.h"
@@ -200,6 +201,78 @@ restart_check:
             goto restart_check;
         }
     }
+}
+
+bool PartView::beginOptimizationPointDrag(QPointF mouse_ndc_pos) {
+    auto picked = m_printer->pickOptimizationPoint(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos);
+    if (!picked.isValid()) {
+        return false;
+    }
+
+    QVector3D bed_intersection;
+    if (!m_printer->bedIntersection(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, bed_intersection)) {
+        return false;
+    }
+
+    m_state.dragging_seam = true;
+    m_state.dragged_seam = picked.object;
+    m_state.dragged_seam_x_setting = picked.x_setting;
+    m_state.dragged_seam_y_setting = picked.y_setting;
+    m_state.dragged_seam_offset = picked.object->translation() - bed_intersection;
+
+    emit optimizationPointDragStarted(picked.x_setting, picked.y_setting);
+
+    this->setCursor(QCursor(Qt::ClosedHandCursor));
+    return true;
+}
+
+bool PartView::updateOptimizationPointDrag(QPointF mouse_ndc_pos, bool finish) {
+    if (!m_state.dragging_seam || m_state.dragged_seam.isNull()) {
+        return false;
+    }
+
+    QVector3D bed_intersection;
+    if (!m_printer->bedIntersection(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, bed_intersection)) {
+        return false;
+    }
+
+    QVector3D translation = bed_intersection + m_state.dragged_seam_offset;
+    translation.setZ(m_printer->printerCenter().z());
+    m_state.dragged_seam->translateAbsolute(translation);
+
+    const double x = translation.x() * Constants::OpenGL::kViewToObject;
+    const double y = translation.y() * Constants::OpenGL::kViewToObject;
+    if (finish) {
+        emit optimizationPointDragFinished(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y);
+    }
+    else {
+        emit optimizationPointDragged(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y);
+    }
+
+    this->update();
+    return true;
+}
+
+void PartView::finishOptimizationPointDrag(QPointF mouse_ndc_pos) {
+    if (!m_state.dragging_seam) {
+        return;
+    }
+
+    if (!updateOptimizationPointDrag(mouse_ndc_pos, true) && !m_state.dragged_seam.isNull()) {
+        const QVector3D translation = m_state.dragged_seam->translation();
+        emit optimizationPointDragFinished(m_state.dragged_seam_x_setting,
+                                           translation.x() * Constants::OpenGL::kViewToObject,
+                                           m_state.dragged_seam_y_setting,
+                                           translation.y() * Constants::OpenGL::kViewToObject);
+    }
+
+    m_state.dragging_seam = false;
+    m_state.dragged_seam.reset();
+    m_state.dragged_seam_x_setting.clear();
+    m_state.dragged_seam_y_setting.clear();
+    m_state.dragged_seam_offset = QVector3D();
+    this->setCursor(QCursor(Qt::ArrowCursor));
+    this->update();
 }
 
 void PartView::centerSelectedParts() {
@@ -422,6 +495,10 @@ void PartView::initView() {
 }
 
 void PartView::handleLeftClick(QPointF mouse_ndc_pos) {
+    if (beginOptimizationPointDrag(mouse_ndc_pos)) {
+        return;
+    }
+
     auto picked_part = this->pickPart(mouse_ndc_pos, m_part_objects);
     if (!picked_part.isNull()) {
         // If currently in an alignment state, try to align.
@@ -504,6 +581,11 @@ void PartView::handleLeftDoubleClick(QPointF mouse_ndc_pos) {
 }
 
 void PartView::handleLeftRelease(QPointF mouse_ndc_pos) {
+    if (m_state.dragging_seam) {
+        finishOptimizationPointDrag(mouse_ndc_pos);
+        return;
+    }
+
     m_low_plane->hide();
     m_state.translate_start = QVector3D(0, 0, 0);
     m_state.part_trans_start.clear();
@@ -524,6 +606,11 @@ void PartView::handleLeftRelease(QPointF mouse_ndc_pos) {
 }
 
 void PartView::handleLeftMove(QPointF mouse_ndc_pos) {
+    if (m_state.dragging_seam) {
+        updateOptimizationPointDrag(mouse_ndc_pos, false);
+        return;
+    }
+
     if (m_selected_objects.empty())
         return;
     if (!m_state.translating)
@@ -718,6 +805,18 @@ void PartView::handleRightRelease(QPointF mouse_ndc_pos, QPointF global_pos) {
 }
 
 void PartView::handleMouseMove(QPointF mouse_ndc_pos) {
+    auto picked_seam = m_printer->pickOptimizationPoint(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos);
+    if (picked_seam.isValid()) {
+        if (!m_state.highlighted_part.isNull()) {
+            m_state.highlighted_part->unhighlight();
+            m_state.highlighted_part.reset();
+            this->update();
+        }
+
+        this->setCursor(QCursor(Qt::OpenHandCursor));
+        return;
+    }
+
     auto picked_part = this->pickPart(mouse_ndc_pos, m_part_objects);
 
     QCursor c = QCursor(Qt::ArrowCursor);

--- a/src/widgets/gcode_widget.cpp
+++ b/src/widgets/gcode_widget.cpp
@@ -43,6 +43,8 @@ void GCodeWidget::showSegmentInfo(bool show) { m_segment_info_control->setVisibl
 
 void GCodeWidget::showGhosts(bool status) { m_gcode_view->showGhosts(status); }
 
+void GCodeWidget::showSeams(bool show) { m_gcode_view->showSeams(show); }
+
 void GCodeWidget::handleModifiedSetting(QString key) {
     static const auto printer_settings = QSet<QString> {PRS::Dimensions::kXMin,
                                                         PRS::Dimensions::kXMax,
@@ -64,8 +66,26 @@ void GCodeWidget::handleModifiedSetting(QString key) {
                                                         PRS::Dimensions::kGridYDistance,
                                                         PRS::Dimensions::kGridYOffset};
 
+    static const auto optimization_settings = QSet<QString> {PS::Optimizations::kIslandOrder,
+                                                             PS::Optimizations::kCustomIslandXLocation,
+                                                             PS::Optimizations::kCustomIslandYLocation,
+                                                             PS::Optimizations::kPathOrder,
+                                                             PS::Optimizations::kCustomPathXLocation,
+                                                             PS::Optimizations::kCustomPathYLocation,
+                                                             PS::Optimizations::kPointOrder,
+                                                             PS::Optimizations::kCustomPointXLocation,
+                                                             PS::Optimizations::kCustomPointYLocation,
+                                                             PS::Optimizations::kEnableSecondCustomLocation,
+                                                             PS::Optimizations::kCustomPointSecondXLocation,
+                                                             PS::Optimizations::kCustomPointSecondYLocation,
+                                                             PRS::Dimensions::kXOffset,
+                                                             PRS::Dimensions::kYOffset};
+
     if (printer_settings.contains(key)) {
         m_gcode_view->updatePrinterSettings(GSM->getGlobal());
+    }
+    else if (optimization_settings.contains(key)) {
+        m_gcode_view->updateOptimizationSettings(GSM->getGlobal());
     }
 }
 

--- a/src/widgets/main_toolbar.cpp
+++ b/src/widgets/main_toolbar.cpp
@@ -524,11 +524,10 @@ void MainToolbar::handleModifiedSetting(const QString& setting_key) {
         static_cast<PathOrderOptimization>(GSM->getGlobal()->setting<int>(PS::Optimizations::kPathOrder));
     PointOrderOptimization pointOrder =
         static_cast<PointOrderOptimization>(GSM->getGlobal()->setting<int>(PS::Optimizations::kPointOrder));
-    bool secondPointEnabled = GSM->getGlobal()->setting<bool>(PS::Optimizations::kEnableSecondCustomLocation);
 
     // Disable button.
     if (islandOrder != IslandOrderOptimization::kCustomPoint && pathOrder != PathOrderOptimization::kCustomPoint &&
-        !usesCustomPointLocation(pointOrder) && !secondPointEnabled) {
+        !usesCustomPointLocation(pointOrder)) {
         m_seam_btn->setDisabled(true);
         m_seam_btn->setToolTip("Custom optimization points are not set");
         m_seam_btn->setChecked(false);

--- a/src/widgets/part_widget/part_widget.cpp
+++ b/src/widgets/part_widget/part_widget.cpp
@@ -60,6 +60,11 @@ QSharedPointer<PartMetaModel> PartWidget::getPartMeta() { return m_model; }
 
 QString PartWidget::getFirstPartName() { return m_part_control->nameOfFirstPart(); }
 
+PartView* PartWidget::view() {
+    m_view_controls->raise();
+    return m_part_view;
+}
+
 void PartWidget::takeScreenshot() {
     QString filepath;
     QImage screenshot;
@@ -151,6 +156,7 @@ void PartWidget::handleModifiedSetting(const QString& setting_key) {
                                                              PS::Optimizations::kPathOrder,
                                                              PS::Optimizations::kCustomPathXLocation,
                                                              PS::Optimizations::kCustomPathYLocation,
+                                                             PS::Optimizations::kPointOrder,
                                                              PS::Optimizations::kCustomPointXLocation,
                                                              PS::Optimizations::kCustomPointYLocation,
                                                              PS::Optimizations::kEnableSecondCustomLocation,

--- a/src/widgets/settings/setting_bar.cpp
+++ b/src/widgets/settings/setting_bar.cpp
@@ -400,6 +400,32 @@ void SettingBar::restoreSettingValue(QString setting_key) {
     emit settingModified(setting_key);
 }
 
+void SettingBar::beginPairedGlobalSettingChange(QString first_key, QString second_key) {
+    emit settingAboutToChange(first_key, QList<QSharedPointer<SettingsBase>>());
+    emit settingAboutToChange(second_key, QList<QSharedPointer<SettingsBase>>());
+}
+
+void SettingBar::updatePairedGlobalSetting(QString first_key, double first_value, QString second_key,
+                                           double second_value) {
+    QSharedPointer<SettingsBase> sb = GSM->getGlobal();
+    sb->setSetting(first_key, first_value);
+    sb->setSetting(second_key, second_value);
+
+    m_restoring_settings = true;
+    reloadSettingRow(first_key);
+    reloadSettingRow(second_key);
+    m_restoring_settings = false;
+}
+
+void SettingBar::finishPairedGlobalSettingChange(QString first_key, double first_value, QString second_key,
+                                                 double second_value) {
+    updatePairedGlobalSetting(first_key, first_value, second_key, second_value);
+    enableDependRows();
+
+    emit settingModified(first_key);
+    emit settingModified(second_key);
+}
+
 void SettingBar::forwardHideTab(QString pane, QString category) { emit tabHidden(pane, category); }
 
 void SettingBar::showHiddenSetting(QString panel, QString category) {

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -1009,6 +1009,18 @@ void MainWindow::setupEvents() {
     connect(m_settingbar, &SettingBar::settingModified, m_layerbar, &LayerBar::handleModifiedSetting);
     connect(m_settingbar, &SettingBar::settingModified, m_main_toolbar, &MainToolbar::handleModifiedSetting);
     connect(m_settingbar, &SettingBar::settingModified, this, &MainWindow::handleModifiedSetting);
+    connect(m_part_widget->view(), &PartView::optimizationPointDragStarted, m_settingbar,
+            &SettingBar::beginPairedGlobalSettingChange);
+    connect(m_part_widget->view(), &PartView::optimizationPointDragged, m_settingbar,
+            &SettingBar::updatePairedGlobalSetting);
+    connect(m_part_widget->view(), &PartView::optimizationPointDragFinished, m_settingbar,
+            &SettingBar::finishPairedGlobalSettingChange);
+    connect(m_gcode_widget->view(), &GCodeView::optimizationPointDragStarted, m_settingbar,
+            &SettingBar::beginPairedGlobalSettingChange);
+    connect(m_gcode_widget->view(), &GCodeView::optimizationPointDragged, m_settingbar,
+            &SettingBar::updatePairedGlobalSetting);
+    connect(m_gcode_widget->view(), &GCodeView::optimizationPointDragFinished, m_settingbar,
+            &SettingBar::finishPairedGlobalSettingChange);
     connect(m_settingbar, &SettingBar::settingsBaseChanged, this,
             [this](QString) { this->markProjectModified(); });
     connect(m_settingbar, &SettingBar::tabHidden, this, &MainWindow::addHiddenSetting);
@@ -1031,6 +1043,7 @@ void MainWindow::setupEvents() {
     connect(m_main_toolbar, &MainToolbar::showSegmentInfo, m_gcode_widget, &GCodeWidget::showSegmentInfo);
     connect(m_main_toolbar, &MainToolbar::setOrthoGcode, m_gcode_widget, &GCodeWidget::setOrthoView);
     connect(m_main_toolbar, &MainToolbar::showGhosts, m_gcode_widget, &GCodeWidget::showGhosts);
+    connect(m_main_toolbar, &MainToolbar::showSeams, m_gcode_widget, &GCodeWidget::showSeams);
     connect(m_main_toolbar, &MainToolbar::exportGCode, m_export_window, [this] {
         m_export_window->raise();
         m_export_window->showNormal();


### PR DESCRIPTION
## Summary

- Show custom optimization point markers in the G-code toolpath view using the existing toolbar toggle.
- Place optimization point markers on the printer bed in both part and G-code coordinate modes.
- Allow visible optimization point markers to be clicked and dragged in either view, updating the associated X/Y settings as they move.
- Refresh optimization marker visibility and position when relevant optimization settings change.

## Impact

Users can inspect and adjust custom island, path, and point optimization locations directly from the 3D views instead of manually editing coordinate settings. The same toolbar button now controls marker visibility consistently across Part View and G-Code View.

## Validation

- `nix develop --command cmake --build build/generic-llvm-ninja`