### PR TITLE
Fix angled slicing Z calcluations

### DIFF
--- a/include/step/layer/layer.h
+++ b/include/step/layer/layer.h
@@ -87,9 +87,24 @@ class Layer : public Step {
     QList<QSharedPointer<IslandBase>> m_island_order;
 
   private:
+    //! \brief Builds the translation used to move paths between the flattened slicing frame and printer coordinates.
+    Point getOrientationShift() const;
+
+    //! \brief Moves restored paths above the minimum printable Z height for the slicing plane.
+    void applyMinimumZShift();
+
+    //! \brief Removes the minimum printable Z shift before flattening paths again.
+    void removeMinimumZShift();
+
+    //! \brief Returns the minimum Z coordinate among material-depositing segments.
+    float getMinimumPrintZ();
+
     //! \brief Creates tree-like structure if brims exist, otherwise, sorts islands into precendence order
     QList<QHash<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>>
     createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSharedPointer<IslandBase>>> children);
+
+    //! \brief Vertical shift applied to keep printing paths above the build surface.
+    Distance m_minimum_z_shift;
 
     //! \brief a collection of polygons on this layer that contain setting overrides
     QVector<SettingsPolygon> m_settings_polygons;

--- a/src/step/layer/layer.cpp
+++ b/src/step/layer/layer.cpp
@@ -1,5 +1,6 @@
 #include "step/layer/layer.h"
 
+#include <cmath>
 #include <cstdlib>
 #include <limits>
 
@@ -28,7 +29,8 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
-Layer::Layer(uint layer_nr, const QSharedPointer<SettingsBase>& sb) : Step(sb), m_layer_nr(layer_nr) {
+Layer::Layer(uint layer_nr, const QSharedPointer<SettingsBase>& sb)
+    : Step(sb), m_layer_nr(layer_nr), m_minimum_z_shift(0) {
     m_type = StepType::kLayer;
 }
 
@@ -293,30 +295,87 @@ Point Layer::getEndLocation() {
     return Point(0, 0, 0);
 }
 
+Point Layer::getOrientationShift() const {
+    Point orientation_shift = m_shift_amount;
+
+    if (m_sb->setting<bool>(PS::SpecialModes::kEnableSpiralize)) {
+        // Spiralized paths start on the build surface instead of at a full layer height.
+        const Distance half_layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight) / 2.0;
+        orientation_shift.z(m_shift_amount.z() - half_layer_height);
+    }
+
+    orientation_shift.x(orientation_shift.x() - m_sb->setting<double>(PRS::Dimensions::kXOffset));
+    orientation_shift.y(orientation_shift.y() - m_sb->setting<double>(PRS::Dimensions::kYOffset));
+
+    return orientation_shift;
+}
+
+void Layer::applyMinimumZShift() {
+    m_minimum_z_shift = 0;
+
+    if (m_sb->setting<bool>(PS::SpecialModes::kEnableSpiralize))
+        return;
+
+    const QVector3D normal = m_slicing_plane.normal().normalized();
+    constexpr float kMinimumZComponent = 1.0e-6f;
+    const float z_component = std::abs(normal.z());
+    if (z_component < kMinimumZComponent)
+        return;
+
+    const Distance layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+    const Distance minimum_print_z = layer_height / z_component;
+    const Distance current_min_z = getMinimumPrintZ();
+    if (current_min_z >= minimum_print_z)
+        return;
+
+    m_minimum_z_shift = minimum_print_z - current_min_z;
+    const Point shift(0.0f, 0.0f, m_minimum_z_shift());
+    for (QSharedPointer<IslandBase> island : getIslands()) {
+        island->transform(QQuaternion(), shift);
+    }
+}
+
+void Layer::removeMinimumZShift() {
+    if (m_minimum_z_shift == 0)
+        return;
+
+    const Point shift(0.0f, 0.0f, -m_minimum_z_shift());
+    for (QSharedPointer<IslandBase> island : getIslands()) {
+        island->transform(QQuaternion(), shift);
+    }
+    m_minimum_z_shift = 0;
+}
+
+float Layer::getMinimumPrintZ() {
+    float minimum_print_z = std::numeric_limits<float>::max();
+
+    for (const QSharedPointer<IslandBase>& island : getIslands()) {
+        for (const QSharedPointer<RegionBase>& region : island->getRegions()) {
+            for (Path& path : region->getPaths()) {
+                for (const QSharedPointer<SegmentBase>& segment : path.getSegments()) {
+                    if (segment->isPrintingSegment()) {
+                        const float segment_min_z = segment->getMinZ();
+                        if (segment_min_z < minimum_print_z)
+                            minimum_print_z = segment_min_z;
+                    }
+                }
+            }
+        }
+    }
+
+    return minimum_print_z;
+}
+
 void Layer::unorient() {
     if (!this->isDirty()) {
-        // raise the layer by half the layer height, because cross-sections are taken at the center of a layer
-        // but the path for the extruder should be at a full layer height
-        // don't add half the height if spiralize is enabled because spiralize should start printing
-        // with the nozzle sitting on the build surface, z=0
-        Point half_shift = m_shift_amount;
-        Distance layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
-
-        if (m_sb->setting<bool>(PS::SpecialModes::kEnableSpiralize)) {
-            half_shift.z(m_shift_amount.z() - (0.5 * layer_height));
-        }
-        else {
-            half_shift.z(m_shift_amount.z() + (0.5 * layer_height));
-        }
-
-        half_shift.x(half_shift.x() - m_sb->setting<double>(PRS::Dimensions::kXOffset));
-        half_shift.y(half_shift.y() - m_sb->setting<double>(PRS::Dimensions::kYOffset));
+        removeMinimumZShift();
+        const Point orientation_shift = getOrientationShift();
 
         // rotate and then shift every island in the layer
         QQuaternion rotation = MathUtils::CreateQuaternion(QVector3D(0, 0, 1), m_slicing_plane.normal());
 
         for (QSharedPointer<IslandBase> island : getIslands()) {
-            island->transform(rotation.inverted(), half_shift * -1);
+            island->transform(rotation.inverted(), orientation_shift * -1);
         }
 
         // unapply current origin shift
@@ -338,30 +397,16 @@ void Layer::reorient() {
         island->transform(QQuaternion(), origin_shift);
     }
 
-    // Raise the layer by half the layer height, because cross-sections are taken at the center of a layer but the
-    // path for the extruder should be at a full layer height.
-    // Don't add half the height if spiralize is enabled because spiralize should start printing with the nozzle
-    // sitting on the build surface, z = 0.
-    Point half_shift = m_shift_amount;
-    const Distance& layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
-    const Distance& half_layer_height = layer_height / 2.0;
-
-    if (m_sb->setting<bool>(PS::SpecialModes::kEnableSpiralize)) {
-        half_shift.z(m_shift_amount.z() - half_layer_height);
-    }
-    else {
-        half_shift.z(m_shift_amount.z() + half_layer_height);
-    }
-
-    half_shift.x(half_shift.x() - m_sb->setting<double>(PRS::Dimensions::kXOffset));
-    half_shift.y(half_shift.y() - m_sb->setting<double>(PRS::Dimensions::kYOffset));
+    const Point orientation_shift = getOrientationShift();
 
     // Rotate and then shift every island in the layer
     QQuaternion rotation = MathUtils::CreateQuaternion(QVector3D(0, 0, 1), m_slicing_plane.normal());
 
     for (QSharedPointer<IslandBase> island : getIslands()) {
-        island->transform(rotation, half_shift);
+        island->transform(rotation, orientation_shift);
     }
+
+    applyMinimumZShift();
 }
 
 void Layer::compensateForRafts() {

--- a/src/step/layer/layer.cpp
+++ b/src/step/layer/layer.cpp
@@ -322,11 +322,13 @@ void Layer::applyMinimumZShift() {
     if (z_component < kMinimumZComponent)
         return;
 
-    const Distance layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
-    const Distance minimum_print_z = layer_height / z_component;
-    const Distance current_min_z = getMinimumPrintZ();
-    if (current_min_z >= minimum_print_z)
+    const float current_min_z_value = getMinimumPrintZ();
+    if (current_min_z_value == std::numeric_limits<float>::max())
         return;
+
+    const Distance layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+    const Distance current_min_z = current_min_z_value;
+    const Distance minimum_print_z = current_min_z + (layer_height / (2.0 * z_component));
 
     m_minimum_z_shift = minimum_print_z - current_min_z;
     const Point shift(0.0f, 0.0f, m_minimum_z_shift());


### PR DESCRIPTION
## What changed
This updates layer reorientation for angled slicing so restored toolpaths are lifted to the minimum printable Z implied by the slicing plane instead of always relying on the horizontal half-layer-height adjustment.

## Why
Issue #35 showed that angled slices could start too low or too high because the post-rotation Z shift was based on the flattened layer center rather than the actual printable height of the reoriented extrusion paths. For a 0.1 mm layer at 45 degrees, the first printable Z should be about 0.1414 mm.

## Root cause
The old logic always applied the same half-layer-height style offset after reorientation. That works for horizontal slicing, but once the layer is rotated the minimum printable Z depends on the slicing plane normal and on the lowest material-depositing segment, not just the original layer center.

## Impact
Angled slicing now starts at the expected printable Z for the current plane orientation while preserving the existing horizontal and spiralize behavior.

## Validation
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer -j16`
- `nix develop --command clang-format --dry-run --Werror include/step/layer/layer.h src/step/layer/layer.cpp`
- `git diff --check`
- Verified generated G-code first-print Z values for horizontal, 45 degree, 30 degree, 60 degree, and 45 degree plus Z-offset cases