### PR TITLE
Fix input box arrows for default appearance

### DIFF
--- a/src/widgets/part_widget/part_toolbar.cpp
+++ b/src/widgets/part_widget/part_toolbar.cpp
@@ -203,10 +203,14 @@ void PartToolbar::setupStyle() {
 
     auto partToolbarStyle = style->readAll();
     this->setStyleSheet(partToolbarStyle);
-    m_translation_controls->setStyleSheet(partToolbarStyle);
-    m_rotation_controls->setStyleSheet(partToolbarStyle);
-    m_scale_controls->setStyleSheet(partToolbarStyle);
-    m_align_controls->setStyleSheet(partToolbarStyle);
+
+    // The input panels have their own stylesheet. Replacing it with the part
+    // toolbar stylesheet removes input-specific rules such as the spin-box
+    // arrow images in the system-default theme.
+    m_translation_controls->setupStyle();
+    m_rotation_controls->setupStyle();
+    m_scale_controls->setupStyle();
+    m_align_controls->setupStyle();
 
     style->close();
 }


### PR DESCRIPTION
## Summary

- Reload each object-manipulation input panel's dedicated theme stylesheet when the part toolbar style is refreshed.
- Preserve the spin-box up/down arrow rules in the system-default appearance.
- Apply the same correct refresh path to translation, rotation, scale, and alignment panels.

## Root cause

`PartToolbar::setupStyle()` replaced each input panel's `tool_bar_input.qss` with `part_toolbar.qss`. The replacement removed the default theme's spin-box arrow image rules. Dark mode appeared unaffected because its global stylesheet also defines `QAbstractSpinBox` arrows.

## Impact

The object-manipulation input boxes once again display their up and down arrows in the system-default appearance, including after theme refreshes.

## Validation

- `git diff --check`
- `nix develop --command cmake --build build/generic-llvm-ninja --parallel 2 --target ornlslicer` (compiled and linked successfully)