### PR TITLE
Fix parent child rotation bug

### DIFF
--- a/src/widgets/part_widget/model/part_meta_item.cpp
+++ b/src/widgets/part_widget/model/part_meta_item.cpp
@@ -117,7 +117,12 @@ void PartMetaItem::setRotation(QQuaternion r, bool current_rotation) {
     if (m_rotation == r)
         return;
 
-    if (current_rotation) {
+    const bool has_parenting = !m_parent.isNull() || !m_children.isEmpty();
+
+    // Parent/child groups need to keep rotation in the live transform so child graphics objects
+    // can inherit the motion correctly. Baking rotation into the mesh resets the parent transform
+    // and breaks the hierarchy relationship for settings meshes.
+    if (current_rotation || has_parenting) {
         m_rotation = r;
         m_transformation = MathUtils::composeTransformMatrix(m_translation, m_rotation, m_scale);
         emit modified(PartMetaUpdateType::kTransformUpdate);


### PR DESCRIPTION
## Summary
- keep rotation as a live transform for parts that participate in parent/child relationships
- avoid baking parented rotations into the mesh, which reset the part transform and break hierarchy propagation
- preserve the existing rotation-bake behavior for standalone parts

## Why
Issue #22 reported that when a settings mesh is parented to a build mesh, translating the group works but rotating it causes the settings mesh to disappear. The root cause was that `PartMetaItem::setRotation` baked rotations into the mesh and reset the live transform. That works for standalone parts, but it breaks parent/child transform propagation because the hierarchy needs the rotation to remain on the graphics object transform.

## Impact
Parent and child parts now rotate together as expected, including settings meshes attached to build meshes. Standalone parts keep their previous behavior.

## Validation
- Reviewed the parent/child transform flow from `PartMetaItem` through `PartView` and `GraphicsObject`
- Confirmed the branch only contains the issue #22 fix
- Build not run in this environment because `cmake` is unavailable
