### PR TITLE
Arc Fitting

### DIFF
--- a/include/geometry/path.h
+++ b/include/geometry/path.h
@@ -12,6 +12,7 @@ namespace ORNL {
 class Polygon;
 class PolygonList;
 class Polyline;
+class SettingsBase;
 
 /*!
  * \class Path
@@ -107,6 +108,9 @@ class Path {
 
     //! \brief remove only travel segments from path
     void removeTravels();
+
+    //! \brief Replaces eligible line runs with circular arc segments.
+    void fitCircularArcs(const QSharedPointer<SettingsBase>& fallback_settings);
 
     //! \brief Checks whether path is closed
     //! \return Whether path is closed

--- a/include/step/layer/island/island_base.h
+++ b/include/step/layer/island/island_base.h
@@ -95,6 +95,9 @@ class IslandBase {
     //! \param previousRegions: chain of regions visited to allow cross-island and cross-layer transitions
     void calculateMultiMaterialTransitions(QVector<QSharedPointer<RegionBase>>& previousRegions);
 
+    //! \brief Fits eligible planar line segments in this island to G2/G3 arcs.
+    void fitCircularArcs(const QSharedPointer<SettingsBase>& global_sb);
+
   protected:
     //! \brief Geometry of island.
     PolygonList m_geometry;

--- a/include/step/layer/regions/region_base.h
+++ b/include/step/layer/regions/region_base.h
@@ -101,6 +101,9 @@ class RegionBase {
     //! \param next_material_number: material number to set for transition segments
     void calculateMultiMaterialTransition(Distance& transition_distance, int next_material_number);
 
+    //! \brief Fits eligible planar line segments to G2/G3 arcs.
+    void fitCircularArcs(const QSharedPointer<SettingsBase>& global_sb);
+
     //! \brief Sets whether last region was spiralized or not (path optimizer needs this info)
     //! \param spiral: whether or not last region was spiralized
     void setLastSpiral(bool spiral);

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -801,6 +801,9 @@ class Constants {
             static const QString kEnableOversize;
             static const QString kOversizeDistance;
             static const QString kEnableWidthHeight;
+            static const QString kEnableArcFitting;
+            static const QString kArcFittingTolerance;
+            static const QString kArcFittingMinimumSegmentCount;
         };
 
         class Optimizations {

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -5683,8 +5683,8 @@
   "arc_fitting": {
       "display":"Enable Arc Fitting",
       "type":"boolean",
-      "tooltip":"Fits eligible planar print moves to circular G2/G3 arcs when the selected machine supports G2/G3.",
-      "depends":{"AND":[{"supports_G2_3":true},{"slicing_mode":0}]},
+      "tooltip":"Fits eligible planar print moves to circular G2/G3 arcs when the selected machine and syntax support G2/G3.",
+      "depends":{"AND":[{"supports_G2_3":true},{"AND":[{"slicing_mode":0},{"AND":[{"NOT":[{"syntax":13}]},{"NOT":[{"syntax":29}]}]}]}]},
       "options":"",
       "default":false,
       "minor":"Special Modes",

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -5680,6 +5680,45 @@
       "symbol":"kSmoothingTolerance",
       "local":false
   },
+  "arc_fitting": {
+      "display":"Enable Arc Fitting",
+      "type":"boolean",
+      "tooltip":"Fits eligible planar print moves to circular G2/G3 arcs when the selected machine supports G2/G3.",
+      "depends":{"AND":[{"supports_G2_3":true},{"slicing_mode":0}]},
+      "options":"",
+      "default":false,
+      "minor":"Special Modes",
+      "major":"Profile",
+      "namespace":"Profile::SpecialModes",
+      "symbol":"kEnableArcFitting",
+      "local":true
+  },
+  "arc_fitting_tolerance": {
+      "display":"Arc Fitting Tolerance",
+      "type":"distance",
+      "tooltip":"Maximum radial deviation allowed when replacing a run of line segments with a circular arc.",
+      "depends":{"arc_fitting":true},
+      "options":"",
+      "default":50,
+      "minor":"Special Modes",
+      "major":"Profile",
+      "namespace":"Profile::SpecialModes",
+      "symbol":"kArcFittingTolerance",
+      "local":true
+  },
+  "arc_fitting_minimum_segment_count": {
+      "display":"Minimum Arc Fitting Segments",
+      "type":"positive_int",
+      "tooltip":"Minimum number of consecutive line segments required before arc fitting can replace them with one G2/G3 move.",
+      "depends":{"arc_fitting":true},
+      "options":"",
+      "default":3,
+      "minor":"Special Modes",
+      "major":"Profile",
+      "namespace":"Profile::SpecialModes",
+      "symbol":"kArcFittingMinimumSegmentCount",
+      "local":true
+  },
   "enable_spiralize_mode": {
       "display":"Enable Spiralize Mode",
       "type":"boolean",

--- a/resources/settings/029_profile_special_modes.yaml
+++ b/resources/settings/029_profile_special_modes.yaml
@@ -41,6 +41,42 @@ settings:
     namespace: "Profile::SpecialModes"
     symbol: "kSmoothingTolerance"
     local: false
+  - name: "arc_fitting"
+    display: "Enable Arc Fitting"
+    type: "boolean"
+    tooltip: "Fits eligible planar print moves to circular G2/G3 arcs when the selected machine supports G2/G3."
+    depends: {"AND":[{"supports_G2_3":true},{"slicing_mode":0}]}
+    options: []
+    default: false
+    minor: "Special Modes"
+    major: "Profile"
+    namespace: "Profile::SpecialModes"
+    symbol: "kEnableArcFitting"
+    local: true
+  - name: "arc_fitting_tolerance"
+    display: "Arc Fitting Tolerance"
+    type: "distance"
+    tooltip: "Maximum radial deviation allowed when replacing a run of line segments with a circular arc."
+    depends: {"arc_fitting":true}
+    options: []
+    default: 50
+    minor: "Special Modes"
+    major: "Profile"
+    namespace: "Profile::SpecialModes"
+    symbol: "kArcFittingTolerance"
+    local: true
+  - name: "arc_fitting_minimum_segment_count"
+    display: "Minimum Arc Fitting Segments"
+    type: "positive_int"
+    tooltip: "Minimum number of consecutive line segments required before arc fitting can replace them with one G2/G3 move."
+    depends: {"arc_fitting":true}
+    options: []
+    default: 3
+    minor: "Special Modes"
+    major: "Profile"
+    namespace: "Profile::SpecialModes"
+    symbol: "kArcFittingMinimumSegmentCount"
+    local: true
   - name: "enable_spiralize_mode"
     display: "Enable Spiralize Mode"
     type: "boolean"

--- a/resources/settings/029_profile_special_modes.yaml
+++ b/resources/settings/029_profile_special_modes.yaml
@@ -44,8 +44,8 @@ settings:
   - name: "arc_fitting"
     display: "Enable Arc Fitting"
     type: "boolean"
-    tooltip: "Fits eligible planar print moves to circular G2/G3 arcs when the selected machine supports G2/G3."
-    depends: {"AND":[{"supports_G2_3":true},{"slicing_mode":0}]}
+    tooltip: "Fits eligible planar print moves to circular G2/G3 arcs when the selected machine and syntax support G2/G3."
+    depends: {"AND":[{"supports_G2_3":true},{"AND":[{"slicing_mode":0},{"AND":[{"NOT":[{"syntax":13}]},{"NOT":[{"syntax":29}]}]}]}]}
     options: []
     default: false
     minor: "Special Modes"

--- a/src/geometry/path.cpp
+++ b/src/geometry/path.cpp
@@ -34,6 +34,8 @@ struct CircleFit {
     bool ccw = false;
 };
 
+enum class ArcFitResult { kInvalid, kNeedsMoreSweep, kValid };
+
 double normalizedAngleDelta(double delta) {
     while (delta <= -kPi)
         delta += 2.0 * kPi;
@@ -199,20 +201,20 @@ bool fitCircle(const QVector<Point>& points, CircleFit& fit) {
     return std::isfinite(fit.radius);
 }
 
-bool validateArcFit(const QVector<Point>& points, double tolerance, CircleFit& fit) {
+ArcFitResult validateArcFit(const QVector<Point>& points, double tolerance, CircleFit& fit) {
     const double allowed_error = std::max(tolerance, kNumericalTolerance);
     const float reference_z = points.front().z();
     for (const Point& point : points) {
         if (std::abs(point.z() - reference_z) > kPlanarZTolerance)
-            return false;
+            return ArcFitResult::kInvalid;
 
         const double point_radius = std::hypot(point.x() - fit.center.x(), point.y() - fit.center.y());
         if (std::abs(point_radius - fit.radius) > allowed_error)
-            return false;
+            return ArcFitResult::kInvalid;
     }
 
     if (points.front().distance(points.back()) <= kNumericalTolerance)
-        return false;
+        return ArcFitResult::kInvalid;
 
     double sweep = 0.0;
     int direction = 0;
@@ -229,7 +231,7 @@ bool validateArcFit(const QVector<Point>& points, double tolerance, CircleFit& f
         if (direction == 0)
             direction = delta_direction;
         else if (direction != delta_direction)
-            return false;
+            return ArcFitResult::kInvalid;
 
         sweep += delta;
     }
@@ -237,13 +239,25 @@ bool validateArcFit(const QVector<Point>& points, double tolerance, CircleFit& f
     fit.sweep = std::abs(sweep);
     fit.ccw = sweep > 0.0;
 
-    return direction != 0 && fit.sweep >= kMinimumArcSweep && fit.sweep <= kMaximumArcSweep;
+    if (direction == 0)
+        return ArcFitResult::kInvalid;
+
+    if (fit.sweep < kMinimumArcSweep)
+        return ArcFitResult::kNeedsMoreSweep;
+
+    if (fit.sweep > kMaximumArcSweep)
+        return ArcFitResult::kInvalid;
+
+    return ArcFitResult::kValid;
 }
 
-bool tryFitArc(const QList<QSharedPointer<SegmentBase>>& segments, int begin, int end, double tolerance,
-               CircleFit& fit) {
+ArcFitResult tryFitArc(const QList<QSharedPointer<SegmentBase>>& segments, int begin, int end, double tolerance,
+                       CircleFit& fit) {
     const QVector<Point> points = collectPoints(segments, begin, end);
-    return fitCircle(points, fit) && validateArcFit(points, tolerance, fit);
+    if (!fitCircle(points, fit))
+        return ArcFitResult::kInvalid;
+
+    return validateArcFit(points, tolerance, fit);
 }
 
 QSharedPointer<ArcSegment> createArcSegment(const QSharedPointer<SegmentBase>& source, const Point& start,
@@ -407,8 +421,10 @@ void Path::fitCircularArcs(const QSharedPointer<SettingsBase>& fallback_settings
 
             for (int candidate_end = run_index + minimum_segments; candidate_end <= run_end; ++candidate_end) {
                 CircleFit candidate_fit;
-                if (!tryFitArc(m_segments, run_index, candidate_end, tolerance(), candidate_fit)) {
-                    if (best_end >= 0)
+                const ArcFitResult fit_result =
+                    tryFitArc(m_segments, run_index, candidate_end, tolerance(), candidate_fit);
+                if (fit_result != ArcFitResult::kValid) {
+                    if (best_end >= 0 || fit_result == ArcFitResult::kInvalid)
                         break;
 
                     continue;

--- a/src/geometry/path.cpp
+++ b/src/geometry/path.cpp
@@ -1,5 +1,7 @@
 #include "geometry/path.h"
 
+#include <algorithm>
+#include <cmath>
 #include <limits>
 
 #include <qcontainerfwd.h>
@@ -7,12 +9,254 @@
 #include <qquaternion.h>
 #include <qsharedpointer.h>
 
+#include "configs/settings_base.h"
 #include "geometry/polyline.h"
 #include "geometry/segment_base.h"
+#include "geometry/segments/arc.h"
+#include "geometry/segments/line.h"
 #include "geometry/segments/travel.h"
 #include "units/unit.h"
+#include "utilities/constants.h"
 
 namespace ORNL {
+namespace {
+constexpr double kNumericalTolerance = 1.0e-6;
+constexpr double kPlanarZTolerance = 1.0;
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kMinimumArcSweep = 5.0 * kPi / 180.0;
+constexpr double kMaximumArcSweep = kPi;
+constexpr int kDefaultMinimumArcSegments = 3;
+
+struct CircleFit {
+    Point center;
+    double radius = 0.0;
+    double sweep = 0.0;
+    bool ccw = false;
+};
+
+double normalizedAngleDelta(double delta) {
+    while (delta <= -kPi)
+        delta += 2.0 * kPi;
+    while (delta > kPi)
+        delta -= 2.0 * kPi;
+    return delta;
+}
+
+bool solve3x3(double matrix[3][4], double solution[3]) {
+    for (int column = 0; column < 3; ++column) {
+        int pivot_row = column;
+        double pivot_value = std::abs(matrix[column][column]);
+        for (int row = column + 1; row < 3; ++row) {
+            const double candidate = std::abs(matrix[row][column]);
+            if (candidate > pivot_value) {
+                pivot_value = candidate;
+                pivot_row = row;
+            }
+        }
+
+        if (pivot_value < kNumericalTolerance)
+            return false;
+
+        if (pivot_row != column) {
+            for (int i = column; i < 4; ++i)
+                std::swap(matrix[column][i], matrix[pivot_row][i]);
+        }
+
+        const double pivot = matrix[column][column];
+        for (int i = column; i < 4; ++i)
+            matrix[column][i] /= pivot;
+
+        for (int row = 0; row < 3; ++row) {
+            if (row == column)
+                continue;
+
+            const double scale = matrix[row][column];
+            for (int i = column; i < 4; ++i)
+                matrix[row][i] -= scale * matrix[column][i];
+        }
+    }
+
+    for (int i = 0; i < 3; ++i)
+        solution[i] = matrix[i][3];
+
+    return true;
+}
+
+void removeTransientSettings(fifojson& settings) {
+    if (!settings.is_array())
+        return;
+
+    for (auto& item : settings) {
+        if (item.is_object())
+            item.erase(SS::kIsRegionStartSegment.toStdString());
+    }
+}
+
+bool settingsCompatible(const QSharedPointer<SettingsBase>& lhs, const QSharedPointer<SettingsBase>& rhs) {
+    if (lhs == nullptr || rhs == nullptr)
+        return lhs == rhs;
+
+    fifojson lhs_json = lhs->json();
+    fifojson rhs_json = rhs->json();
+    removeTransientSettings(lhs_json);
+    removeTransientSettings(rhs_json);
+
+    return lhs_json == rhs_json;
+}
+
+QSharedPointer<SettingsBase> resolvedArcSettings(const QSharedPointer<SegmentBase>& segment,
+                                                 const QSharedPointer<SettingsBase>& fallback_settings) {
+    QSharedPointer<SettingsBase> segment_settings = segment->getSb();
+    if (segment_settings != nullptr && segment_settings->contains(PS::SpecialModes::kEnableArcFitting))
+        return segment_settings;
+
+    return fallback_settings;
+}
+
+bool lineEligibleForArcFitting(const QSharedPointer<SegmentBase>& segment,
+                               const QSharedPointer<SettingsBase>& fallback_settings) {
+    if (dynamic_cast<LineSegment*>(segment.data()) == nullptr)
+        return false;
+
+    if (!segment->isPrintingSegment())
+        return false;
+
+    QSharedPointer<SettingsBase> settings = resolvedArcSettings(segment, fallback_settings);
+    if (settings == nullptr || !settings->setting<bool>(PS::SpecialModes::kEnableArcFitting))
+        return false;
+
+    if (segment->length() <= 0)
+        return false;
+
+    return std::abs(segment->start().z() - segment->end().z()) <= kPlanarZTolerance;
+}
+
+QVector<Point> collectPoints(const QList<QSharedPointer<SegmentBase>>& segments, int begin, int end) {
+    QVector<Point> points;
+    points.reserve(end - begin + 1);
+    points.push_back(segments[begin]->start());
+
+    for (int i = begin; i < end; ++i)
+        points.push_back(segments[i]->end());
+
+    return points;
+}
+
+bool fitCircle(const QVector<Point>& points, CircleFit& fit) {
+    if (points.size() < 3)
+        return false;
+
+    double mean_x = 0.0;
+    double mean_y = 0.0;
+    for (const Point& point : points) {
+        mean_x += point.x();
+        mean_y += point.y();
+    }
+    mean_x /= static_cast<double>(points.size());
+    mean_y /= static_cast<double>(points.size());
+
+    double uu = 0.0;
+    double uv = 0.0;
+    double vv = 0.0;
+    double u = 0.0;
+    double v = 0.0;
+    double ur = 0.0;
+    double vr = 0.0;
+    double r = 0.0;
+
+    for (const Point& point : points) {
+        const double local_x = point.x() - mean_x;
+        const double local_y = point.y() - mean_y;
+        const double radius_squared = (local_x * local_x) + (local_y * local_y);
+
+        uu += local_x * local_x;
+        uv += local_x * local_y;
+        vv += local_y * local_y;
+        u += local_x;
+        v += local_y;
+        ur += local_x * radius_squared;
+        vr += local_y * radius_squared;
+        r += radius_squared;
+    }
+
+    double matrix[3][4] = {{uu, uv, u, -ur}, {uv, vv, v, -vr}, {u, v, static_cast<double>(points.size()), -r}};
+    double solution[3] = {0.0, 0.0, 0.0};
+    if (!solve3x3(matrix, solution))
+        return false;
+
+    const double center_x = mean_x - (solution[0] / 2.0);
+    const double center_y = mean_y - (solution[1] / 2.0);
+    const double center_local_x = center_x - mean_x;
+    const double center_local_y = center_y - mean_y;
+    const double radius_squared = (center_local_x * center_local_x) + (center_local_y * center_local_y) - solution[2];
+
+    if (radius_squared <= kNumericalTolerance)
+        return false;
+
+    fit.center = Point(center_x, center_y, points.front().z());
+    fit.radius = std::sqrt(radius_squared);
+
+    return std::isfinite(fit.radius);
+}
+
+bool validateArcFit(const QVector<Point>& points, double tolerance, CircleFit& fit) {
+    const double allowed_error = std::max(tolerance, kNumericalTolerance);
+    const float reference_z = points.front().z();
+    for (const Point& point : points) {
+        if (std::abs(point.z() - reference_z) > kPlanarZTolerance)
+            return false;
+
+        const double point_radius = std::hypot(point.x() - fit.center.x(), point.y() - fit.center.y());
+        if (std::abs(point_radius - fit.radius) > allowed_error)
+            return false;
+    }
+
+    if (points.front().distance(points.back()) <= kNumericalTolerance)
+        return false;
+
+    double sweep = 0.0;
+    int direction = 0;
+    for (int i = 1, end = points.size(); i < end; ++i) {
+        const double previous_angle =
+            std::atan2(points[i - 1].y() - fit.center.y(), points[i - 1].x() - fit.center.x());
+        const double current_angle = std::atan2(points[i].y() - fit.center.y(), points[i].x() - fit.center.x());
+        const double delta = normalizedAngleDelta(current_angle - previous_angle);
+
+        if (std::abs(delta) <= kNumericalTolerance)
+            continue;
+
+        const int delta_direction = delta > 0.0 ? 1 : -1;
+        if (direction == 0)
+            direction = delta_direction;
+        else if (direction != delta_direction)
+            return false;
+
+        sweep += delta;
+    }
+
+    fit.sweep = std::abs(sweep);
+    fit.ccw = sweep > 0.0;
+
+    return direction != 0 && fit.sweep >= kMinimumArcSweep && fit.sweep <= kMaximumArcSweep;
+}
+
+bool tryFitArc(const QList<QSharedPointer<SegmentBase>>& segments, int begin, int end, double tolerance,
+               CircleFit& fit) {
+    const QVector<Point> points = collectPoints(segments, begin, end);
+    return fitCircle(points, fit) && validateArcFit(points, tolerance, fit);
+}
+
+QSharedPointer<ArcSegment> createArcSegment(const QSharedPointer<SegmentBase>& source, const Point& start,
+                                            const Point& end, const CircleFit& fit) {
+    QSharedPointer<ArcSegment> arc = QSharedPointer<ArcSegment>::create(start, end, fit.center, Angle(fit.sweep),
+                                                                        fit.ccw);
+    QSharedPointer<SettingsBase> settings = QSharedPointer<SettingsBase>::create(*source->getSb());
+    arc->setSb(settings);
+
+    return arc;
+}
+} // namespace
+
 void Path::add(const QSharedPointer<SegmentBase>& ps) { m_segments.append(ps); }
 
 void Path::append(const QSharedPointer<SegmentBase>& ps) { m_segments.append(ps); }
@@ -122,6 +366,74 @@ void Path::removeTravels() {
         if (TravelSegment* ts = dynamic_cast<TravelSegment*>(m_segments[i].data()))
             m_segments.removeAt(i);
     }
+}
+
+void Path::fitCircularArcs(const QSharedPointer<SettingsBase>& fallback_settings) {
+    if (m_segments.size() < kDefaultMinimumArcSegments)
+        return;
+
+    QList<QSharedPointer<SegmentBase>> fitted_segments;
+    fitted_segments.reserve(m_segments.size());
+
+    int index = 0;
+    while (index < m_segments.size()) {
+        if (!lineEligibleForArcFitting(m_segments[index], fallback_settings)) {
+            fitted_segments.push_back(m_segments[index]);
+            ++index;
+            continue;
+        }
+
+        int run_end = index + 1;
+        while (run_end < m_segments.size() &&
+               lineEligibleForArcFitting(m_segments[run_end], fallback_settings) &&
+               m_segments[run_end - 1]->end() == m_segments[run_end]->start() &&
+               settingsCompatible(m_segments[run_end - 1]->getSb(), m_segments[run_end]->getSb())) {
+            ++run_end;
+        }
+
+        int run_index = index;
+        while (run_index < run_end) {
+            QSharedPointer<SettingsBase> settings = resolvedArcSettings(m_segments[run_index], fallback_settings);
+            Distance tolerance = settings->setting<Distance>(PS::SpecialModes::kArcFittingTolerance);
+            if (tolerance < 0)
+                tolerance = 0.0 * micron;
+
+            const int minimum_segments =
+                std::max(kDefaultMinimumArcSegments,
+                         settings->setting<int>(PS::SpecialModes::kArcFittingMinimumSegmentCount));
+
+            CircleFit best_fit;
+            int best_end = -1;
+
+            for (int candidate_end = run_index + minimum_segments; candidate_end <= run_end; ++candidate_end) {
+                CircleFit candidate_fit;
+                if (!tryFitArc(m_segments, run_index, candidate_end, tolerance(), candidate_fit)) {
+                    if (best_end >= 0)
+                        break;
+
+                    continue;
+                }
+
+                best_fit = candidate_fit;
+                best_end = candidate_end;
+            }
+
+            if (best_end >= 0) {
+                const Point start = m_segments[run_index]->start();
+                const Point end = m_segments[best_end - 1]->end();
+                fitted_segments.push_back(createArcSegment(m_segments[run_index], start, end, best_fit));
+                run_index = best_end;
+            }
+            else {
+                fitted_segments.push_back(m_segments[run_index]);
+                ++run_index;
+            }
+        }
+
+        index = run_end;
+    }
+
+    m_segments = fitted_segments;
 }
 
 bool Path::isClosed() { return m_segments.first()->start() == m_segments.last()->end(); }

--- a/src/step/global_layer.cpp
+++ b/src/step/global_layer.cpp
@@ -92,6 +92,9 @@ void GlobalLayer::calculateModifiers(QSharedPointer<SettingsBase> global_sb, Poi
             }
         }
     }
+
+    for (QSharedPointer<IslandBase> island : m_island_order)
+        island->fitCircularArcs(global_sb);
 }
 
 void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& start, int& start_index,

--- a/src/step/layer/island/island_base.cpp
+++ b/src/step/layer/island/island_base.cpp
@@ -262,4 +262,9 @@ void IslandBase::calculateMultiMaterialTransitions(QVector<QSharedPointer<Region
     }
 }
 
+void IslandBase::fitCircularArcs(const QSharedPointer<SettingsBase>& global_sb) {
+    for (QSharedPointer<RegionBase> region : m_regions)
+        region->fitCircularArcs(global_sb);
+}
+
 } // namespace ORNL

--- a/src/step/layer/layer.cpp
+++ b/src/step/layer/layer.cpp
@@ -337,6 +337,9 @@ void Layer::calculateModifiers(Point& currentLocation) {
             currentLocation = getIslands().last()->getRegions().last()->getPaths().last().back()->end();
         }
     }
+
+    for (QSharedPointer<IslandBase> island : getIslands())
+        island->fitCircularArcs(this->getSb());
 }
 
 void Layer::setSb(const QSharedPointer<SettingsBase>& sb) {

--- a/src/step/layer/regions/region_base.cpp
+++ b/src/step/layer/regions/region_base.cpp
@@ -1,6 +1,7 @@
 #include "step/layer/regions/region_base.h"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 
 #include <qcontainerfwd.h>
@@ -19,8 +20,27 @@
 #include "optimizers/optimization_anchor.h"
 #include "units/unit.h"
 #include "utilities/constants.h"
+#include "utilities/enums.h"
 
 namespace ORNL {
+namespace {
+bool planarArcFittingAllowed(const QSharedPointer<SettingsBase>& global_sb) {
+    if (global_sb == nullptr)
+        return false;
+
+    if (!global_sb->setting<bool>(PRS::MachineSetup::kSupportG3))
+        return false;
+
+    if (static_cast<SlicingMode>(global_sb->setting<int>(PS::Slicing::kSlicingMode)) != SlicingMode::kPlanar)
+        return false;
+
+    constexpr double kVectorTolerance = 1.0e-6;
+    return std::abs(global_sb->setting<float>(PS::Slicing::kSlicePlaneNormalX)) <= kVectorTolerance &&
+           std::abs(global_sb->setting<float>(PS::Slicing::kSlicePlaneNormalY)) <= kVectorTolerance &&
+           std::abs(global_sb->setting<float>(PS::Slicing::kSlicePlaneNormalZ) - 1.0f) <= kVectorTolerance;
+}
+} // namespace
+
 RegionBase::RegionBase(const QSharedPointer<SettingsBase>& sb, const int index,
                        const QVector<SettingsPolygon>& settings_polygons, PolygonList uncut_geometry)
     : m_sb(sb), m_index(index), m_settings_polygons(settings_polygons), m_uncut_geometry(uncut_geometry) {
@@ -138,6 +158,14 @@ void RegionBase::calculateMultiMaterialTransition(Distance& transition_distance,
         if (transition_distance <= 0)
             break;
     }
+}
+
+void RegionBase::fitCircularArcs(const QSharedPointer<SettingsBase>& global_sb) {
+    if (!planarArcFittingAllowed(global_sb))
+        return;
+
+    for (Path& path : m_paths)
+        path.fitCircularArcs(m_sb);
 }
 
 void RegionBase::setLastSpiral(bool spiral) { m_was_last_region_spiral = spiral; }

--- a/src/step/layer/regions/region_base.cpp
+++ b/src/step/layer/regions/region_base.cpp
@@ -24,11 +24,26 @@
 
 namespace ORNL {
 namespace {
+bool selectedSyntaxSupportsArcFitting(const QSharedPointer<SettingsBase>& global_sb) {
+    const GcodeSyntax syntax = global_sb->setting<GcodeSyntax>(PRS::MachineSetup::kSyntax);
+    switch (syntax) {
+        // These writers inherit WriterBase::writeArc(), which emits no motion.
+        case GcodeSyntax::kAdamantine:
+        case GcodeSyntax::kMVP:
+            return false;
+        default:
+            return true;
+    }
+}
+
 bool planarArcFittingAllowed(const QSharedPointer<SettingsBase>& global_sb) {
     if (global_sb == nullptr)
         return false;
 
     if (!global_sb->setting<bool>(PRS::MachineSetup::kSupportG3))
+        return false;
+
+    if (!selectedSyntaxSupportsArcFitting(global_sb))
         return false;
 
     if (static_cast<SlicingMode>(global_sb->setting<int>(PS::Slicing::kSlicingMode)) != SlicingMode::kPlanar)

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -738,6 +738,10 @@ const QString Constants::ProfileSettings::SpecialModes::kEnableFixModel = "enabl
 const QString Constants::ProfileSettings::SpecialModes::kEnableOversize = "oversize";
 const QString Constants::ProfileSettings::SpecialModes::kOversizeDistance = "oversize_distance";
 const QString Constants::ProfileSettings::SpecialModes::kEnableWidthHeight = "enable_width_height";
+const QString Constants::ProfileSettings::SpecialModes::kEnableArcFitting = "arc_fitting";
+const QString Constants::ProfileSettings::SpecialModes::kArcFittingTolerance = "arc_fitting_tolerance";
+const QString Constants::ProfileSettings::SpecialModes::kArcFittingMinimumSegmentCount =
+    "arc_fitting_minimum_segment_count";
 
 // Optimizations
 const QString Constants::ProfileSettings::Optimizations::kLayerOrdering = "layer_ordering";


### PR DESCRIPTION
## Summary
- Add planar slicer circular arc fitting support that emits G2/G3-ready path segments when geometry fits within configured tolerances.
- Wire arc fitting through layer, island, and region modifier paths, gated by G2/G3 machine support and planar slicing.
- Add arc fitting settings under Special Modes and regenerate master config.

## Verification
- `nix develop -c cmake --build build/generic-llvm-ninja`
- `git diff --check`