### PR TITLE
Set number of  object instances

### DIFF
--- a/include/widgets/part_widget/model/part_meta_item.h
+++ b/include/widgets/part_widget/model/part_meta_item.h
@@ -137,6 +137,12 @@ class PartMetaItem : public QObject, public QEnableSharedFromThis<PartMetaItem> 
     //! \brief Get the part pointer.
     QSharedPointer<Part> part();
 
+    //! \brief Gets the number of visible instances for this item.
+    int instanceCount();
+
+    //! \brief Sets the number of visible instances for this item.
+    void setInstanceCount(int count);
+
   signals:
     //! \brief Signal that this item was modified.
     void modified(PartMetaUpdateType type);

--- a/include/widgets/part_widget/model/part_meta_model.h
+++ b/include/widgets/part_widget/model/part_meta_model.h
@@ -57,6 +57,12 @@ class PartMetaModel : public QObject, public QEnableSharedFromThis<PartMetaModel
     //! \brief Pastes the previously copied items.
     void copySelection();
 
+    //! \brief Gets the number of items that are instances of this item.
+    int instanceCount(QSharedPointer<PartMetaItem> pm);
+
+    //! \brief Sets the number of items that are instances of this item.
+    void setInstanceCount(QSharedPointer<PartMetaItem> pm, int count);
+
   signals:
     //! \brief Signal that an item was added.
     void itemAddedUpdate(QSharedPointer<PartMetaItem> pm);
@@ -89,5 +95,8 @@ class PartMetaModel : public QObject, public QEnableSharedFromThis<PartMetaModel
 
     //! \brief Copied items.
     QList<QSharedPointer<PartMetaItem>> m_copied_list;
+
+    //! \brief Gets the items that are instances of the supplied item.
+    QList<QSharedPointer<PartMetaItem>> instanceItems(QSharedPointer<PartMetaItem> pm);
 };
 } // namespace ORNL

--- a/include/widgets/part_widget/right_click_menu.h
+++ b/include/widgets/part_widget/right_click_menu.h
@@ -51,6 +51,7 @@ class RightClickMenu : public QMenu {
     QAction* m_wireframe_action;
     QAction* m_solidwireframe_action;
     QAction* m_lock_part_action;
+    QAction* m_set_instances_action;
 
     //! \brief Menu to hold transparency
     QMenu* m_transparency_menu;

--- a/src/widgets/part_widget/model/part_meta_item.cpp
+++ b/src/widgets/part_widget/model/part_meta_item.cpp
@@ -216,5 +216,19 @@ uint PartMetaItem::scaleUnitIndex() { return m_scale_unit_index; }
 
 QSharedPointer<Part> PartMetaItem::part() { return m_part; }
 
+int PartMetaItem::instanceCount() {
+    if (m_model.isNull())
+        return 1;
+
+    return m_model->instanceCount(this->sharedFromThis());
+}
+
+void PartMetaItem::setInstanceCount(int count) {
+    if (m_model.isNull())
+        return;
+
+    m_model->setInstanceCount(this->sharedFromThis(), count);
+}
+
 void PartMetaItem::setModel(QSharedPointer<PartMetaModel> m) { m_model = m; }
 } // namespace ORNL

--- a/src/widgets/part_widget/model/part_meta_model.cpp
+++ b/src/widgets/part_widget/model/part_meta_model.cpp
@@ -1,6 +1,10 @@
 #include "widgets/part_widget/model/part_meta_model.h"
 
+#include <algorithm>
+#include <limits>
+
 #include <QStack>
+#include <QStringList>
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qmap.h>
@@ -16,6 +20,100 @@
 #include "widgets/part_widget/part_control/part_control_tree_item.h"
 
 namespace ORNL {
+namespace {
+const QString kCopySuffix = "_copy";
+
+QString instanceBaseName(const QString& name) {
+    const int copy_index = name.lastIndexOf(kCopySuffix);
+    if (copy_index < 0)
+        return name;
+
+    const QString suffix = name.mid(copy_index + kCopySuffix.size());
+    if (suffix.isEmpty())
+        return name.left(copy_index);
+
+    if (suffix.startsWith("_")) {
+        bool suffix_is_number = false;
+        suffix.mid(1).toUInt(&suffix_is_number);
+        if (suffix_is_number)
+            return name.left(copy_index);
+    }
+
+    return name;
+}
+
+bool isInstanceName(const QString& name, const QString& base_name) {
+    if (name == base_name)
+        return true;
+
+    const QString copy_name = base_name + kCopySuffix;
+    if (name == copy_name)
+        return true;
+
+    const QString numbered_copy_prefix = copy_name + "_";
+    if (!name.startsWith(numbered_copy_prefix))
+        return false;
+
+    bool suffix_is_number = false;
+    name.mid(numbered_copy_prefix.size()).toUInt(&suffix_is_number);
+    return suffix_is_number;
+}
+
+uint instanceSortIndex(const QString& name, const QString& base_name) {
+    if (name == base_name)
+        return 0;
+
+    const QString copy_name = base_name + kCopySuffix;
+    if (name == copy_name)
+        return 1;
+
+    const QString numbered_copy_prefix = copy_name + "_";
+    if (name.startsWith(numbered_copy_prefix)) {
+        bool suffix_is_number = false;
+        const uint suffix = name.mid(numbered_copy_prefix.size()).toUInt(&suffix_is_number);
+        if (suffix_is_number)
+            return suffix + 2;
+    }
+
+    return std::numeric_limits<uint>::max();
+}
+
+QString uniqueInstanceName(const QString& base_name, const QStringList& names) {
+    if (!names.contains(base_name))
+        return base_name;
+
+    const QString first_copy_name = base_name + kCopySuffix;
+    if (!names.contains(first_copy_name))
+        return first_copy_name;
+
+    uint count = 1;
+    QString name;
+    do {
+        name = first_copy_name + "_" + QString::number(count);
+        ++count;
+    } while (names.contains(name));
+
+    return name;
+}
+
+void setPartInstanceName(QSharedPointer<Part> part, const QString& name) {
+    if (part.isNull())
+        return;
+
+    part->setName(name);
+    if (!part->rootMesh().isNull())
+        part->rootMesh()->setName(name);
+}
+
+QSharedPointer<Part> copyPartInstance(QSharedPointer<Part> source, const QString& name) {
+    QSharedPointer<Part> copy = QSharedPointer<Part>::create(source);
+    copy->setTransformation(QMatrix4x4());
+    setPartInstanceName(copy, name);
+
+    return copy;
+}
+} // namespace
+
 PartMetaModel::PartMetaModel() {
     // NOP
 }
@@ -173,6 +271,7 @@ void PartMetaModel::copySelection() {
             p->setName(org_name + "_" + QString::number(count));
             count++;
         }
+        setPartInstanceName(p, p->name());
 
         result[pm] = p;
 
@@ -188,6 +287,70 @@ void PartMetaModel::copySelection() {
             continue;
         this->newItem(p);
     }
+}
+
+int PartMetaModel::instanceCount(QSharedPointer<PartMetaItem> pm) { return this->instanceItems(pm).size(); }
+
+void PartMetaModel::setInstanceCount(QSharedPointer<PartMetaItem> pm, int count) {
+    if (pm.isNull() || count < 1)
+        return;
+
+    QList<QSharedPointer<PartMetaItem>> instances = this->instanceItems(pm);
+    const QString base_name = instanceBaseName(pm->part()->name());
+
+    while (instances.size() > count) {
+        int remove_index = -1;
+        for (int i = instances.size() - 1; i >= 0; --i) {
+            if (instances.at(i) != pm) {
+                remove_index = i;
+                break;
+            }
+        }
+
+        if (remove_index < 0)
+            break;
+
+        QSharedPointer<PartMetaItem> item = instances.takeAt(remove_index);
+        this->removeItem(item);
+    }
+
+    if (instances.size() >= count)
+        return;
+
+    QStringList namelist;
+    for (auto& p : m_pointer_lookup.keys()) {
+        namelist.append(p->name());
+    }
+
+    while (instances.size() < count) {
+        const QString name = uniqueInstanceName(base_name, namelist);
+        QSharedPointer<Part> copy = copyPartInstance(pm->part(), name);
+
+        CSM->addPart(copy, false);
+        setPartInstanceName(copy, copy->name());
+        namelist.append(copy->name());
+        instances.append(this->newItem(copy));
+    }
+}
+
+QList<QSharedPointer<PartMetaItem>> PartMetaModel::instanceItems(QSharedPointer<PartMetaItem> pm) {
+    QList<QSharedPointer<PartMetaItem>> instances;
+    if (pm.isNull())
+        return instances;
+
+    const QString base_name = instanceBaseName(pm->part()->name());
+    for (auto& item : m_pointer_lookup.values()) {
+        if (isInstanceName(item->part()->name(), base_name))
+            instances.append(item);
+    }
+
+    std::sort(instances.begin(), instances.end(),
+              [base_name](const QSharedPointer<PartMetaItem>& lhs, const QSharedPointer<PartMetaItem>& rhs) {
+                  return instanceSortIndex(lhs->part()->name(), base_name) <
+                         instanceSortIndex(rhs->part()->name(), base_name);
+              });
+
+    return instances;
 }
 
 void PartMetaModel::itemUpdated(PartMetaItem::PartMetaUpdateType type) {

--- a/src/widgets/part_widget/right_click_menu.cpp
+++ b/src/widgets/part_widget/right_click_menu.cpp
@@ -1,6 +1,7 @@
 #include "widgets/part_widget/right_click_menu.h"
 
 #include <QFileDialog>
+#include <QInputDialog>
 #include <QLabel>
 #include <QWidgetAction>
 #include <qaction.h>
@@ -33,6 +34,7 @@ void RightClickMenu::setupActions() {
     m_reload_part_action = new QAction("Reload Part Model(s)", this);
     m_delete_part_action = new QAction("Delete Part(s)", this);
     m_lock_part_action = new QAction("Toggle Part Lock(s)", this);
+    m_set_instances_action = new QAction("Set Number of Instances", this);
 
     m_switch_to_clipper_action->setIcon(QIcon(":/icons/clip.png"));
     m_switch_to_build_action->setIcon(QIcon(":/icons/print_head.png"));
@@ -42,12 +44,14 @@ void RightClickMenu::setupActions() {
     m_reload_part_action->setIcon(QIcon(":/icons/file_refresh_black.png"));
     m_delete_part_action->setIcon(QIcon(":/icons/delete_black.png"));
     m_lock_part_action->setIcon(QIcon(":/icons/lock.png"));
+    m_set_instances_action->setIcon(QIcon(":/icons/copy_black.png"));
 
     this->addAction(m_switch_to_build_action);
     this->addAction(m_switch_to_clipper_action);
     this->addAction(m_switch_to_setting_action);
     this->addSeparator();
     this->addAction(m_lock_part_action);
+    this->addAction(m_set_instances_action);
     this->addAction(m_reset_transformation_action);
     this->addAction(m_replace_part_action);
     this->addAction(m_reload_part_action);
@@ -163,6 +167,19 @@ void RightClickMenu::setupEvents() {
             item->graphicsPart()->setLocked(!item->graphicsPart()->locked());
         }
     });
+    connect(m_set_instances_action, &QAction::triggered, this, [this]() {
+        if (m_selected_items.size() != 1)
+            return;
+
+        QSharedPointer<PartMetaItem> item = m_selected_items.first();
+        bool accepted = false;
+        const int current_count = item->instanceCount();
+        const int instance_count =
+            QInputDialog::getInt(this, "Set Number of Instances", "Instances:", current_count, 1, 1000, 1, &accepted);
+
+        if (accepted)
+            item->setInstanceCount(instance_count);
+    });
     connect(m_solidwireframe_action, &QAction::triggered, this, [this]() {
         for (auto item : m_selected_items) {
             // Solid wireframe and wireframe cannot both be active, uncheck the other
@@ -234,9 +251,11 @@ void RightClickMenu::disableActions() {
 
         if (m_selected_items.size() == 1) {
             m_replace_part_action->setDisabled(false);
+            m_set_instances_action->setDisabled(false);
         }
         else {
             m_replace_part_action->setDisabled(true);
+            m_set_instances_action->setDisabled(true);
         }
     }
     else {
@@ -248,6 +267,7 @@ void RightClickMenu::disableActions() {
         m_replace_part_action->setDisabled(true);
         m_reload_part_action->setDisabled(true);
         m_delete_part_action->setDisabled(true);
+        m_set_instances_action->setDisabled(true);
         m_transparency_menu->setDisabled(true);
         m_wireframe_action->setDisabled(true);
         m_solidwireframe_action->setDisabled(true);


### PR DESCRIPTION
## Summary
- Adds a right-click menu action for setting the number of instances for a selected object.
- Adds model-level instance counting, creation, and removal using the existing object copy naming pattern.
- Keeps copied part and mesh names aligned so session save/load paths see the expected names.

## Validation
- `nix develop -c cmake --build build/generic-llvm-ninja`
- `git diff --check`