### PR TITLE
Add Final Z Lift Functionality

### DIFF
--- a/include/gcode/writers/cincinnati_writer.h
+++ b/include/gcode/writers/cincinnati_writer.h
@@ -96,6 +96,9 @@ class CincinnatiWriter : public WriterBase {
     //! \brief Writes G-Code to update the acceleration value
     QString writeAcceleration(Acceleration acc);
 
+    //! \brief Writes the end-of-print lift before shutdown logic executes.
+    QString writeFinalLift();
+
     //! \brief Writes gcode coordinates WXYZ for a move or travel to the destination point
     QString writeCoordinates(Point destination);
 

--- a/include/gcode/writers/writer_base.h
+++ b/include/gcode/writers/writer_base.h
@@ -112,6 +112,15 @@ class WriterBase {
     //! \brief Return current feedrate
     Velocity getFeedrate() const;
 
+    //! \brief Records the current output position after a segment is emitted.
+    void setCurrentPosition(const Point& point);
+
+    //! \brief Returns whether a concrete output position has been recorded yet.
+    bool hasCurrentPosition() const;
+
+    //! \brief Returns the most recent recorded output position.
+    Point getCurrentPosition() const;
+
     //! \brief Write purge command
     virtual QString writePurge(int RPM, int duration, int delay) { return QString(); }
 
@@ -135,6 +144,30 @@ class WriterBase {
     //! \brief gets a vector in the direction normal to the plane and of a length = travel lift height
     QVector3D getTravelLift();
 
+    //! \brief gets a vector in the direction normal to the plane and of the provided length
+    QVector3D getLiftVector(Distance lift_height) const;
+
+    //! \brief emits a final lift move for point-based writers when configured
+    template <typename MoveEmitter>
+    QString writeFinalTravelLift(MoveEmitter&& emit_move, const QString& comment) {
+        const Distance final_lift = m_sb->setting<Distance>(PS::Travel::kFinalLiftDistance);
+        if (final_lift <= 0 || !m_has_current_position)
+            return QString();
+
+        const Point lift_destination = m_current_position + getLiftVector(final_lift);
+        QString rv = emit_move(lift_destination);
+        if (rv.isEmpty())
+            return rv;
+
+        if (comment.isEmpty())
+            rv += m_newline;
+        else
+            rv += commentSpaceLine(comment);
+
+        setCurrentPosition(lift_destination);
+        return rv;
+    }
+
     //! \brief Gets the segment-local initial extruder speed, falling back to the global setting.
     int getInitialExtruderSpeed(const QSharedPointer<SettingsBase>& params = nullptr) const;
 
@@ -151,6 +184,12 @@ class WriterBase {
 
     //! \brief maintains the min z of the last layer so that we can determine if/when to move the table
     float m_min_z;
+
+    //! \brief the most recent point emitted by the gcode writer
+    Point m_current_position;
+
+    //! \brief whether or not the writer has emitted a point yet
+    bool m_has_current_position;
 
     //! \brief preallocated common prefixes that all writers use
     QChar m_space;

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -745,6 +745,7 @@ class Constants {
             static const QString kMinTravelLength;
             static const QString kMinTravelForLift;
             static const QString kLiftHeight;
+            static const QString kFinalLiftDistance;
             static const QString kEnableTravelPause;
             static const QString kEnableTravelCentroidMove;
             static const QString kTravelPauseDuration;

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -5069,6 +5069,19 @@
       "symbol":"kTravelLiftHeight",
       "local":false
   },
+  "final_lift_distance": {
+      "display":"Final Lift Distance",
+      "type":"distance",
+      "tooltip":"Distance to lift the tool at the end of the print along the slicing plane normal before shutdown.",
+      "depends":"",
+      "options":"",
+      "default":0,
+      "minor":"Travel",
+      "major":"Profile",
+      "namespace":"Profile::Travel",
+      "symbol":"kFinalLiftDistance",
+      "local":false
+  },
   "enable_travel_pause": {
       "display":"Pause During Travel",
       "type":"boolean",

--- a/resources/settings/027_profile_travel.yaml
+++ b/resources/settings/027_profile_travel.yaml
@@ -61,6 +61,18 @@ settings:
     namespace: "Profile::Travel"
     symbol: "kTravelLiftHeight"
     local: false
+  - name: "final_lift_distance"
+    display: "Final Lift Distance"
+    type: "distance"
+    tooltip: "Distance to lift the tool at the end of the print along the slicing plane normal before shutdown."
+    depends: {}
+    options: []
+    default: 0
+    minor: "Travel"
+    major: "Profile"
+    namespace: "Profile::Travel"
+    symbol: "kFinalLiftDistance"
+    local: false
   - name: "enable_travel_pause"
     display: "Pause During Travel"
     type: "boolean"

--- a/src/gcode/writers/aml3d_writer.cpp
+++ b/src/gcode/writers/aml3d_writer.cpp
@@ -379,6 +379,8 @@ QString AML3DWriter::writeAfterLayer() {
 
 QString AML3DWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
     rv += m_M5 % commentSpaceLine("TURN EXTRUDER OFF END OF PRINT") % writeTamperOff();
 
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M30" % commentSpaceLine("END OF G-CODE");

--- a/src/gcode/writers/cincinnati_writer.cpp
+++ b/src/gcode/writers/cincinnati_writer.cpp
@@ -764,6 +764,7 @@ QString CincinnatiWriter::writeAfterLayer() {
 
 QString CincinnatiWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalLift();
     rv += m_M5 % commentSpaceLine("TURN EXTRUDER OFF END OF PRINT") % writeTamperOff() % "M68 (PARK)\n";
 
     if (m_sb->setting<int>(MS::Extruder::kServoToTravelSpeed)) {
@@ -776,6 +777,48 @@ QString CincinnatiWriter::writeShutdown() {
               commentSpaceLine("JOG W TO DOFFING LOCATION");
     }
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M30" % commentSpaceLine("END OF G-CODE");
+    return rv;
+}
+
+QString CincinnatiWriter::writeFinalLift() {
+    const Distance final_lift = m_sb->setting<Distance>(PS::Travel::kFinalLiftDistance);
+    if (final_lift <= 0 || !hasCurrentPosition()) {
+        return QString();
+    }
+
+    QString rv;
+    const Point lift_destination = getCurrentPosition() + getLiftVector(final_lift);
+
+    m_is_lift = true;
+    m_is_travel = false;
+
+    if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
+        if (m_sb->setting<int>(PRS::Dimensions::kLayerChangeAxis) == static_cast<int>(LayerChange::kW_only)) {
+            rv += m_G1 % m_f %
+                  QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kWTableSpeed).to(m_meta.m_velocity_unit)) %
+                  writeCoordinates(lift_destination);
+            setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kWTableSpeed));
+        }
+        else {
+            rv += m_G1 % m_f %
+                  QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
+                  writeCoordinates(lift_destination);
+            setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
+        }
+    }
+    else {
+        rv += m_G0 % writeCoordinates(lift_destination);
+    }
+
+    if (m_w_travel) {
+        rv += commentSpaceLine("TRAVEL FINAL LIFT W");
+    }
+    else {
+        rv += commentSpaceLine("TRAVEL FINAL LIFT Z");
+    }
+
+    setCurrentPosition(lift_destination);
+    m_is_lift = false;
     return rv;
 }
 

--- a/src/gcode/writers/dmg_dmu_writer.cpp
+++ b/src/gcode/writers/dmg_dmu_writer.cpp
@@ -319,6 +319,8 @@ QString DMGDMUWriter::writeAfterLayer() {
 
 QString DMGDMUWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
 
     rv += "G91G28Z0.0" % m_newline;
     rv += "G91G28Y0.0" % m_newline;

--- a/src/gcode/writers/gudel_writer.cpp
+++ b/src/gcode/writers/gudel_writer.cpp
@@ -309,6 +309,8 @@ QString GudelWriter::writeAfterLayer() {
 
 QString GudelWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
 
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M84" % commentSpaceLine("END OF G-CODE");
     return rv;

--- a/src/gcode/writers/haas_metric_no_comments_writer.cpp
+++ b/src/gcode/writers/haas_metric_no_comments_writer.cpp
@@ -327,6 +327,8 @@ QString HaasMetricNoCommentsWriter::writeAfterLayer() {
 
 QString HaasMetricNoCommentsWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               QString());
 
     rv += "G91G28Z0.0" % m_newline;
     rv += "G91G28Y0.0" % m_newline;

--- a/src/gcode/writers/haas_writer.cpp
+++ b/src/gcode/writers/haas_writer.cpp
@@ -340,6 +340,8 @@ QString HaasWriter::writeAfterLayer() {
 
 QString HaasWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
 
     rv += "G91G28Z0.0" % m_newline;
     rv += "G91G28Y0.0" % m_newline;

--- a/src/gcode/writers/hurco_writer.cpp
+++ b/src/gcode/writers/hurco_writer.cpp
@@ -329,6 +329,8 @@ QString HurcoWriter::writeAfterLayer() {
 
 QString HurcoWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
 
     rv += "G91G28Z0.0" % m_newline;
     rv += "G91G28Y0.0" % m_newline;

--- a/src/gcode/writers/ingersoll_writer.cpp
+++ b/src/gcode/writers/ingersoll_writer.cpp
@@ -345,6 +345,17 @@ QString IngersollWriter::writeAfterLayer() {
 
 QString IngersollWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift(
+        [&](const Point& destination) -> QString {
+            const Velocity z_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
+            setFeedrate(z_speed);
+            if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
+                return QString(m_G1 % m_f % QString::number(z_speed.to(m_meta.m_velocity_unit)) %
+                               writeCoordinates(destination));
+            }
+            return QString(m_G0 % writeCoordinates(destination));
+        },
+        "TRAVEL FINAL LIFT Z");
     rv += writeExtruderOff(0); // update to turn off the extruder
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode);
     return rv;

--- a/src/gcode/writers/juggerbot_writer.cpp
+++ b/src/gcode/writers/juggerbot_writer.cpp
@@ -381,6 +381,13 @@ QString JuggerBotWriter::writeAfterLayer() {
 
 QString JuggerBotWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift(
+        [&](const Point& destination) {
+            const Velocity z_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
+            setFeedrate(z_speed);
+            return m_G1 % m_f % QString::number(z_speed.to(m_meta.m_velocity_unit)) % writeCoordinates(destination);
+        },
+        "TRAVEL FINAL LIFT Z");
     rv += "M5" % commentSpaceLine("TURN EXTRUDER OFF END OF PRINT") % "M104 S0 T0" %
           commentSpaceLine("TURN EXTRUDER OFF");
     rv +=

--- a/src/gcode/writers/kraussmaffei_writer.cpp
+++ b/src/gcode/writers/kraussmaffei_writer.cpp
@@ -489,6 +489,13 @@ QString KraussMaffeiWriter::writeAfterLayer() {
 
 QString KraussMaffeiWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift(
+        [&](const Point& destination) {
+            const Velocity z_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
+            setFeedrate(z_speed);
+            return m_G1 % m_f % QString::number(z_speed.to(m_meta.m_velocity_unit)) % writeCoordinates(destination);
+        },
+        "TRAVEL FINAL LIFT Z");
     rv += commentSpaceLine("END OF THE MAIN G-CODE");
     rv += m_newline;
     rv += commentSpaceLine("START OF THE END G-CODE");

--- a/src/gcode/writers/mach4_writer.cpp
+++ b/src/gcode/writers/mach4_writer.cpp
@@ -544,6 +544,13 @@ QString Mach4Writer::writeAfterLayer() {
 
 QString Mach4Writer::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift(
+        [&](const Point& destination) {
+            const Velocity z_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
+            setFeedrate(z_speed);
+            return m_G1 % m_f % QString::number(z_speed.to(m_meta.m_velocity_unit)) % writeCoordinates(destination);
+        },
+        "TRAVEL FINAL LIFT Z");
     rv += "G28" % commentSpaceLine("TRAVEL HOME ALL AXES");
 
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M104 S0" % commentSpaceLine("TURN EXTRUDER OFF") %

--- a/src/gcode/writers/marlin_writer.cpp
+++ b/src/gcode/writers/marlin_writer.cpp
@@ -647,6 +647,13 @@ QString MarlinWriter::writeAfterLayer() {
 
 QString MarlinWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift(
+        [&](const Point& destination) {
+            const Velocity z_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
+            setFeedrate(z_speed);
+            return m_G1 % m_f % QString::number(z_speed.to(m_meta.m_velocity_unit)) % writeCoordinates(destination);
+        },
+        "TRAVEL FINAL LIFT Z");
     rv += "G28" % commentSpaceLine("TRAVEL HOME ALL AXES");
 
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M104 S0" % commentSpaceLine("TURN EXTRUDER OFF") %

--- a/src/gcode/writers/mazak_writer.cpp
+++ b/src/gcode/writers/mazak_writer.cpp
@@ -353,6 +353,8 @@ QString MazakWriter::writeAfterLayer() {
 
 QString MazakWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
 
     rv += "G91Z1.25" % m_newline;
     rv += "G91G28Y0.0" % m_newline;

--- a/src/gcode/writers/meltio_writer.cpp
+++ b/src/gcode/writers/meltio_writer.cpp
@@ -339,6 +339,8 @@ QString MeltioWriter::writeAfterLayer() {
 
 QString MeltioWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
     rv += "M5\n";
     rv += "G0 G90 G53 Z0.0\n";
     rv += "G53 Y0.0\n";

--- a/src/gcode/writers/mvp_writer.cpp
+++ b/src/gcode/writers/mvp_writer.cpp
@@ -276,6 +276,8 @@ QString MVPWriter::writeAfterLayer() {
 
 QString MVPWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
     rv += "M5" % commentSpaceLine("TURN PUMP OFF END OF PRINT");
     rv += "M53" % commentSpaceLine("TURN GUN OFF END OF PRINT");
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline;

--- a/src/gcode/writers/okuma_writer.cpp
+++ b/src/gcode/writers/okuma_writer.cpp
@@ -341,6 +341,8 @@ QString OkumaWriter::writeAfterLayer() {
 
 QString OkumaWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
 
     rv += "( --- 5X_end.txt --- )" % m_newline;
     rv += "G170 " % m_newline;

--- a/src/gcode/writers/ornl_writer.cpp
+++ b/src/gcode/writers/ornl_writer.cpp
@@ -393,6 +393,8 @@ QString ORNLWriter::writeAfterLayer() {
 
 QString ORNLWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
     if (m_sb->setting<MachineType>(PRS::MachineSetup::kMachineType) == MachineType::kPellet) {
         rv += m_M5 % commentSpaceLine("TURN EXTRUDER OFF END OF PRINT");
     }

--- a/src/gcode/writers/reprap_writer.cpp
+++ b/src/gcode/writers/reprap_writer.cpp
@@ -493,6 +493,13 @@ QString RepRapWriter::writeAfterLayer() {
 
 QString RepRapWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift(
+        [&](const Point& destination) {
+            const Velocity z_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
+            setFeedrate(z_speed);
+            return m_G1 % m_f % QString::number(z_speed.to(m_meta.m_velocity_unit)) % writeCoordinates(destination);
+        },
+        "TRAVEL FINAL LIFT Z");
 
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M104 S0" % commentSpaceLine("TURN EXTRUDER OFF") %
           "M140 S0" % commentSpaceLine("TURN BED OFF") % "M84" % commentSpaceLine("DISABLE MOTORS") % "M106 S0" %

--- a/src/gcode/writers/romi_fanuc_writer.cpp
+++ b/src/gcode/writers/romi_fanuc_writer.cpp
@@ -329,6 +329,8 @@ QString RomiFanucWriter::writeAfterLayer() {
 
 QString RomiFanucWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
 
     rv += "G91G28Z0.0" % m_newline;
     rv += "G91G28Y200.0" % m_newline;

--- a/src/gcode/writers/sandia_writer.cpp
+++ b/src/gcode/writers/sandia_writer.cpp
@@ -349,6 +349,13 @@ QString SandiaWriter::writeAfterLayer() {
 
 QString SandiaWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift(
+        [&](const Point& destination) {
+            const Velocity z_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
+            setFeedrate(z_speed);
+            return m_G1 % m_f % QString::number(z_speed.to(m_meta.m_velocity_unit)) % writeCoordinates(destination);
+        },
+        "TRAVEL FINAL LIFT Z");
     rv += m_M5 % commentSpaceLine("TURN EXTRUDER OFF END OF PRINT") % writeTamperOff();
 
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M30" % commentSpaceLine("END OF G-CODE");

--- a/src/gcode/writers/siemens_writer.cpp
+++ b/src/gcode/writers/siemens_writer.cpp
@@ -364,6 +364,8 @@ QString SiemensWriter::writeAfterLayer() {
 
 QString SiemensWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
     rv += comment("PARK");
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M30" % commentSpaceLine("END OF G-CODE");
     return rv;

--- a/src/gcode/writers/thermwood_writer.cpp
+++ b/src/gcode/writers/thermwood_writer.cpp
@@ -345,6 +345,13 @@ QString ThermwoodWriter::writeAfterLayer() {
 
 QString ThermwoodWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift(
+        [&](const Point& destination) {
+            const Velocity z_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
+            setFeedrate(z_speed);
+            return m_G1 % m_f % QString::number(z_speed.to(m_meta.m_velocity_unit)) % writeCoordinates(destination);
+        },
+        "TRAVEL FINAL LIFT Z");
     rv += m_M5 % commentSpaceLine("TURN EXTRUDER OFF END OF PRINT");
 
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M83" %

--- a/src/gcode/writers/tormach_writer.cpp
+++ b/src/gcode/writers/tormach_writer.cpp
@@ -330,6 +330,8 @@ QString TormachWriter::writeAfterLayer() {
 
 QString TormachWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift([&](const Point& destination) { return m_G0 % writeCoordinates(destination); },
+                               "TRAVEL FINAL LIFT Z");
     rv +=
         m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline % "M65 P1" % commentSpaceLine("ROBOT READY LOW *****");
     return rv;

--- a/src/gcode/writers/wolf_writer.cpp
+++ b/src/gcode/writers/wolf_writer.cpp
@@ -294,6 +294,13 @@ QString WolfWriter::writeAfterLayer() {
 
 QString WolfWriter::writeShutdown() {
     QString rv;
+    rv += writeFinalTravelLift(
+        [&](const Point& destination) {
+            const Velocity z_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
+            setFeedrate(z_speed);
+            return m_G1 % m_f % QString::number(z_speed.to(m_meta.m_velocity_unit)) % writeCoordinates(destination);
+        },
+        "TRAVEL FINAL LIFT Z");
     return rv;
 }
 

--- a/src/gcode/writers/writer_base.cpp
+++ b/src/gcode/writers/writer_base.cpp
@@ -45,6 +45,8 @@ WriterBase::WriterBase(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb) :
     m_M3 = "M3";
     m_M5 = "M5";
     m_start_point = Point(0, 0, 0);
+    m_current_position = Point(0, 0, 0);
+    m_has_current_position = false;
 
     m_extruder_on = false;
 }
@@ -63,20 +65,30 @@ QString WriterBase::commentSpaceLine(const QString& text) {
 }
 
 QVector3D WriterBase::getTravelLift() {
+    return getLiftVector(m_sb->setting<Distance>(PS::Travel::kLiftHeight));
+}
+
+QVector3D WriterBase::getLiftVector(Distance lift_height) const {
     // Retrieve the slicing plane normal
     QVector3D slicing_vector = {m_sb->setting<float>(PS::Slicing::kSlicingVectorX),
                                 m_sb->setting<float>(PS::Slicing::kSlicingVectorY),
                                 m_sb->setting<float>(PS::Slicing::kSlicingVectorZ)};
     slicing_vector.normalize();
 
-    // Retrieve the lift height
-    Distance lift_height = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
-
     // Calculate the lift vector
     QVector3D lift_vector = slicing_vector * lift_height();
 
     return lift_vector;
 }
+
+void WriterBase::setCurrentPosition(const Point& point) {
+    m_current_position = point;
+    m_has_current_position = true;
+}
+
+bool WriterBase::hasCurrentPosition() const { return m_has_current_position; }
+
+Point WriterBase::getCurrentPosition() const { return m_current_position; }
 
 int WriterBase::getInitialExtruderSpeed(const QSharedPointer<SettingsBase>& params) const {
     if (params != nullptr && params->contains(MS::Extruder::kInitialSpeed)) {

--- a/src/geometry/segments/arc.cpp
+++ b/src/geometry/segments/arc.cpp
@@ -73,7 +73,9 @@ QString ArcSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     int extruderSpeed = this->getSb()->setting<int>(SS::kExtruderSpeed);
     RegionType regionType = this->getSb()->setting<RegionType>(SS::kRegionType);
     PathModifiers modifiers = this->getSb()->setting<PathModifiers>(SS::kPathModifiers);
-    return writer->writeArc(m_start, m_end, m_center, m_angle, m_ccw, this->getSb());
+    const QString gcode = writer->writeArc(m_start, m_end, m_center, m_angle, m_ccw, this->getSb());
+    writer->setCurrentPosition(m_end);
+    return gcode;
 }
 
 void ArcSegment::reverse() {

--- a/src/geometry/segments/arc.cpp
+++ b/src/geometry/segments/arc.cpp
@@ -74,7 +74,8 @@ QString ArcSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     RegionType regionType = this->getSb()->setting<RegionType>(SS::kRegionType);
     PathModifiers modifiers = this->getSb()->setting<PathModifiers>(SS::kPathModifiers);
     const QString gcode = writer->writeArc(m_start, m_end, m_center, m_angle, m_ccw, this->getSb());
-    writer->setCurrentPosition(m_end);
+    if (!gcode.isEmpty())
+        writer->setCurrentPosition(m_end);
     return gcode;
 }
 

--- a/src/geometry/segments/line.cpp
+++ b/src/geometry/segments/line.cpp
@@ -24,7 +24,8 @@ QSharedPointer<SegmentBase> LineSegment::clone() const { return QSharedPointer<L
 
 QString LineSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     const QString gcode = writer->writeLine(m_start, m_end, this->getSb());
-    writer->setCurrentPosition(m_end);
+    if (!gcode.isEmpty())
+        writer->setCurrentPosition(m_end);
     return gcode;
 }
 

--- a/src/geometry/segments/line.cpp
+++ b/src/geometry/segments/line.cpp
@@ -23,7 +23,9 @@ void LineSegment::createGraphic(std::vector<float>& vertices, std::vector<float>
 QSharedPointer<SegmentBase> LineSegment::clone() const { return QSharedPointer<LineSegment>::create(*this); }
 
 QString LineSegment::writeGCode(QSharedPointer<WriterBase> writer) {
-    return writer->writeLine(m_start, m_end, this->getSb());
+    const QString gcode = writer->writeLine(m_start, m_end, this->getSb());
+    writer->setCurrentPosition(m_end);
+    return gcode;
 }
 
 float LineSegment::getMinZ() {

--- a/src/geometry/segments/scan.cpp
+++ b/src/geometry/segments/scan.cpp
@@ -22,7 +22,8 @@ QSharedPointer<SegmentBase> ScanSegment::clone() const { return QSharedPointer<S
 QString ScanSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     Velocity speed = this->getSb()->setting<Velocity>(SS::kSpeed);
     const QString gcode = writer->writeScan(m_end, speed, m_on_off);
-    writer->setCurrentPosition(m_end);
+    if (!gcode.isEmpty())
+        writer->setCurrentPosition(m_end);
     return gcode;
 }
 

--- a/src/geometry/segments/scan.cpp
+++ b/src/geometry/segments/scan.cpp
@@ -21,8 +21,9 @@ QSharedPointer<SegmentBase> ScanSegment::clone() const { return QSharedPointer<S
 
 QString ScanSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     Velocity speed = this->getSb()->setting<Velocity>(SS::kSpeed);
-
-    return writer->writeScan(m_end, speed, m_on_off);
+    const QString gcode = writer->writeScan(m_end, speed, m_on_off);
+    writer->setCurrentPosition(m_end);
+    return gcode;
 }
 
 void ScanSegment::setDataCollection(bool on) { m_on_off = on; }

--- a/src/geometry/segments/travel.cpp
+++ b/src/geometry/segments/travel.cpp
@@ -17,7 +17,9 @@ TravelSegment::TravelSegment(Point start, Point end, TravelLiftType liftType)
 QSharedPointer<SegmentBase> TravelSegment::clone() const { return QSharedPointer<TravelSegment>::create(*this); }
 
 QString TravelSegment::writeGCode(QSharedPointer<WriterBase> writer) {
-    return writer->writeTravel(m_start, m_end, m_lift_type, this->getSb());
+    const QString gcode = writer->writeTravel(m_start, m_end, m_lift_type, this->getSb());
+    writer->setCurrentPosition(m_end);
+    return gcode;
 }
 
 void TravelSegment::setLiftType(TravelLiftType newLiftType) { m_lift_type = newLiftType; }

--- a/src/geometry/segments/travel.cpp
+++ b/src/geometry/segments/travel.cpp
@@ -18,7 +18,8 @@ QSharedPointer<SegmentBase> TravelSegment::clone() const { return QSharedPointer
 
 QString TravelSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     const QString gcode = writer->writeTravel(m_start, m_end, m_lift_type, this->getSb());
-    writer->setCurrentPosition(m_end);
+    if (!gcode.isEmpty())
+        writer->setCurrentPosition(m_end);
     return gcode;
 }
 

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -682,6 +682,7 @@ const QString Constants::ProfileSettings::Travel::kInfillMinLength = "minimum_in
 const QString Constants::ProfileSettings::Travel::kMinTravelLength = "min_travel_length";
 const QString Constants::ProfileSettings::Travel::kMinTravelForLift = "minimum_travel_for_lift";
 const QString Constants::ProfileSettings::Travel::kLiftHeight = "travel_lift_height";
+const QString Constants::ProfileSettings::Travel::kFinalLiftDistance = "final_lift_distance";
 const QString Constants::ProfileSettings::Travel::kEnableTravelPause = "enable_travel_pause";
 const QString Constants::ProfileSettings::Travel::kEnableTravelCentroidMove = "travel_centroid_move";
 const QString Constants::ProfileSettings::Travel::kTravelPauseDuration = "travel_pause_duration";


### PR DESCRIPTION
## Summary
This PR adds configurable final lift behavior at the end of a print.

## What changed
- Added a new `final_lift_distance` profile setting.
- Implemented Cincinnati final lift output before shutdown, following the slicing plane normal.
- Updated the final lift comment so the UI recognizes it as travel.
- Added shared writer-base tracking for the last emitted point and reusable lift-vector helpers.
- Extended final lift support to the traditional point-based writers, while intentionally skipping radial and other special-case writers for now.

## Why
Issue #47 requested a user-configurable end-of-print lift that occurs before shutdown and follows the slicing plane normal instead of assuming machine Z.

## Impact
- Users can configure a final lift distance as part of travel settings.
- Supported writers now emit a final travel-style lift before their normal shutdown sequence.
- The UI colors the Cincinnati final-lift comment correctly as travel.

## Validation
- Built successfully with `nix develop -c ninja -C build/generic-llvm-ninja`.
