### PR TITLE
Prevent bed collisions for tip wipes and spiral lifts during angled printing

### DIFF
--- a/include/step/layer/layer.h
+++ b/include/step/layer/layer.h
@@ -99,6 +99,9 @@ class Layer : public Step {
     //! \brief Returns the minimum Z coordinate among material-depositing segments.
     float getMinimumPrintZ();
 
+    //! \brief Redirects clearance moves that would intersect the build plate.
+    void redirectClearanceMoves();
+
     //! \brief Creates tree-like structure if brims exist, otherwise, sorts islands into precendence order
     QList<QHash<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>>
     createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSharedPointer<IslandBase>>> children);

--- a/src/step/layer/layer.cpp
+++ b/src/step/layer/layer.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <limits>
 
+#include <CGAL/intersections.h>
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qhashfunctions.h>
@@ -18,6 +19,8 @@
 #include "geometry/path.h"
 #include "geometry/path_modifier.h"
 #include "geometry/point.h"
+#include "geometry/segments/arc.h"
+#include "geometry/segments/line.h"
 #include "geometry/settings_polygon.h"
 #include "optimizers/island_order_optimizer.h"
 #include "step/layer/island/polymer_island.h"
@@ -29,6 +32,50 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
+namespace {
+bool isClearanceModifier(PathModifiers modifiers) {
+    constexpr PathModifiers clearance_modifiers =
+        PathModifiers::kForwardTipWipe | PathModifiers::kReverseTipWipe | PathModifiers::kAngledTipWipe |
+        PathModifiers::kPerimeterTipWipe | PathModifiers::kSpiralLift;
+
+    return (modifiers & clearance_modifiers) != PathModifiers::kNone;
+}
+
+bool intersectsBuildPlate(const Point& start, const Point& end, const MeshTypes::Plane_3& build_plate) {
+    const MeshTypes::Point_3 start_point = start.toCartesian3D();
+    const MeshTypes::Point_3 end_point = end.toCartesian3D();
+
+    const bool extends_below_plate = build_plate.oriented_side(start_point) == CGAL::ON_NEGATIVE_SIDE ||
+                                     build_plate.oriented_side(end_point) == CGAL::ON_NEGATIVE_SIDE;
+
+    return extends_below_plate && CGAL::do_intersect(MeshTypes::Segment_3(start_point, end_point), build_plate);
+}
+
+Point redirectTipWipeEnd(const Point& start, const QVector3D& original_move, const QVector3D& slicing_normal) {
+    // Mirror the move's in-plane component while preserving its lift along the slicing normal.
+    const QVector3D normal_component = slicing_normal * QVector3D::dotProduct(original_move, slicing_normal);
+    const QVector3D redirected_move = (2.0f * normal_component) - original_move;
+
+    return start + Point::fromQVector3D(redirected_move);
+}
+
+QSharedPointer<SegmentBase> rewriteRedirectedSegment(const QSharedPointer<SegmentBase>& segment, const Point& start,
+                                                     const Point& end) {
+    // Arc spiral lifts carry center-point metadata; once redirected, replace them with a linear clearance move so the
+    // stored arc geometry stays consistent with the emitted path.
+    if (!segment.dynamicCast<ArcSegment>().isNull()) {
+        QSharedPointer<LineSegment> redirected_segment = QSharedPointer<LineSegment>::create(start, end);
+        redirected_segment->setSb(segment->getSb());
+        return redirected_segment;
+    }
+
+    QSharedPointer<SegmentBase> redirected_segment = segment->clone();
+    redirected_segment->setStart(start);
+    redirected_segment->setEnd(end);
+    return redirected_segment;
+}
+} // namespace
+
 Layer::Layer(uint layer_nr, const QSharedPointer<SettingsBase>& sb)
     : Step(sb), m_layer_nr(layer_nr), m_minimum_z_shift(0) {
     m_type = StepType::kLayer;
@@ -409,6 +456,61 @@ void Layer::reorient() {
     }
 
     applyMinimumZShift();
+    redirectClearanceMoves();
+}
+
+void Layer::redirectClearanceMoves() {
+    QVector3D slicing_normal = m_slicing_plane.normal().normalized();
+    if (slicing_normal.isNull()) {
+        return;
+    }
+
+    const MeshTypes::Plane_3 build_plate(MeshTypes::Point_3(0.0, 0.0, 0.0), MeshTypes::Vector_3(0.0, 0.0, 1.0));
+
+    for (const QSharedPointer<IslandBase>& island : getIslands()) {
+        for (const QSharedPointer<RegionBase>& region : island->getRegions()) {
+            for (Path& path : region->getPaths()) {
+                QList<QSharedPointer<SegmentBase>>& segments = path.getSegments();
+
+                for (int index = 0; index < segments.size();) {
+                    if (!isClearanceModifier(segments[index]->getSb()->setting<PathModifiers>(SS::kPathModifiers))) {
+                        ++index;
+                        continue;
+                    }
+
+                    Point original_position = segments[index]->start();
+                    Point redirected_position = original_position;
+                    bool has_redirected = false;
+
+                    // Reconstruct the emitted moves from successive endpoints. Multi-segment wipes and spiral lifts
+                    // store segment starts on the source contour, but the machine moves from the preceding endpoint.
+                    while (index < segments.size() &&
+                           isClearanceModifier(segments[index]->getSb()->setting<PathModifiers>(SS::kPathModifiers))) {
+                        const QSharedPointer<SegmentBase>& segment = segments[index];
+                        const Point original_end = segment->end();
+                        const QVector3D original_move = (original_end - original_position).toQVector3D();
+                        Point candidate_end =
+                            has_redirected ? redirected_position + Point::fromQVector3D(original_move) : original_end;
+                        bool should_rewrite_segment = has_redirected;
+
+                        if (intersectsBuildPlate(redirected_position, candidate_end, build_plate)) {
+                            candidate_end = redirectTipWipeEnd(redirected_position, original_move, slicing_normal);
+                            has_redirected = true;
+                            should_rewrite_segment = true;
+                        }
+
+                        if (should_rewrite_segment) {
+                            segments[index] = rewriteRedirectedSegment(segment, redirected_position, candidate_end);
+                        }
+
+                        original_position = original_end;
+                        redirected_position = candidate_end;
+                        ++index;
+                    }
+                }
+            }
+        }
+    }
 }
 
 void Layer::compensateForRafts() {

--- a/src/step/layer/layer.cpp
+++ b/src/step/layer/layer.cpp
@@ -1,10 +1,10 @@
 #include "step/layer/layer.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <limits>
 
-#include <CGAL/intersections.h>
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qhashfunctions.h>
@@ -41,14 +41,59 @@ bool isClearanceModifier(PathModifiers modifiers) {
     return (modifiers & clearance_modifiers) != PathModifiers::kNone;
 }
 
-bool intersectsBuildPlate(const Point& start, const Point& end, const MeshTypes::Plane_3& build_plate) {
-    const MeshTypes::Point_3 start_point = start.toCartesian3D();
-    const MeshTypes::Point_3 end_point = end.toCartesian3D();
+bool isBelowBuildPlate(const Point& point, const MeshTypes::Plane_3& build_plate) {
+    return build_plate.oriented_side(point.toCartesian3D()) == CGAL::ON_NEGATIVE_SIDE;
+}
 
-    const bool extends_below_plate = build_plate.oriented_side(start_point) == CGAL::ON_NEGATIVE_SIDE ||
-                                     build_plate.oriented_side(end_point) == CGAL::ON_NEGATIVE_SIDE;
+bool lineIntersectsBuildPlate(const Point& start, const Point& end, const MeshTypes::Plane_3& build_plate) {
+    if (isBelowBuildPlate(start, build_plate) || isBelowBuildPlate(end, build_plate)) {
+        return true;
+    }
 
-    return extends_below_plate && CGAL::do_intersect(MeshTypes::Segment_3(start_point, end_point), build_plate);
+    return false;
+}
+
+bool arcIntersectsBuildPlate(const ArcSegment& arc, const Point& start, const Point& end,
+                             const MeshTypes::Plane_3& build_plate) {
+    const Point center = arc.center();
+    const double start_radius = std::hypot(start.x() - center.x(), start.y() - center.y());
+    const double end_radius = std::hypot(end.x() - center.x(), end.y() - center.y());
+    constexpr double kRadiusTolerance = 1.0e-4;
+    if (start_radius <= kRadiusTolerance || std::abs(start_radius - end_radius) > kRadiusTolerance) {
+        return lineIntersectsBuildPlate(start, end, build_plate);
+    }
+
+    constexpr double kMaxSampleAngle = M_PI / 36.0;
+    const double arc_angle = std::abs(arc.angle()());
+    const int sample_count = std::max(1, static_cast<int>(std::ceil(arc_angle / kMaxSampleAngle)));
+    const double start_angle = std::atan2(start.y() - center.y(), start.x() - center.x());
+    const double signed_angle = arc.counterclockwise() ? arc_angle : -arc_angle;
+
+    Point previous = start;
+    for (int sample = 1; sample <= sample_count; ++sample) {
+        const double fraction = static_cast<double>(sample) / sample_count;
+        const double angle = start_angle + (signed_angle * fraction);
+        const Point current(center.x() + (start_radius * std::cos(angle)),
+                            center.y() + (start_radius * std::sin(angle)),
+                            start.z() + ((end.z() - start.z()) * fraction));
+
+        if (lineIntersectsBuildPlate(previous, current, build_plate)) {
+            return true;
+        }
+        previous = current;
+    }
+
+    return false;
+}
+
+bool clearanceMoveIntersectsBuildPlate(const QSharedPointer<SegmentBase>& segment, const Point& start, const Point& end,
+                                       const MeshTypes::Plane_3& build_plate) {
+    const QSharedPointer<ArcSegment> arc = segment.dynamicCast<ArcSegment>();
+    if (!arc.isNull()) {
+        return arcIntersectsBuildPlate(*arc, start, end, build_plate);
+    }
+
+    return lineIntersectsBuildPlate(start, end, build_plate);
 }
 
 Point redirectTipWipeEnd(const Point& start, const QVector3D& original_move, const QVector3D& slicing_normal) {
@@ -493,7 +538,8 @@ void Layer::redirectClearanceMoves() {
                             has_redirected ? redirected_position + Point::fromQVector3D(original_move) : original_end;
                         bool should_rewrite_segment = has_redirected;
 
-                        if (intersectsBuildPlate(redirected_position, candidate_end, build_plate)) {
+                        if (clearanceMoveIntersectsBuildPlate(segment, redirected_position, candidate_end,
+                                                              build_plate)) {
                             candidate_end = redirectTipWipeEnd(redirected_position, original_move, slicing_normal);
                             has_redirected = true;
                             should_rewrite_segment = true;

--- a/src/step/layer/layer.cpp
+++ b/src/step/layer/layer.cpp
@@ -478,12 +478,12 @@ void Layer::redirectClearanceMoves() {
                         continue;
                     }
 
-                    Point original_position = segments[index]->start();
+                    Point original_position = index > 0 ? segments[index - 1]->end() : segments[index]->start();
                     Point redirected_position = original_position;
                     bool has_redirected = false;
 
                     // Reconstruct the emitted moves from successive endpoints. Multi-segment wipes and spiral lifts
-                    // store segment starts on the source contour, but the machine moves from the preceding endpoint.
+                    // can store starts on the source contour, but the machine moves from the preceding endpoint.
                     while (index < segments.size() &&
                            isClearanceModifier(segments[index]->getSb()->setting<PathModifiers>(SS::kPathModifiers))) {
                         const QSharedPointer<SegmentBase>& segment = segments[index];

--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -261,19 +261,8 @@ void Infill::calculateModifiers(Path& path, bool supportsG3) {
                                                 m_sb->setting<double>(MS::Slowdown::kSlowDownAreaModifier));
     }
     if (m_sb->setting<bool>(MS::TipWipe::kInfillEnable)) {
-        // If angled slicing, force tip wipe to be reverse
-        if (m_sb->setting<float>(PS::Slicing::kSlicingVectorX) != 0 ||
-            m_sb->setting<float>(PS::Slicing::kSlicingVectorY) != 0 ||
-            m_sb->setting<float>(PS::Slicing::kSlicingVectorZ) != 1) {
-            PathModifierGenerator::GenerateTipWipe(
-                path, PathModifiers::kReverseTipWipe, m_sb->setting<Distance>(MS::TipWipe::kInfillDistance),
-                m_sb->setting<Velocity>(MS::TipWipe::kInfillSpeed), m_sb->setting<Angle>(MS::TipWipe::kInfillAngle),
-                m_sb->setting<AngularVelocity>(MS::TipWipe::kInfillExtruderSpeed),
-                m_sb->setting<Distance>(MS::TipWipe::kInfillLiftHeight),
-                m_sb->setting<Distance>(MS::TipWipe::kInfillCutoffDistance));
-        }
         // if Forward OR (if Optimal AND (Perimeter OR Inset)) OR (if Optimal AND Concentric)
-        else if (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kInfillDirection)) ==
+        if (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kInfillDirection)) ==
                      TipWipeDirection::kForward ||
                  (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kInfillDirection)) ==
                       TipWipeDirection::kOptimal &&

--- a/src/step/layer/regions/skin.cpp
+++ b/src/step/layer/regions/skin.cpp
@@ -358,19 +358,8 @@ void Skin::calculateModifiers(Path& path, bool supportsG3) {
                                                 m_sb->setting<double>(MS::Slowdown::kSlowDownAreaModifier));
     }
     if (m_sb->setting<bool>(MS::TipWipe::kSkinEnable)) {
-        // If angled slicing, force tip wipe to be reverse
-        if (m_sb->setting<float>(PS::Slicing::kSlicingVectorX) != 0 ||
-            m_sb->setting<float>(PS::Slicing::kSlicingVectorY) != 0 ||
-            m_sb->setting<float>(PS::Slicing::kSlicingVectorZ) != 1) {
-            PathModifierGenerator::GenerateTipWipe(
-                path, PathModifiers::kReverseTipWipe, m_sb->setting<Distance>(MS::TipWipe::kSkinDistance),
-                m_sb->setting<Velocity>(MS::TipWipe::kSkinSpeed), m_sb->setting<Angle>(MS::TipWipe::kSkinAngle),
-                m_sb->setting<AngularVelocity>(MS::TipWipe::kSkinExtruderSpeed),
-                m_sb->setting<Distance>(MS::TipWipe::kSkinLiftHeight),
-                m_sb->setting<Distance>(MS::TipWipe::kSkinCutoffDistance));
-        }
         // if Forward OR (if Optimal AND (Perimeter OR Inset)) OR (if Optimal AND Concentric)
-        else if (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kSkinDirection)) ==
+        if (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kSkinDirection)) ==
                      TipWipeDirection::kForward ||
                  (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kSkinDirection)) ==
                       TipWipeDirection::kOptimal &&


### PR DESCRIPTION
## Summary

This change prevents angled-printing clearance moves from intersecting the build plate after layer reorientation.

## What changed

- added a post-`reorient()` clearance pass in `Layer` that checks tip wipes and spiral lifts against the build plate plane in machine coordinates
- redirects colliding clearance moves by mirroring their in-plane motion while preserving lift along the slicing normal
- rewrites redirected arc-based spiral lifts as linear clearance moves so the emitted geometry stays valid after redirection
- removed the older angled-slicing override in infill and skin that forced tip wipes to `REVERSE TIP WIPE`

## Root cause

Tip wipes and spiral lifts were generated in slice-local coordinates. During angled printing, those moves could become bed-crossing motions only after the layer was rotated back into machine space, but there was no post-reorientation collision check to catch them.

## Impact

- forward tip wipes can now remain forward during angled slicing when requested
- tip wipes and spiral lifts that would otherwise cross `z = 0` are redirected to a safe path instead of colliding with the bed
- Cincinnati and other writers benefit from the same geometry fix because the correction happens before G-code emission

## Validation

- `nix develop -c ninja -C build/generic-llvm-ninja ornlslicer`
- verified emitted path modifiers still surface in G-code comments for practical inspection (`TIP WIPE`, `SPIRAL LIFT`)

## Issue

- fixes #66