### PR TITLE
G-Code Segment Visualization Improvements

### DIFF
--- a/include/graphics/objects/gcode_object.h
+++ b/include/graphics/objects/gcode_object.h
@@ -33,8 +33,9 @@ class GCodeObject : public GraphicsObject {
     //! \param view: View to render to.
     //! \param gcode: GCode segments to visualize.
     //! \param segmentInfoControl: Segment / Bead info display control
+    //! \param use_true_widths: If true, draw printable moves as bead meshes when they are small enough to load.
     GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentBase>>> gcode,
-                QSharedPointer<GCodeInfoControl> segmentInfoControl);
+                QSharedPointer<GCodeInfoControl> segmentInfoControl, bool use_true_widths);
 
     //! \brief Destructor.
     ~GCodeObject();
@@ -146,7 +147,7 @@ class GCodeObject : public GraphicsObject {
     //! \param color: Color to paint.
     void paintSegment(QSharedPointer<SegmentDisplayMeta> seg_meta, QColor color);
 
-    //! \brief True when very large gcode is rendered as lightweight GL lines instead of bead meshes.
+    //! \brief True when gcode is rendered as lightweight GL lines instead of bead meshes.
     bool m_lightweight_lines = false;
 
     //! \brief Render mode used by the primary GraphicsObject buffer.

--- a/include/graphics/objects/gcode_object.h
+++ b/include/graphics/objects/gcode_object.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -34,11 +35,20 @@ class GCodeObject : public GraphicsObject {
     //! \param gcode: GCode segments to visualize.
     //! \param segmentInfoControl: Segment / Bead info display control
     //! \param use_true_widths: If true, draw printable moves as bead meshes when they are small enough to load.
+    //! \param preview_mode: Preview rendering policy to apply.
+    //! \param true_width_vertex_threshold: Maximum estimated vertices to build for true-width preview.
+    //! \param update_segment_info: If true, this object owns the segment info control's backing g-code.
     GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentBase>>> gcode,
-                QSharedPointer<GCodeInfoControl> segmentInfoControl, bool use_true_widths);
+                QSharedPointer<GCodeInfoControl> segmentInfoControl, bool use_true_widths,
+                GCodePreviewMode preview_mode = GCodePreviewMode::kAuto,
+                qsizetype true_width_vertex_threshold = 5000000, bool update_segment_info = true);
 
     //! \brief Destructor.
     ~GCodeObject();
+
+    //! \brief Estimates vertices required if printable segments are expanded to true-width bead meshes.
+    static qsizetype estimateTrueWidthVertexCount(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode,
+                                                  qsizetype limit = std::numeric_limits<qsizetype>::max());
 
     //! \brief Hides/Show all segments matching a type.
     //! \param type: Type to hide/show.
@@ -95,6 +105,9 @@ class GCodeObject : public GraphicsObject {
     //! \return Pairs of (line number, segment endpoints) for each line segment.
     const QVector<std::pair<uint, std::pair<QVector3D, QVector3D>>> segmentLines();
 
+    //! \brief Returns true when this object renders printable segments as lightweight lines.
+    bool isLightweight() const;
+
   protected:
     //! \brief Overridden draw call to allow segment hiding.
     void draw();
@@ -149,6 +162,9 @@ class GCodeObject : public GraphicsObject {
 
     //! \brief True when gcode is rendered as lightweight GL lines instead of bead meshes.
     bool m_lightweight_lines = false;
+
+    //! \brief If true, this object updates the segment info control.
+    bool m_updates_segment_info = true;
 
     //! \brief Render mode used by the primary GraphicsObject buffer.
     ushort m_primary_render_mode = GL_TRIANGLES;

--- a/include/graphics/view/gcode_view.h
+++ b/include/graphics/view/gcode_view.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include <QVector>
 #include <qcontainerfwd.h>
 #include <qlist.h>
@@ -186,6 +188,15 @@ class GCodeView : public BaseView {
     //! \brief Rebuilds ghosted part meshes when ghost display is enabled.
     void rebuildGhosts();
 
+    //! \brief Removes the visible-range true-width overlay from the G-code object.
+    void clearTrueWidthOverlay();
+
+    //! \brief Rebuilds the visible-range true-width overlay when the current range is below the preference threshold.
+    void refreshTrueWidthOverlay();
+
+    //! \brief Returns a printable-segment subset for the currently visible layer and segment range.
+    QVector<QVector<QSharedPointer<SegmentBase>>> visiblePrintableGCodeSubset() const;
+
     //! \brief Picks a segment based on the mouse position.
     //! \param mouse_ndc_pos: Mouse normalized location.
     //! \param gog: GCode object to search through.
@@ -211,6 +222,8 @@ class GCodeView : public BaseView {
     QSharedPointer<PrinterObject> m_printer;
     //! \brief Main GCodeObject.
     QSharedPointer<GCodeObject> m_gcode_object;
+    //! \brief Optional true-width overlay for the currently visible range when the full preview uses thin lines.
+    QSharedPointer<GCodeObject> m_true_width_overlay_object;
 
     //! \brief m_meta_model tracks the states of the parts and their transformations
     QSharedPointer<PartMetaModel> m_meta_model;
@@ -230,6 +243,11 @@ class GCodeView : public BaseView {
         uint low_layer = 0;
         //! \brief Highest layer shown.
         uint high_layer = 1;
+
+        //! \brief Lowest segment shown inside the visible layer range.
+        uint low_segment = 0;
+        //! \brief Highest segment shown inside the visible layer range.
+        uint high_segment = std::numeric_limits<uint>::max();
 
         //! \brief If using the orthographic projection or not.
         bool ortho = false;
@@ -260,6 +278,27 @@ class GCodeView : public BaseView {
         //! \brief Hidden segment types.
         SegmentDisplayType hidden_type = SegmentDisplayType::kNone;
     } m_state;
+
+    //! \brief Cache key for the visible-range true-width overlay.
+    struct TrueWidthOverlayKey {
+        uint low_layer = 0;
+        uint high_layer = 0;
+        uint low_segment = 0;
+        uint high_segment = 0;
+        GCodePreviewMode preview_mode = GCodePreviewMode::kAuto;
+        int vertex_threshold = 0;
+        bool use_true_widths = false;
+
+        bool operator==(const TrueWidthOverlayKey& other) const {
+            return low_layer == other.low_layer && high_layer == other.high_layer &&
+                   low_segment == other.low_segment && high_segment == other.high_segment &&
+                   preview_mode == other.preview_mode && vertex_threshold == other.vertex_threshold &&
+                   use_true_widths == other.use_true_widths;
+        }
+    };
+
+    TrueWidthOverlayKey m_true_width_overlay_key;
+    bool m_true_width_overlay_key_valid = false;
 
     //! \brief Segment / Bead info display control
     QSharedPointer<GCodeInfoControl> m_segment_info_control;

--- a/include/graphics/view/gcode_view.h
+++ b/include/graphics/view/gcode_view.h
@@ -203,6 +203,11 @@ class GCodeView : public BaseView {
     //! \return Segment line number.
     uint pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeObject> gog);
 
+    //! \brief Picks the visible G-code segment, preferring the true-width overlay when it is active.
+    //! \param mouse_ndc_pos: Mouse normalized location.
+    //! \return Segment line number.
+    uint pickVisibleSegment(const QPointF& mouse_ndc_pos);
+
     //! \brief Refreshes camera-dependent segment info display.
     void updateSegmentInfoViewMatrix();
 

--- a/include/graphics/view/gcode_view.h
+++ b/include/graphics/view/gcode_view.h
@@ -180,6 +180,12 @@ class GCodeView : public BaseView {
     //! \brief Enables hover tracking only when the visible segment count is small enough for interactive picking.
     void updateHoverTracking();
 
+    //! \brief Removes ghosted part meshes from the G-code view.
+    void clearGhosts();
+
+    //! \brief Rebuilds ghosted part meshes when ghost display is enabled.
+    void rebuildGhosts();
+
     //! \brief Picks a segment based on the mouse position.
     //! \param mouse_ndc_pos: Mouse normalized location.
     //! \param gog: GCode object to search through.

--- a/include/managers/preferences_manager.h
+++ b/include/managers/preferences_manager.h
@@ -127,6 +127,12 @@ class PreferencesManager : public QObject {
     //! \return if true widths should be used
     bool getUseTrueWidthsPreference();
 
+    //! \brief Returns the preferred g-code preview rendering mode.
+    GCodePreviewMode getGCodePreviewModePreference();
+
+    //! \brief Returns the true-width preview vertex threshold.
+    int getGCodePreviewVertexThresholdPreference();
+
     //! \brief Return the user preference for warning about unsaved projects when closing
     bool getWarnUnsavedProjectOnClosePreference();
 
@@ -342,6 +348,18 @@ class PreferencesManager : public QObject {
     //! \param use if true widths should be used
     void setUseTrueWidthsPreference(bool use);
 
+    //! \brief Sets the preferred g-code preview rendering mode.
+    //! \param mode selected preview mode
+    void setGCodePreviewModePreference(GCodePreviewMode mode);
+
+    //! \brief Sets the preferred g-code preview rendering mode from a UI index.
+    //! \param mode selected preview mode as an integer
+    void setGCodePreviewModePreference(int mode);
+
+    //! \brief Sets the true-width preview vertex threshold.
+    //! \param threshold maximum estimated vertices to build for true-width preview
+    void setGCodePreviewVertexThresholdPreference(int threshold);
+
     //! \brief Sets the preference for warning about unsaved projects when closing
     void setWarnUnsavedProjectOnClosePreference(bool warn);
 
@@ -412,6 +430,8 @@ class PreferencesManager : public QObject {
     bool m_hide_travel_preference;
     bool m_hide_support_preference;
     bool m_use_true_widths_preference;
+    GCodePreviewMode m_gcode_preview_mode_preference;
+    int m_gcode_preview_vertex_threshold_preference;
     bool m_warn_unsaved_project_on_close_preference;
 
     //! \brief Preferences for window size and position

--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -665,6 +665,9 @@ enum class PreferenceChoice : uint8_t { kAsk = 0, kPerformAutomatically = 1, kSk
 /*!
  * \enum GCodePreviewMode
  * \brief Controls how g-code visualization chooses between true bead meshes and lightweight lines.
+ *
+ * Auto uses the configured vertex threshold. True Bead Widths honors the toolbar true-width request without applying the
+ * automatic threshold fallback. Thin Lines disables true-width previews.
  */
 enum class GCodePreviewMode : uint8_t {
     kAuto = 0,

--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -662,6 +662,28 @@ enum class ForceMinimumLayerTime : uint8_t { kUse_Purge_Dwells, kSlow_Feedrate }
 
 enum class PreferenceChoice : uint8_t { kAsk = 0, kPerformAutomatically = 1, kSkipAutomatically = 2 };
 
+/*!
+ * \enum GCodePreviewMode
+ * \brief Controls how g-code visualization chooses between true bead meshes and lightweight lines.
+ */
+enum class GCodePreviewMode : uint8_t {
+    kAuto = 0,
+    kTrueWidths = 1,
+    kThinLines = 2,
+};
+
+inline QString toString(GCodePreviewMode mode) {
+    switch (mode) {
+        case GCodePreviewMode::kTrueWidths:
+            return "True Bead Widths";
+        case GCodePreviewMode::kThinLines:
+            return "Thin Lines";
+        case GCodePreviewMode::kAuto:
+        default:
+            return "Auto";
+    }
+}
+
 enum class VisualizationColors {
     kBrim = 0,
     kCoasting,

--- a/include/windows/preferences_window.h
+++ b/include/windows/preferences_window.h
@@ -92,6 +92,8 @@ class PreferencesWindow : public QMainWindow {
     QComboBox* m_mass_unit_combobox;
     QComboBox* m_rotation_unit_combobox;
     QComboBox* m_theme_combobox;
+    QComboBox* m_gcode_preview_mode_combobox;
+    QSpinBox* m_gcode_preview_vertex_threshold_spinbox;
     QCheckBox* m_warn_unsaved_project_on_close_checkbox;
 
     //! \brief List of groupboxes that hold radio buttons for various preferences

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -60,6 +60,20 @@ bool hasMeshSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode)
     return false;
 }
 
+//! @brief Counts travel segments before GL buffer construction so their secondary line buffer can be preallocated.
+qsizetype countTravelSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
+    qsizetype count = 0;
+    for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
+        for (const QSharedPointer<SegmentBase>& segment : layer) {
+            if (static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) {
+                ++count;
+            }
+        }
+    }
+
+    return count;
+}
+
 //! @brief Estimates vertices required if printable segments are expanded to true-width bead meshes.
 qsizetype estimateMeshVertexCount(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
     qsizetype count = 0;
@@ -135,6 +149,21 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
     m_primary_render_mode = (m_lightweight_lines || !hasMeshSegments(gcode)) ? GL_LINES : GL_TRIANGLES;
 
     if (m_lightweight_lines) {
+        primary_vertices.reserve(segment_count * 2 * 3);
+        primary_normals.reserve(segment_count * 2 * 3);
+        primary_colors.reserve(segment_count * 2 * 4);
+    }
+    else if (m_primary_render_mode == GL_TRIANGLES) {
+        primary_vertices.reserve(mesh_vertex_count * 3);
+        primary_normals.reserve(mesh_vertex_count * 3);
+        primary_colors.reserve(mesh_vertex_count * 4);
+
+        const qsizetype travel_segment_count = countTravelSegments(gcode);
+        travel_line_vertices.reserve(travel_segment_count * 2 * 3);
+        travel_line_normals.reserve(travel_segment_count * 2 * 3);
+        travel_line_colors.reserve(travel_segment_count * 2 * 4);
+    }
+    else {
         primary_vertices.reserve(segment_count * 2 * 3);
         primary_normals.reserve(segment_count * 2 * 3);
         primary_colors.reserve(segment_count * 2 * 4);

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -28,12 +28,6 @@
 
 namespace ORNL {
 namespace {
-//! @brief Segment count where full bead mesh visualization is likely to exceed practical GL buffer sizes.
-constexpr qsizetype kLightweightLineThreshold = 1000000;
-
-//! @brief Estimated mesh vertices where true-width bead rendering becomes too expensive for interactive loading.
-constexpr qsizetype kLightweightMeshVertexThreshold = 5000000;
-
 //! @brief Vertex counts emitted by ShapeFactory for each full bead mesh segment type.
 constexpr qsizetype kLinearBeadVertexCount = 120;
 constexpr qsizetype kCurvedBeadVertexCount = 2376;
@@ -74,32 +68,6 @@ qsizetype countTravelSegments(const QVector<QVector<QSharedPointer<SegmentBase>>
     return count;
 }
 
-//! @brief Estimates vertices required if printable segments are expanded to true-width bead meshes.
-qsizetype estimateMeshVertexCount(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
-    qsizetype count = 0;
-    for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
-        for (const QSharedPointer<SegmentBase>& segment : layer) {
-            if (static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) {
-                continue;
-            }
-
-            if (dynamic_cast<ArcSegment*>(segment.data()) != nullptr ||
-                dynamic_cast<BezierSegment*>(segment.data()) != nullptr) {
-                count += kCurvedBeadVertexCount;
-            }
-            else {
-                count += kLinearBeadVertexCount;
-            }
-
-            if (count > kLightweightMeshVertexThreshold) {
-                return count;
-            }
-        }
-    }
-
-    return count;
-}
-
 //! @brief Appends a single GL_LINES segment using the parser's display-space line representation.
 void appendLightweightLine(const QSharedPointer<SegmentBase>& segment, std::vector<float>& vertices,
                            std::vector<float>& normals, std::vector<float>& colors) {
@@ -130,8 +98,36 @@ void appendLightweightLine(const QSharedPointer<SegmentBase>& segment, std::vect
 }
 } // namespace
 
+qsizetype GCodeObject::estimateTrueWidthVertexCount(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode,
+                                                    qsizetype limit) {
+    qsizetype count = 0;
+    for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
+        for (const QSharedPointer<SegmentBase>& segment : layer) {
+            if (static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) {
+                continue;
+            }
+
+            if (dynamic_cast<ArcSegment*>(segment.data()) != nullptr ||
+                dynamic_cast<BezierSegment*>(segment.data()) != nullptr) {
+                count += kCurvedBeadVertexCount;
+            }
+            else {
+                count += kLinearBeadVertexCount;
+            }
+
+            if (count > limit) {
+                return count;
+            }
+        }
+    }
+
+    return count;
+}
+
 GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentBase>>> gcode,
-                         QSharedPointer<GCodeInfoControl> segmentInfoControl, bool use_true_widths) {
+                         QSharedPointer<GCodeInfoControl> segmentInfoControl, bool use_true_widths,
+                         GCodePreviewMode preview_mode, qsizetype true_width_vertex_threshold,
+                         bool update_segment_info) {
     std::vector<float> primary_vertices;
     std::vector<float> primary_normals;
     std::vector<float> primary_colors;
@@ -140,12 +136,17 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
     std::vector<float> travel_line_colors;
 
     m_segment_info_control = segmentInfoControl;
-    m_segment_info_control->setGCode(gcode);
+    m_updates_segment_info = update_segment_info;
+    if (m_updates_segment_info && !m_segment_info_control.isNull()) {
+        m_segment_info_control->setGCode(gcode);
+    }
 
     const qsizetype segment_count = countSegments(gcode);
-    const qsizetype mesh_vertex_count = use_true_widths ? estimateMeshVertexCount(gcode) : 0;
-    m_lightweight_lines = !use_true_widths || segment_count > kLightweightLineThreshold ||
-                          mesh_vertex_count > kLightweightMeshVertexThreshold;
+    const qsizetype vertex_threshold = true_width_vertex_threshold < 0 ? 0 : true_width_vertex_threshold;
+    const bool true_widths_requested = use_true_widths && preview_mode != GCodePreviewMode::kThinLines;
+    const qsizetype mesh_vertex_count =
+        true_widths_requested ? estimateTrueWidthVertexCount(gcode, vertex_threshold) : 0;
+    m_lightweight_lines = !true_widths_requested || mesh_vertex_count > vertex_threshold;
     m_primary_render_mode = (m_lightweight_lines || !hasMeshSegments(gcode)) ? GL_LINES : GL_TRIANGLES;
 
     if (m_lightweight_lines) {
@@ -358,7 +359,9 @@ void GCodeObject::selectSegment(uint line_number) {
                 this->paintSegment(seg, QColor(Qt::yellow));
                 m_selected_segments.insert(line_number, seg);
 
-                m_segment_info_control->addSegmentInfo(line_number);
+                if (m_updates_segment_info && !m_segment_info_control.isNull()) {
+                    m_segment_info_control->addSegmentInfo(line_number);
+                }
                 return;
             }
         }
@@ -373,7 +376,9 @@ void GCodeObject::deselectSegment(uint line_number) {
         seg_meta->current_color = seg_meta->original_color;
         this->paintSegment(seg_meta, seg_meta->original_color);
 
-        m_segment_info_control->removeSegmentInfo(line_number);
+        if (m_updates_segment_info && !m_segment_info_control.isNull()) {
+            m_segment_info_control->removeSegmentInfo(line_number);
+        }
     }
 }
 
@@ -385,7 +390,9 @@ QList<int> GCodeObject::deselectAll() {
         this->paintSegment(seg_meta, seg_meta->original_color);
         lines_to_remove.push_back(seg_meta->line - 1);
 
-        m_segment_info_control->removeSegmentInfo(seg_meta->line);
+        if (m_updates_segment_info && !m_segment_info_control.isNull()) {
+            m_segment_info_control->removeSegmentInfo(seg_meta->line);
+        }
     }
     m_selected_segments.clear();
     return lines_to_remove;
@@ -437,6 +444,8 @@ uint GCodeObject::visibleSegmentCount() {
 }
 
 bool GCodeObject::isCurrentlySelected(int line_num) { return m_selected_segments.contains(line_num); }
+
+bool GCodeObject::isLightweight() const { return m_lightweight_lines; }
 
 const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriangles() {
     QVector<std::pair<uint, std::vector<Triangle>>> ret;

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -3,6 +3,7 @@
 #include <GL/gl.h>
 
 #include <cstring>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -144,9 +145,13 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
     const qsizetype segment_count = countSegments(gcode);
     const qsizetype vertex_threshold = true_width_vertex_threshold < 0 ? 0 : true_width_vertex_threshold;
     const bool true_widths_requested = use_true_widths && preview_mode != GCodePreviewMode::kThinLines;
+    const bool auto_threshold_limited = preview_mode != GCodePreviewMode::kTrueWidths;
+    const qsizetype estimate_limit =
+        auto_threshold_limited ? vertex_threshold : std::numeric_limits<qsizetype>::max();
     const qsizetype mesh_vertex_count =
-        true_widths_requested ? estimateTrueWidthVertexCount(gcode, vertex_threshold) : 0;
-    m_lightweight_lines = !true_widths_requested || mesh_vertex_count > vertex_threshold;
+        true_widths_requested ? estimateTrueWidthVertexCount(gcode, estimate_limit) : 0;
+    m_lightweight_lines =
+        !true_widths_requested || (auto_threshold_limited && mesh_vertex_count > vertex_threshold);
     m_primary_render_mode = (m_lightweight_lines || !hasMeshSegments(gcode)) ? GL_LINES : GL_TRIANGLES;
 
     if (m_lightweight_lines) {

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -36,7 +36,7 @@ constexpr qsizetype kLightweightMeshVertexThreshold = 5000000;
 
 //! @brief Vertex counts emitted by ShapeFactory for each full bead mesh segment type.
 constexpr qsizetype kLinearBeadVertexCount = 120;
-constexpr qsizetype kCurvedBeadVertexCount = 9120;
+constexpr qsizetype kCurvedBeadVertexCount = 2376;
 
 //! @brief Counts display segments before GL buffer construction so oversized gcode can use a lighter path.
 qsizetype countSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
@@ -117,7 +117,7 @@ void appendLightweightLine(const QSharedPointer<SegmentBase>& segment, std::vect
 } // namespace
 
 GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentBase>>> gcode,
-                         QSharedPointer<GCodeInfoControl> segmentInfoControl) {
+                         QSharedPointer<GCodeInfoControl> segmentInfoControl, bool use_true_widths) {
     std::vector<float> primary_vertices;
     std::vector<float> primary_normals;
     std::vector<float> primary_colors;
@@ -129,9 +129,9 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
     m_segment_info_control->setGCode(gcode);
 
     const qsizetype segment_count = countSegments(gcode);
-    const qsizetype mesh_vertex_count = estimateMeshVertexCount(gcode);
-    m_lightweight_lines =
-        segment_count > kLightweightLineThreshold || mesh_vertex_count > kLightweightMeshVertexThreshold;
+    const qsizetype mesh_vertex_count = use_true_widths ? estimateMeshVertexCount(gcode) : 0;
+    m_lightweight_lines = !use_true_widths || segment_count > kLightweightLineThreshold ||
+                          mesh_vertex_count > kLightweightMeshVertexThreshold;
     m_primary_render_mode = (m_lightweight_lines || !hasMeshSegments(gcode)) ? GL_LINES : GL_TRIANGLES;
 
     if (m_lightweight_lines) {

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -25,8 +25,8 @@ constexpr int kCylinderSegments = 50;
 constexpr int kConeSlices = 50;
 constexpr int kSphereMinSectorCount = 3;
 constexpr int kSphereMinStackCount = 2;
-constexpr int kTubeCrossSectionResolution = 20;
-constexpr int kCurveSegments = 75;
+constexpr int kTubeCrossSectionResolution = 12;
+constexpr int kCurveSegments = 32;
 constexpr int kBuildVolumeCylinderSegments = 100;
 constexpr int kBuildVolumeVerticalLines = 6;
 

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -41,7 +41,15 @@ struct Rgba {
           b(static_cast<float>(color.blueF())), a(static_cast<float>(color.alphaF())) {}
 };
 
-void reserveAdditional(std::vector<float>& values, std::size_t count) { values.reserve(values.size() + count); }
+void reserveAdditional(std::vector<float>& values, std::size_t count) {
+    const std::size_t required_capacity = values.size() + count;
+    if (required_capacity <= values.capacity()) {
+        return;
+    }
+
+    const std::size_t grown_capacity = values.capacity() == 0 ? required_capacity : values.capacity() * 2;
+    values.reserve(std::max(required_capacity, grown_capacity));
+}
 
 void reserveTriangleMesh(std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals,
                          std::size_t triangle_count) {

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -1,5 +1,6 @@
 #include "graphics/view/gcode_view.h"
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <tuple>
@@ -140,6 +141,14 @@ void GCodeView::useOrthographic(bool ortho) {
 
 void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     clearGhosts();
+    clearTrueWidthOverlay();
+    if (!m_gcode_object.isNull()) {
+        m_printer->orphanChild(m_gcode_object);
+        m_gcode_object.reset();
+    }
+
+    m_true_width_overlay_key_valid = false;
+    m_gcode = gcode;
 
     if (m_state.ortho) {
         m_state.zoom_factor = 1.0f;
@@ -147,20 +156,36 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     }
 
     if (gcode.isEmpty()) {
-        m_printer->orphanChild(m_gcode_object);
         m_gcode_object = nullptr;
     }
     else {
+        if (m_state.low_layer >= gcode.size()) {
+            m_state.low_layer = gcode.size() - 1;
+        }
         if (m_state.high_layer >= gcode.size()) {
             m_state.high_layer = gcode.size() - 1;
         }
+        if (m_state.high_layer < m_state.low_layer) {
+            m_state.high_layer = m_state.low_layer;
+        }
 
+        QSharedPointer<PreferencesManager> preferences = PreferencesManager::getInstance();
         m_gcode_object = QSharedPointer<GCodeObject>::create(this, gcode, m_segment_info_control,
-                                                             m_use_true_segment_widths);
+                                                             m_use_true_segment_widths,
+                                                             preferences->getGCodePreviewModePreference(),
+                                                             preferences->getGCodePreviewVertexThresholdPreference());
         m_gcode_object->showLayers(m_state.low_layer, m_state.high_layer);
+        if (m_state.high_segment != std::numeric_limits<uint>::max()) {
+            const uint max_segment = m_gcode_object->visibleSegmentCount();
+            if (max_segment > 0) {
+                const uint high_segment = std::min(m_state.high_segment, max_segment - 1);
+                m_gcode_object->showSegments(std::min(m_state.low_segment, high_segment), high_segment);
+            }
+        }
         m_gcode_object->hideSegmentType(m_state.hidden_type, true);
 
         m_printer->adoptChild(m_gcode_object);
+        refreshTrueWidthOverlay();
     }
     updateHoverTracking();
 
@@ -169,7 +194,6 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     }
 
     this->update();
-    m_gcode = gcode;
     updateSegmentInfoViewMatrix();
 }
 
@@ -255,6 +279,9 @@ void GCodeView::hideSegmentType(SegmentDisplayType type, bool hidden) {
         return;
 
     m_gcode_object->hideSegmentType(type, hidden);
+    if (!m_true_width_overlay_object.isNull()) {
+        m_true_width_overlay_object->hideSegmentType(type, hidden);
+    }
 
     this->update();
 }
@@ -298,6 +325,107 @@ void GCodeView::rebuildGhosts() {
     }
 }
 
+void GCodeView::clearTrueWidthOverlay() {
+    if (!m_true_width_overlay_object.isNull()) {
+        if (!m_gcode_object.isNull()) {
+            m_gcode_object->orphanChild(m_true_width_overlay_object);
+        }
+        m_true_width_overlay_object.reset();
+    }
+}
+
+QVector<QVector<QSharedPointer<SegmentBase>>> GCodeView::visiblePrintableGCodeSubset() const {
+    QVector<QVector<QSharedPointer<SegmentBase>>> subset;
+    if (m_gcode.isEmpty()) {
+        return subset;
+    }
+
+    const uint low_layer = std::min(m_state.low_layer, static_cast<uint>(m_gcode.size() - 1));
+    const uint high_layer = std::min(m_state.high_layer, static_cast<uint>(m_gcode.size() - 1));
+    if (low_layer > high_layer) {
+        return subset;
+    }
+
+    const uint high_segment = m_state.high_segment == std::numeric_limits<uint>::max()
+                                  ? std::numeric_limits<uint>::max()
+                                  : std::max(m_state.low_segment, m_state.high_segment);
+    uint visible_segment_index = 0;
+
+    for (uint layer_index = low_layer; layer_index <= high_layer; ++layer_index) {
+        QVector<QSharedPointer<SegmentBase>> layer_subset;
+        const QVector<QSharedPointer<SegmentBase>>& layer = m_gcode[layer_index];
+        layer_subset.reserve(layer.size());
+
+        for (const QSharedPointer<SegmentBase>& segment : layer) {
+            const bool in_segment_range =
+                visible_segment_index >= m_state.low_segment && visible_segment_index <= high_segment;
+            if (in_segment_range && !static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) {
+                layer_subset.push_back(segment);
+            }
+
+            ++visible_segment_index;
+        }
+
+        if (!layer_subset.isEmpty()) {
+            subset.push_back(layer_subset);
+        }
+    }
+
+    return subset;
+}
+
+void GCodeView::refreshTrueWidthOverlay() {
+    if (m_gcode_object.isNull() || !m_gcode_object->isLightweight() || !m_use_true_segment_widths) {
+        clearTrueWidthOverlay();
+        m_true_width_overlay_key_valid = false;
+        return;
+    }
+
+    QSharedPointer<PreferencesManager> preferences = PreferencesManager::getInstance();
+    const GCodePreviewMode preview_mode = preferences->getGCodePreviewModePreference();
+    const int vertex_threshold = preferences->getGCodePreviewVertexThresholdPreference();
+
+    TrueWidthOverlayKey key;
+    key.low_layer = m_state.low_layer;
+    key.high_layer = m_state.high_layer;
+    key.low_segment = m_state.low_segment;
+    key.high_segment = m_state.high_segment;
+    key.preview_mode = preview_mode;
+    key.vertex_threshold = vertex_threshold;
+    key.use_true_widths = m_use_true_segment_widths;
+
+    if (m_true_width_overlay_key_valid && key == m_true_width_overlay_key) {
+        return;
+    }
+
+    clearTrueWidthOverlay();
+    m_true_width_overlay_key = key;
+    m_true_width_overlay_key_valid = true;
+
+    if (preview_mode == GCodePreviewMode::kThinLines) {
+        return;
+    }
+
+    QVector<QVector<QSharedPointer<SegmentBase>>> visible_gcode = visiblePrintableGCodeSubset();
+    if (visible_gcode.isEmpty()) {
+        return;
+    }
+
+    const qsizetype estimated_vertices =
+        GCodeObject::estimateTrueWidthVertexCount(visible_gcode, static_cast<qsizetype>(vertex_threshold));
+    if (estimated_vertices > vertex_threshold) {
+        return;
+    }
+
+    m_true_width_overlay_object = QSharedPointer<GCodeObject>::create(
+        this, visible_gcode, m_segment_info_control, true, GCodePreviewMode::kTrueWidths, vertex_threshold, false);
+    if (m_state.hidden_type != SegmentDisplayType::kNone) {
+        m_true_width_overlay_object->hideSegmentType(m_state.hidden_type, true);
+    }
+    m_true_width_overlay_object->setOnTop(true);
+    m_gcode_object->adoptChild(m_true_width_overlay_object);
+}
+
 void GCodeView::updateSegmentWidths(bool use_true_width) {
     clear();
     m_use_true_segment_widths = use_true_width;
@@ -339,15 +467,25 @@ void GCodeView::handleLeftClick(QPointF mouse_ndc_pos) {
 
     uint picked_line_num = this->pickSegment(mouse_ndc_pos, m_gcode_object);
 
-    if (picked_line_num == 0)
+    if (picked_line_num == 0) {
+        if (!m_true_width_overlay_object.isNull()) {
+            m_true_width_overlay_object->deselectAll();
+        }
         emit updateSelectedSegments(QList<int>(), m_gcode_object->deselectAll());
+    }
     else {
         if (m_gcode_object->isCurrentlySelected(picked_line_num)) {
             m_gcode_object->deselectSegment(picked_line_num);
+            if (!m_true_width_overlay_object.isNull()) {
+                m_true_width_overlay_object->deselectSegment(picked_line_num);
+            }
             emit updateSelectedSegments(QList<int>(), QList<int> {(int)picked_line_num - 1});
         }
         else {
             m_gcode_object->selectSegment(picked_line_num);
+            if (!m_true_width_overlay_object.isNull()) {
+                m_true_width_overlay_object->selectSegment(picked_line_num);
+            }
             emit updateSelectedSegments(QList<int> {(int)picked_line_num - 1}, QList<int> {});
         }
     }
@@ -391,6 +529,9 @@ void GCodeView::handleMouseMove(QPointF mouse_ndc_pos) {
     uint picked_line_num = this->pickSegment(mouse_ndc_pos, m_gcode_object);
 
     m_gcode_object->highlightSegment(picked_line_num);
+    if (!m_true_width_overlay_object.isNull()) {
+        m_true_width_overlay_object->highlightSegment(picked_line_num);
+    }
 
     this->update();
 }
@@ -592,7 +733,8 @@ void GCodeView::setLowLayer(uint low_layer) {
     uint segment_count = m_gcode_object->visibleSegmentCount();
     updateHoverTracking();
 
-    emit maxSegmentChanged(segment_count - 1);
+    emit maxSegmentChanged(segment_count == 0 ? 0 : segment_count - 1);
+    refreshTrueWidthOverlay();
 
     this->update();
 }
@@ -607,7 +749,8 @@ void GCodeView::setHighLayer(uint high_layer) {
     uint segment_count = m_gcode_object->visibleSegmentCount();
     updateHoverTracking();
 
-    emit maxSegmentChanged(segment_count - 1);
+    emit maxSegmentChanged(segment_count == 0 ? 0 : segment_count - 1);
+    refreshTrueWidthOverlay();
 
     this->update();
 }
@@ -617,8 +760,10 @@ void GCodeView::setLowSegment(uint low_segment) {
         return;
 
     m_gcode_object->showLowSegment(low_segment);
+    m_state.low_segment = low_segment;
 
     updateHoverTracking();
+    refreshTrueWidthOverlay();
 
     this->update();
 }
@@ -628,8 +773,10 @@ void GCodeView::setHighSegment(uint high_segment) {
         return;
 
     m_gcode_object->showHighSegment(high_segment);
+    m_state.high_segment = high_segment;
 
     updateHoverTracking();
+    refreshTrueWidthOverlay();
 
     this->update();
 }
@@ -638,16 +785,27 @@ void GCodeView::updateSegments(QList<int> linesToAdd, QList<int> linesToRemove) 
     if (m_gcode_object.isNull())
         return;
 
-    for (int line_num : linesToAdd)
+    for (int line_num : linesToAdd) {
         m_gcode_object->selectSegment(line_num + 1);
+        if (!m_true_width_overlay_object.isNull()) {
+            m_true_width_overlay_object->selectSegment(line_num + 1);
+        }
+    }
 
-    for (int line_num : linesToRemove)
+    for (int line_num : linesToRemove) {
         m_gcode_object->deselectSegment(line_num + 1);
+        if (!m_true_width_overlay_object.isNull()) {
+            m_true_width_overlay_object->deselectSegment(line_num + 1);
+        }
+    }
 
     this->update();
 }
 
 void GCodeView::clear() {
+    clearTrueWidthOverlay();
+    m_true_width_overlay_key_valid = false;
+
     if (!m_gcode_object.isNull()) {
         m_printer->orphanChild(m_gcode_object);
         m_gcode_object.reset();

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -426,6 +426,21 @@ void GCodeView::refreshTrueWidthOverlay() {
     m_gcode_object->adoptChild(m_true_width_overlay_object);
 }
 
+uint GCodeView::pickVisibleSegment(const QPointF& mouse_ndc_pos) {
+    if (!m_true_width_overlay_object.isNull()) {
+        const uint overlay_line_num = this->pickSegment(mouse_ndc_pos, m_true_width_overlay_object);
+        if (overlay_line_num != 0) {
+            return overlay_line_num;
+        }
+    }
+
+    if (m_gcode_object.isNull()) {
+        return 0;
+    }
+
+    return this->pickSegment(mouse_ndc_pos, m_gcode_object);
+}
+
 void GCodeView::updateSegmentWidths(bool use_true_width) {
     clear();
     m_use_true_segment_widths = use_true_width;
@@ -465,7 +480,7 @@ void GCodeView::handleLeftClick(QPointF mouse_ndc_pos) {
     if (m_gcode_object.isNull())
         return;
 
-    uint picked_line_num = this->pickSegment(mouse_ndc_pos, m_gcode_object);
+    uint picked_line_num = this->pickVisibleSegment(mouse_ndc_pos);
 
     if (picked_line_num == 0) {
         if (!m_true_width_overlay_object.isNull()) {
@@ -515,6 +530,9 @@ void GCodeView::handleMouseMove(QPointF mouse_ndc_pos) {
         if (!m_gcode_object.isNull()) {
             m_gcode_object->highlightSegment(0);
         }
+        if (!m_true_width_overlay_object.isNull()) {
+            m_true_width_overlay_object->highlightSegment(0);
+        }
 
         this->setCursor(QCursor(Qt::OpenHandCursor));
         this->update();
@@ -526,7 +544,7 @@ void GCodeView::handleMouseMove(QPointF mouse_ndc_pos) {
     if (m_gcode_object.isNull())
         return;
 
-    uint picked_line_num = this->pickSegment(mouse_ndc_pos, m_gcode_object);
+    uint picked_line_num = this->pickVisibleSegment(mouse_ndc_pos);
 
     m_gcode_object->highlightSegment(picked_line_num);
     if (!m_true_width_overlay_object.isNull()) {

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -139,15 +139,7 @@ void GCodeView::useOrthographic(bool ortho) {
 }
 
 void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
-    // Adjust segment widths down if needed
-    if (!m_use_true_segment_widths) {
-        for (auto& layer : gcode) {
-            for (auto& segment : layer) {
-                segment->setDisplayWidth(segment->displayWidth() * 0.2f);
-                segment->setDisplayHeight(segment->displayHeight() * 0.2f);
-            }
-        }
-    }
+    clearGhosts();
 
     if (m_state.ortho) {
         m_state.zoom_factor = 1.0f;
@@ -163,7 +155,8 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
             m_state.high_layer = gcode.size() - 1;
         }
 
-        m_gcode_object = QSharedPointer<GCodeObject>::create(this, gcode, m_segment_info_control);
+        m_gcode_object = QSharedPointer<GCodeObject>::create(this, gcode, m_segment_info_control,
+                                                             m_use_true_segment_widths);
         m_gcode_object->showLayers(m_state.low_layer, m_state.high_layer);
         m_gcode_object->hideSegmentType(m_state.hidden_type, true);
 
@@ -171,26 +164,8 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     }
     updateHoverTracking();
 
-    // Clear out old ghosted parts
-    for (auto ghost : m_ghosted_parts) {
-        m_printer->orphanChild(ghost);
-    }
-    m_ghosted_parts.clear();
-
-    // Add ghosted parts
-    for (auto item : m_meta_model->items()) {
-        auto gop = QSharedPointer<PartObject>::create(this, item->part());
-        gop->setTransparency(item->transparency());
-
-        if (!m_state.showing_ghosts) {
-            gop->hide();
-        }
-
-        gop->setTransformation(item->transformation());
-        gop->translateAbsolute(QVector3D(item->translation().x(), item->translation().y(),
-                                         item->translation().z() + m_printer->minimum().z()));
-        m_printer->adoptChild(gop);
-        m_ghosted_parts[item] = gop;
+    if (m_state.showing_ghosts) {
+        rebuildGhosts();
     }
 
     this->update();
@@ -293,21 +268,41 @@ void GCodeView::updateHoverTracking() {
     this->setMouseTracking(m_gcode_object->visibleSegmentCount() <= kHoverTrackingSegmentLimit);
 }
 
+void GCodeView::clearGhosts() {
+    if (m_printer.isNull()) {
+        m_ghosted_parts.clear();
+        return;
+    }
+
+    for (auto ghost : m_ghosted_parts) {
+        m_printer->orphanChild(ghost);
+    }
+    m_ghosted_parts.clear();
+}
+
+void GCodeView::rebuildGhosts() {
+    if (m_meta_model.isNull() || m_printer.isNull()) {
+        return;
+    }
+
+    clearGhosts();
+
+    for (auto item : m_meta_model->items()) {
+        auto gop = QSharedPointer<PartObject>::create(this, item->part());
+        gop->setTransparency(item->transparency());
+        gop->setTransformation(item->transformation());
+        gop->translateAbsolute(QVector3D(item->translation().x(), item->translation().y(),
+                                         item->translation().z() + m_printer->minimum().z()));
+        m_printer->adoptChild(gop);
+        m_ghosted_parts[item] = gop;
+    }
+}
+
 void GCodeView::updateSegmentWidths(bool use_true_width) {
     clear();
     m_use_true_segment_widths = use_true_width;
 
-    // Adjust existing G-code
     if (!m_gcode.isEmpty()) {
-        // Adjust segment widths back up if needed
-        if (m_use_true_segment_widths) {
-            for (auto& layer : m_gcode) {
-                for (auto& segment : layer) {
-                    segment->setDisplayWidth(segment->displayWidth() * 5.0f);
-                    segment->setDisplayHeight(segment->displayHeight() * 5.0f);
-                }
-            }
-        }
         addGCode(m_gcode);
     }
 }
@@ -653,11 +648,12 @@ void GCodeView::updateSegments(QList<int> linesToAdd, QList<int> linesToRemove) 
 }
 
 void GCodeView::clear() {
-    if (m_gcode_object.isNull())
-        return;
+    if (!m_gcode_object.isNull()) {
+        m_printer->orphanChild(m_gcode_object);
+        m_gcode_object.reset();
+    }
 
-    m_printer->orphanChild(m_gcode_object);
-    m_gcode_object.reset();
+    clearGhosts();
 
     this->update();
 }
@@ -676,12 +672,19 @@ void GCodeView::setMeta(QSharedPointer<PartMetaModel> meta) {
 
 void GCodeView::showGhosts(bool show) {
     m_state.showing_ghosts = show;
-    for (auto ghost : m_ghosted_parts)
+    if (show && m_ghosted_parts.isEmpty()) {
+        rebuildGhosts();
+    }
+
+    for (auto ghost : m_ghosted_parts) {
         if (show) {
             ghost->show();
         }
         else
             ghost->hide();
+    }
+
+    this->update();
 }
 
 void GCodeView::resetCamera() {

--- a/src/managers/preferences_manager.cpp
+++ b/src/managers/preferences_manager.cpp
@@ -87,6 +87,7 @@ PreferencesManager::PreferencesManager()
       m_mass_unit(kg), m_project_shift_preference(PreferenceChoice::kAsk),
       m_file_shift_preference(PreferenceChoice::kPerformAutomatically), m_align_preference(PreferenceChoice::kAsk),
       m_hide_travel_preference(false), m_hide_support_preference(false), m_use_true_widths_preference(true),
+      m_gcode_preview_mode_preference(GCodePreviewMode::kAuto), m_gcode_preview_vertex_threshold_preference(5000000),
       m_warn_unsaved_project_on_close_preference(true), m_themeName(ThemeName::kLightMode),
       m_theme(static_cast<int>(m_themeName)), m_rotation_unit(RotationUnit::kPitchRollYaw), m_dirty(false),
       m_is_maximized(false), m_window_size(-1, -1), m_window_pos(-1, -1), m_use_implicit_transforms(false),
@@ -233,6 +234,12 @@ void PreferencesManager::importPreferences(QString filepath) {
         if (j.contains("use_true_widths"))
             setUseTrueWidthsPreference(j["use_true_widths"]);
 
+        if (j.contains("gcode_preview_mode"))
+            setGCodePreviewModePreference(j["gcode_preview_mode"].get<int>());
+
+        if (j.contains("gcode_preview_vertex_threshold"))
+            setGCodePreviewVertexThresholdPreference(j["gcode_preview_vertex_threshold"].get<int>());
+
         if (j.contains("warn_unsaved_project_on_close"))
             setWarnUnsavedProjectOnClosePreference(j["warn_unsaved_project_on_close"]);
 
@@ -280,6 +287,8 @@ fifojson PreferencesManager::json() {
     j["hide_travel"] = m_hide_travel_preference;
     j["hide_support"] = m_hide_support_preference;
     j["use_true_widths"] = m_use_true_widths_preference;
+    j["gcode_preview_mode"] = static_cast<int>(m_gcode_preview_mode_preference);
+    j["gcode_preview_vertex_threshold"] = m_gcode_preview_vertex_threshold_preference;
     j["warn_unsaved_project_on_close"] = m_warn_unsaved_project_on_close_preference;
     j["hidden_settings"] = m_hidden_settings;
     j["rotation"] = m_rotation_unit;
@@ -350,6 +359,12 @@ bool PreferencesManager::getHideTravelPreference() { return m_hide_travel_prefer
 bool PreferencesManager::getHideSupportPreference() { return m_hide_support_preference; }
 
 bool PreferencesManager::getUseTrueWidthsPreference() { return m_use_true_widths_preference; }
+
+GCodePreviewMode PreferencesManager::getGCodePreviewModePreference() { return m_gcode_preview_mode_preference; }
+
+int PreferencesManager::getGCodePreviewVertexThresholdPreference() {
+    return m_gcode_preview_vertex_threshold_preference;
+}
 
 bool PreferencesManager::getWarnUnsavedProjectOnClosePreference() {
     return m_warn_unsaved_project_on_close_preference;
@@ -573,6 +588,30 @@ void PreferencesManager::setHideSupportPreference(bool hide) {
 
 void PreferencesManager::setUseTrueWidthsPreference(bool use) {
     m_use_true_widths_preference = use;
+    m_dirty = true;
+}
+
+void PreferencesManager::setGCodePreviewModePreference(GCodePreviewMode mode) {
+    switch (mode) {
+        case GCodePreviewMode::kAuto:
+        case GCodePreviewMode::kTrueWidths:
+        case GCodePreviewMode::kThinLines:
+            m_gcode_preview_mode_preference = mode;
+            break;
+        default:
+            m_gcode_preview_mode_preference = GCodePreviewMode::kAuto;
+            break;
+    }
+
+    m_dirty = true;
+}
+
+void PreferencesManager::setGCodePreviewModePreference(int mode) {
+    setGCodePreviewModePreference(static_cast<GCodePreviewMode>(mode));
+}
+
+void PreferencesManager::setGCodePreviewVertexThresholdPreference(int threshold) {
+    m_gcode_preview_vertex_threshold_preference = std::max(0, threshold);
     m_dirty = true;
 }
 

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -357,8 +357,12 @@ void GCodeLoader::run() {
                 layers.push_back(layer);
                 ++current_layer;
 
-                emit updateDialog(StatusUpdateStepType::kVisualization,
-                                  (double)current_layer / (double)total_layer * 100);
+                int visualization_progress = 99;
+                if (total_layer > 0) {
+                    visualization_progress =
+                        qMin(99, static_cast<int>((double)current_layer / (double)total_layer * 100.0));
+                }
+                emit updateDialog(StatusUpdateStepType::kVisualization, visualization_progress);
 
                 if (m_should_cancel) {
                     return;
@@ -412,6 +416,7 @@ void GCodeLoader::run() {
                     ret = QFile::rename(tempFile.fileName(), m_filename);
                 }
             }
+            emit updateDialog(StatusUpdateStepType::kVisualization, 100);
         } catch (ExceptionBase& exception) {
             QString message = "Error parsing GCode: " + QString(exception.what());
             emit error(message);

--- a/src/widgets/gcodebar.cpp
+++ b/src/widgets/gcodebar.cpp
@@ -46,9 +46,11 @@ void GcodeBar::updateGcodeText(QString text, QHash<QString, QTextCharFormat> fon
     m_view->setLayerFirstLineNumbers(m_layer_first_line_numbers);
     m_refresh_btn->setEnabled(false);
 
-    // preserve the last search. No harm if search string is empty
+    // Preserve the last search without running an empty-document search over large G-code files.
     m_search_count = 0;
-    search();
+    if (!m_search_bar->text().trimmed().isEmpty()) {
+        search();
+    }
 }
 
 void GcodeBar::clear() {

--- a/src/widgets/gcodehighlighter.cpp
+++ b/src/widgets/gcodehighlighter.cpp
@@ -10,6 +10,11 @@ GcodeHighlighter::GcodeHighlighter(QTextDocument* parent) : QSyntaxHighlighter(p
 
 void GcodeHighlighter::setColorRules(QHash<QString, QTextCharFormat> colorHash) { m_color_hash = colorHash; }
 
-void GcodeHighlighter::highlightBlock(const QString& text) { setFormat(0, text.length(), m_color_hash[text]); }
+void GcodeHighlighter::highlightBlock(const QString& text) {
+    const auto color = m_color_hash.constFind(text);
+    if (color != m_color_hash.constEnd()) {
+        setFormat(0, text.length(), color.value());
+    }
+}
 
 } // namespace ORNL

--- a/src/widgets/gcodetextboxwidget.cpp
+++ b/src/widgets/gcodetextboxwidget.cpp
@@ -323,6 +323,11 @@ void GcodeTextBoxWidget::search(QString searchString, int searchCount) {
     QTextDocument* document = this->document();
     document->undo();
 
+    if (searchString.isEmpty()) {
+        document->setModified(false);
+        return;
+    }
+
     QTextCursor highlightCursor(document);
     QTextCursor cursor(document);
 

--- a/src/windows/preferences_window.cpp
+++ b/src/windows/preferences_window.cpp
@@ -259,6 +259,9 @@ void PreferencesWindow::setupLayout() {
                                            static_cast<int>(GCodePreviewMode::kTrueWidths));
     m_gcode_preview_mode_combobox->addItem(toString(GCodePreviewMode::kThinLines),
                                            static_cast<int>(GCodePreviewMode::kThinLines));
+    m_gcode_preview_mode_combobox->setToolTip(
+        "Auto uses the vertex threshold. True Bead Widths bypasses it when the toolbar toggle is enabled. Thin Lines "
+        "disables true-width previews.");
     int previewModeIndex = m_gcode_preview_mode_combobox->findData(
         static_cast<int>(PreferencesManager::getInstance()->getGCodePreviewModePreference()));
     m_gcode_preview_mode_combobox->setCurrentIndex(std::max(0, previewModeIndex));

--- a/src/windows/preferences_window.cpp
+++ b/src/windows/preferences_window.cpp
@@ -1,5 +1,7 @@
 #include "windows/preferences_window.h"
 
+#include <algorithm>
+
 #include <QFileDialog>
 #include <QGridLayout>
 #include <QLabel>
@@ -243,6 +245,47 @@ void PreferencesWindow::setupLayout() {
 
     parts_tab_layout->setRowStretch(3, 1);
 
+    // Visualization tab
+    QWidget* visualizationWidget = new QWidget(m_tab_widget);
+    m_tab_widget->addTab(visualizationWidget, "Visualization");
+
+    QGridLayout* visualization_tab_layout = new QGridLayout();
+    visualizationWidget->setLayout(visualization_tab_layout);
+
+    m_gcode_preview_mode_combobox = new QComboBox();
+    m_gcode_preview_mode_combobox->addItem(toString(GCodePreviewMode::kAuto),
+                                           static_cast<int>(GCodePreviewMode::kAuto));
+    m_gcode_preview_mode_combobox->addItem(toString(GCodePreviewMode::kTrueWidths),
+                                           static_cast<int>(GCodePreviewMode::kTrueWidths));
+    m_gcode_preview_mode_combobox->addItem(toString(GCodePreviewMode::kThinLines),
+                                           static_cast<int>(GCodePreviewMode::kThinLines));
+    int previewModeIndex = m_gcode_preview_mode_combobox->findData(
+        static_cast<int>(PreferencesManager::getInstance()->getGCodePreviewModePreference()));
+    m_gcode_preview_mode_combobox->setCurrentIndex(std::max(0, previewModeIndex));
+
+    visualization_tab_layout->addWidget(new QLabel("G-code preview mode:"), 0, 0, Qt::AlignTop);
+    visualization_tab_layout->addWidget(m_gcode_preview_mode_combobox, 0, 1, Qt::AlignTop);
+
+    m_gcode_preview_vertex_threshold_spinbox = new QSpinBox();
+    m_gcode_preview_vertex_threshold_spinbox->setMinimum(0);
+    m_gcode_preview_vertex_threshold_spinbox->setMaximum(50000000);
+    m_gcode_preview_vertex_threshold_spinbox->setSingleStep(100000);
+    m_gcode_preview_vertex_threshold_spinbox->setValue(
+        PreferencesManager::getInstance()->getGCodePreviewVertexThresholdPreference());
+    m_gcode_preview_vertex_threshold_spinbox->setToolTip(
+        "Maximum estimated vertices to build for true bead width previews");
+
+    visualization_tab_layout->addWidget(new QLabel("True-width vertex threshold:"), 1, 0, Qt::AlignTop);
+    visualization_tab_layout->addWidget(m_gcode_preview_vertex_threshold_spinbox, 1, 1, Qt::AlignTop);
+    visualization_tab_layout->setRowStretch(2, 1);
+
+    connect(m_gcode_preview_mode_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this] {
+        PreferencesManager::getInstance()->setGCodePreviewModePreference(
+            m_gcode_preview_mode_combobox->currentData().toInt());
+    });
+    connect(m_gcode_preview_vertex_threshold_spinbox, QOverload<int>::of(&QSpinBox::valueChanged),
+            PreferencesManager::getInstance().get(), &PreferencesManager::setGCodePreviewVertexThresholdPreference);
+
     // Visualization Colors tab
     QScrollArea* scrollArea = new QScrollArea(m_tab_widget);
     scrollArea->setWidgetResizable(true);
@@ -416,6 +459,11 @@ void PreferencesWindow::importPreferences() {
         m_mass_unit_combobox->setCurrentText(m_preferences_manager->getMassUnitText());
         m_voltage_unit_combobox->setCurrentText(m_preferences_manager->getVoltageUnitText());
         m_rotation_unit_combobox->setCurrentText(m_preferences_manager->getRotationUnitText());
+        int previewModeIndex = m_gcode_preview_mode_combobox->findData(
+            static_cast<int>(m_preferences_manager->getGCodePreviewModePreference()));
+        m_gcode_preview_mode_combobox->setCurrentIndex(std::max(0, previewModeIndex));
+        m_gcode_preview_vertex_threshold_spinbox->setValue(
+            m_preferences_manager->getGCodePreviewVertexThresholdPreference());
 
         setPreferenceValue(m_boxes[0], m_preferences_manager->getProjectShiftPreference());
         setPreferenceValue(m_boxes[1], m_preferences_manager->getAlignPreference());


### PR DESCRIPTION
## Summary

This PR improves G-code visualization performance and control for large segment counts while preserving quick true-width toggling.

## What changed

- Avoid expensive full-file true bead mesh construction when the estimated preview geometry exceeds the configured threshold.
- Add a configurable G-code preview mode preference: Auto, True Bead Widths, or Thin Lines.
- Add a configurable true-width vertex threshold in Preferences > Visualization.
- Keep the existing True Bead Widths checkbox as a quick on/off request for true-width rendering.
- For large G-code files, keep the full preview lightweight and build a true-width overlay only for the currently visible printable layer/segment range when it is under the threshold.
- Cache the visible-range overlay key so unchanged layer/segment windows do not rebuild unnecessarily.
- Reduce first-visualization stalls by preallocating preview buffers, avoiding empty text searches, and only reporting visualization complete after queued UI updates are issued.

## Why

Visualization was the final step of slicing and could appear stuck at 99-100%, especially on first load or when large objects triggered costly true-width mesh decisions. The old lightweight fallback also meant large files could not inspect true bead widths even for a small visible layer range.

## Impact

- Large G-code files should load into visualization using lightweight lines instead of freezing while constructing full true-width geometry.
- Users can tune the threshold that decides when true-width geometry is allowed.
- Users can still toggle true bead widths quickly from the G-code bar.
- Single-layer or small visible-range inspection can show true bead widths even when the full file is too large for full true-width rendering.

## Validation

- `nix develop --command cmake --build build/generic-llvm-ninja`
- `nix develop --command build/generic-llvm-ninja/Debug/ornlslicer --input_project_file /home/rhc/develop/SpiralCylinder.s2p --output_location /tmp/SpiralCylinderVizTest`
- `git diff --check`