### PR TITLE
Add minimum segment length settings

### DIFF
--- a/include/geometry/polyline.h
+++ b/include/geometry/polyline.h
@@ -95,6 +95,17 @@ class Polyline : public QVector<Point> {
      */
     Polyline simplify(Distance tol);
 
+    /*!
+     * \brief Collapses segments shorter than \p min_segment_length.
+     *
+     * \param min_segment_length Minimum allowed segment length. A value less than or equal to zero leaves the polyline
+     * unchanged.
+     * \param closed Whether to evaluate the segment from the final point back to the first point.
+     * \returns A cleaned polyline, or an empty polyline when the segment-length requirement cannot be met without
+     * degenerating the path.
+     */
+    Polyline removeShortSegments(Distance min_segment_length, bool closed = false) const;
+
     Polyline cleanPolygon(const Distance distance = 10);
 
     /*!

--- a/include/step/layer/regions/skin.h
+++ b/include/step/layer/regions/skin.h
@@ -82,6 +82,12 @@ class Skin : public RegionBase {
     void optimizeHelper(PolylineOrderOptimizer poo, bool supportsG3, Point& current_location, InfillPatterns pattern,
                         QVector<Polyline> lines, PolygonList geometry);
 
+    //! \brief Creates paths for the skin region using the selected pattern.
+    //! \param line polyline representing path
+    //! \param pattern selected pattern for the path
+    //! \return Polyline converted to path
+    Path createPath(Polyline line, InfillPatterns pattern);
+
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -611,6 +611,7 @@ class Constants {
             static const QString kExtruderSpeed;
             static const QString kExtrusionMultiplier;
             static const QString kMinPathLength;
+            static const QString kMinSegmentLength;
             static const QString kEnableLeadIn;
             static const QString kLeadInFirstLayerOnly;
             static const QString kEnableLeadInX;
@@ -631,6 +632,7 @@ class Constants {
             static const QString kExtruderSpeed;
             static const QString kExtrusionMultiplier;
             static const QString kMinPathLength;
+            static const QString kMinSegmentLength;
             static const QString kOverlap;
             static const QString kEnableSpiralInset;
         };
@@ -653,6 +655,7 @@ class Constants {
             static const QString kSkeletonAdaptMaxWidth;
             static const QString kSkeletonAdaptMaxWidthFilter;
             static const QString kMinPathLength;
+            static const QString kMinSegmentLength;
             static const QString kLeadInEnable;
             static const QString kLeadInDistance;
             static const QString kLeadInSpeed;
@@ -675,6 +678,7 @@ class Constants {
             static const QString kExtrusionMultiplier;
             static const QString kOverlap;
             static const QString kMinPathLength;
+            static const QString kMinSegmentLength;
             static const QString kInfillEnable;
             static const QString kInfillSteps;
             static const QString kInfillPattern;
@@ -701,6 +705,7 @@ class Constants {
             static const QString kCombineXLayers;
             static const QString kCombineLayerShift;
             static const QString kMinPathLength;
+            static const QString kMinSegmentLength;
         };
 
         class Support {
@@ -727,6 +732,7 @@ class Constants {
             static const QString kInterfaceRegion;
             static const QString kBaseLayers;
             static const QString kBaseExpansion;
+            static const QString kMinSegmentLength;
             static const QString kBaseRegion;
             static const QString kBridgeSuppression;
             static const QString kBridgeMaxLength;

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -3756,6 +3756,19 @@
       "symbol":"kMinimumPerimeterPathLength",
       "local":true
   },
+  "perimeter_minimum_segment_length": {
+      "display":"Minimum Perimeter Segment Length",
+      "type":"distance",
+      "tooltip":"Perimeter path segments shorter than this value are collapsed before extrusion paths are created",
+      "depends":{"perimeter":true},
+      "options":"",
+      "default":0,
+      "minor":"Perimeter",
+      "major":"Profile",
+      "namespace":"Profile::Perimeter",
+      "symbol":"kMinimumPerimeterSegmentLength",
+      "local":true
+  },
   "perimeter_lead_in": {
       "display":"Enable Perimeter Lead-In",
       "type":"boolean",
@@ -3949,6 +3962,19 @@
       "major":"Profile",
       "namespace":"Profile::Inset",
       "symbol":"kMinimumInsetPathLength",
+      "local":true
+  },
+  "inset_minimum_segment_length": {
+      "display":"Minimum Inset Segment Length",
+      "type":"distance",
+      "tooltip":"Inset path segments shorter than this value are collapsed before extrusion paths are created",
+      "depends":{"inset":true},
+      "options":"",
+      "default":0,
+      "minor":"Inset",
+      "major":"Profile",
+      "namespace":"Profile::Inset",
+      "symbol":"kMinimumInsetSegmentLength",
       "local":true
   },
   "inset_overlap_distance": {
@@ -4185,6 +4211,19 @@
       "symbol":"kMinimumPathLength",
       "local":true
   },
+  "skeleton_minimum_segment_length": {
+      "display":"Minimum Skeleton Segment Length",
+      "type":"distance",
+      "tooltip":"Skeleton path segments shorter than this value are collapsed before extrusion paths are created.",
+      "depends":{"skeleton":true},
+      "options":"",
+      "default":0,
+      "minor":"Skeleton",
+      "major":"Profile",
+      "namespace":"Profile::Skeleton",
+      "symbol":"kMinimumSkeletonSegmentLength",
+      "local":true
+  },
   "skeleton_prestart": {
       "display":"Enable Skeleton Prestart",
       "type":"boolean",
@@ -4417,6 +4456,19 @@
       "major":"Profile",
       "namespace":"Profile::Skin",
       "symbol":"kMinimumSkinPathLength",
+      "local":true
+  },
+  "skin_minimum_segment_length": {
+      "display":"Minimum Skin Segment Length",
+      "type":"distance",
+      "tooltip":"Skin path segments shorter than this value are collapsed before extrusion paths are created",
+      "depends":{"skin":true},
+      "options":"",
+      "default":0,
+      "minor":"Skin",
+      "major":"Profile",
+      "namespace":"Profile::Skin",
+      "symbol":"kMinimumSkinSegmentLength",
       "local":true
   },
   "skin_gradual_infill": {
@@ -4679,6 +4731,19 @@
       "symbol":"kMinimumInfillPathLength",
       "local":true
   },
+  "infill_minimum_segment_length": {
+      "display":"Minimum Infill Segment Length",
+      "type":"distance",
+      "tooltip":"Infill path segments shorter than this value are collapsed before extrusion paths are created",
+      "depends":{"infill":true},
+      "options":"",
+      "default":0,
+      "minor":"Infill",
+      "major":"Profile",
+      "namespace":"Profile::Infill",
+      "symbol":"kMinimumInfillSegmentLength",
+      "local":true
+  },
   "infill_maximum_path_length": {
       "display":"Maximum Infill Path Length",
       "type":"distance",
@@ -4898,6 +4963,19 @@
       "major":"Profile",
       "namespace":"Profile::Support",
       "symbol":"kSupportLineSpacing",
+      "local":true
+  },
+  "support_minimum_segment_length": {
+      "display":"Minimum Support Segment Length",
+      "type":"distance",
+      "tooltip":"Support path segments shorter than this value are collapsed before extrusion paths are created",
+      "depends":{"support":true},
+      "options":"",
+      "default":0,
+      "minor":"Support",
+      "major":"Profile",
+      "namespace":"Profile::Support",
+      "symbol":"kMinimumSupportSegmentLength",
       "local":true
   },
   "support_wall_contours": {

--- a/resources/settings/021_profile_perimeter.yaml
+++ b/resources/settings/021_profile_perimeter.yaml
@@ -100,6 +100,18 @@ settings:
     namespace: "Profile::Perimeter"
     symbol: "kMinimumPerimeterPathLength"
     local: true
+  - name: "perimeter_minimum_segment_length"
+    display: "Minimum Perimeter Segment Length"
+    type: "distance"
+    tooltip: "Perimeter path segments shorter than this value are collapsed before extrusion paths are created"
+    depends: {"perimeter":true}
+    options: []
+    default: 0
+    minor: "Perimeter"
+    major: "Profile"
+    namespace: "Profile::Perimeter"
+    symbol: "kMinimumPerimeterSegmentLength"
+    local: true
   - name: "perimeter_lead_in"
     display: "Enable Perimeter Lead-In"
     type: "boolean"

--- a/resources/settings/022_profile_inset.yaml
+++ b/resources/settings/022_profile_inset.yaml
@@ -85,6 +85,18 @@ settings:
     namespace: "Profile::Inset"
     symbol: "kMinimumInsetPathLength"
     local: true
+  - name: "inset_minimum_segment_length"
+    display: "Minimum Inset Segment Length"
+    type: "distance"
+    tooltip: "Inset path segments shorter than this value are collapsed before extrusion paths are created"
+    depends: {"inset":true}
+    options: []
+    default: 0
+    minor: "Inset"
+    major: "Profile"
+    namespace: "Profile::Inset"
+    symbol: "kMinimumInsetSegmentLength"
+    local: true
   - name: "inset_overlap_distance"
     display: "Inset Overlap Distance"
     type: "distance"

--- a/resources/settings/023_profile_skeleton.yaml
+++ b/resources/settings/023_profile_skeleton.yaml
@@ -199,6 +199,18 @@ settings:
     namespace: "Profile::Skeleton"
     symbol: "kMinimumPathLength"
     local: true
+  - name: "skeleton_minimum_segment_length"
+    display: "Minimum Skeleton Segment Length"
+    type: "distance"
+    tooltip: "Skeleton path segments shorter than this value are collapsed before extrusion paths are created."
+    depends: {"skeleton":true}
+    options: []
+    default: 0
+    minor: "Skeleton"
+    major: "Profile"
+    namespace: "Profile::Skeleton"
+    symbol: "kMinimumSkeletonSegmentLength"
+    local: true
   - name: "skeleton_prestart"
     display: "Enable Skeleton Prestart"
     type: "boolean"

--- a/resources/settings/024_profile_skin.yaml
+++ b/resources/settings/024_profile_skin.yaml
@@ -151,6 +151,18 @@ settings:
     namespace: "Profile::Skin"
     symbol: "kMinimumSkinPathLength"
     local: true
+  - name: "skin_minimum_segment_length"
+    display: "Minimum Skin Segment Length"
+    type: "distance"
+    tooltip: "Skin path segments shorter than this value are collapsed before extrusion paths are created"
+    depends: {"skin":true}
+    options: []
+    default: 0
+    minor: "Skin"
+    major: "Profile"
+    namespace: "Profile::Skin"
+    symbol: "kMinimumSkinSegmentLength"
+    local: true
   - name: "skin_gradual_infill"
     display: "Enable Gradual Infill Steps"
     type: "boolean"

--- a/resources/settings/025_profile_infill.yaml
+++ b/resources/settings/025_profile_infill.yaml
@@ -188,6 +188,18 @@ settings:
     namespace: "Profile::Infill"
     symbol: "kMinimumInfillPathLength"
     local: true
+  - name: "infill_minimum_segment_length"
+    display: "Minimum Infill Segment Length"
+    type: "distance"
+    tooltip: "Infill path segments shorter than this value are collapsed before extrusion paths are created"
+    depends: {"infill":true}
+    options: []
+    default: 0
+    minor: "Infill"
+    major: "Profile"
+    namespace: "Profile::Infill"
+    symbol: "kMinimumInfillSegmentLength"
+    local: true
   - name: "infill_maximum_path_length"
     display: "Maximum Infill Path Length"
     type: "distance"

--- a/resources/settings/026_profile_support.yaml
+++ b/resources/settings/026_profile_support.yaml
@@ -175,6 +175,18 @@ settings:
     namespace: "Profile::Support"
     symbol: "kSupportLineSpacing"
     local: true
+  - name: "support_minimum_segment_length"
+    display: "Minimum Support Segment Length"
+    type: "distance"
+    tooltip: "Support path segments shorter than this value are collapsed before extrusion paths are created"
+    depends: {"support":true}
+    options: []
+    default: 0
+    minor: "Support"
+    major: "Profile"
+    namespace: "Profile::Support"
+    symbol: "kMinimumSupportSegmentLength"
+    local: true
   - name: "support_wall_contours"
     display: "Support Wall Contours"
     type: "number"

--- a/src/geometry/polyline.cpp
+++ b/src/geometry/polyline.cpp
@@ -130,6 +130,83 @@ Polyline Polyline::simplify(Distance tol) {
     return simplified;
 }
 
+Polyline Polyline::removeShortSegments(Distance min_segment_length, bool closed) const {
+    if (min_segment_length <= 0 || size() < 2) {
+        return *this;
+    }
+
+    Polyline cleaned(*this);
+    const bool repeats_start = closed && cleaned.size() > 1 && cleaned.first() == cleaned.last();
+    if (repeats_start) {
+        cleaned.removeLast();
+    }
+
+    const int min_points = closed ? 3 : 2;
+    if (cleaned.size() < min_points) {
+        return Polyline();
+    }
+
+    auto pointAfter = [](int index, int point_count) { return (index + 1) % point_count; };
+    auto pointBefore = [](int index, int point_count) { return (index + point_count - 1) % point_count; };
+
+    auto replacementLength = [&](int remove_index) {
+        const int point_count = cleaned.size();
+        return cleaned[pointBefore(remove_index, point_count)].distance(cleaned[pointAfter(remove_index, point_count)]);
+    };
+
+    bool removed_point = true;
+    while (removed_point && cleaned.size() > min_points) {
+        removed_point = false;
+        const int segment_count = closed ? cleaned.size() : cleaned.size() - 1;
+
+        for (int segment_index = 0; segment_index < segment_count; ++segment_index) {
+            const int next_index = pointAfter(segment_index, cleaned.size());
+            if (cleaned[segment_index].distance(cleaned[next_index]) >= min_segment_length) {
+                continue;
+            }
+
+            int remove_index = next_index;
+            if (closed) {
+                remove_index =
+                    replacementLength(segment_index) <= replacementLength(next_index) ? segment_index : next_index;
+            }
+            else if (segment_index == 0) {
+                remove_index = next_index;
+            }
+            else if (next_index == cleaned.size() - 1) {
+                remove_index = segment_index;
+            }
+            else {
+                const Distance remove_segment_start_length = cleaned[segment_index - 1].distance(cleaned[next_index]);
+                const Distance remove_segment_end_length = cleaned[segment_index].distance(cleaned[next_index + 1]);
+                remove_index = remove_segment_start_length <= remove_segment_end_length ? segment_index : next_index;
+            }
+
+            cleaned.removeAt(remove_index);
+            removed_point = true;
+            break;
+        }
+    }
+
+    if (cleaned.size() < min_points) {
+        return Polyline();
+    }
+
+    const int segment_count = closed ? cleaned.size() : cleaned.size() - 1;
+    for (int segment_index = 0; segment_index < segment_count; ++segment_index) {
+        const int next_index = pointAfter(segment_index, cleaned.size());
+        if (cleaned[segment_index].distance(cleaned[next_index]) < min_segment_length) {
+            return Polyline();
+        }
+    }
+
+    if (repeats_start) {
+        cleaned.push_back(cleaned.first());
+    }
+
+    return cleaned;
+}
+
 Polygon Polyline::close() {
     Polygon ret(operator()());
     if (ret.back() == ret.front()) {

--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -201,6 +201,13 @@ void Infill::optimize(int layerNumber, Point& current_location, bool& shouldNext
 }
 
 Path Infill::createPath(Polyline line) {
+    const InfillPatterns pattern = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Infill::kPattern));
+    const bool is_closed_path = pattern == InfillPatterns::kConcentric;
+
+    line = line.removeShortSegments(m_sb->setting<Distance>(PS::Infill::kMinSegmentLength), is_closed_path);
+    if (line.size() < (is_closed_path ? 3 : 2)) {
+        return Path();
+    }
 
     Distance width = m_sb->setting<Distance>(PS::Infill::kBeadWidth);
     Distance height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
@@ -227,7 +234,7 @@ Path Infill::createPath(Polyline line) {
     }
 
     //! Creates closing segment if infill pattern is concentric
-    if (static_cast<InfillPatterns>(m_sb->setting<int>(PS::Infill::kPattern)) == InfillPatterns::kConcentric) {
+    if (is_closed_path) {
         QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(line.last(), line.first());
 
         segment->getSb()->setSetting(MS::Extruder::kInitialSpeed,

--- a/src/step/layer/regions/inset.cpp
+++ b/src/step/layer/regions/inset.cpp
@@ -78,6 +78,7 @@ void Inset::compute(uint layer_num) {
 
     Distance overlap = m_sb->setting<Distance>(PS::Inset::kOverlap);
     const Distance min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
+    const Distance min_segment_length = m_sb->setting<Distance>(PS::Inset::kMinSegmentLength);
 
     int ring_nr = 0;
     PolygonList path_line = m_geometry.offset(-beadWidth / 2);
@@ -90,7 +91,7 @@ void Inset::compute(uint layer_num) {
         QVector<Polygon> valid_path_lines;
 
         for (const Polygon& poly : path_line) {
-            Polyline line = toOpenPolyline(poly);
+            Polyline line = toOpenPolyline(poly).removeShortSegments(min_segment_length, true);
             if (!isValidInsetLine(line, min_path_length)) {
                 skipped_path_line = true;
                 continue;
@@ -258,6 +259,11 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 }
 
 Path Inset::createPath(Polyline line) {
+    line = line.removeShortSegments(m_sb->setting<Distance>(PS::Inset::kMinSegmentLength), true);
+    if (line.size() < 3) {
+        return Path();
+    }
+
     // ---------- No Settings Regions ----------
     if (m_settings_polygons.isEmpty()) {
         Path path;

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -40,11 +40,12 @@ bool isValidPerimeterLine(const Polyline& line, Distance min_path_length) {
 }
 
 QVector<Polygon> appendValidPathLines(const PolygonList& path_lines, QVector<Polyline>& computed_geometry,
-                                      Distance min_path_length, bool& skipped_path_line) {
+                                      Distance min_path_length, Distance min_segment_length,
+                                      bool& skipped_path_line) {
     QVector<Polygon> valid_path_lines;
 
     for (const Polygon& poly : path_lines) {
-        Polyline line = toOpenPolyline(poly);
+        Polyline line = toOpenPolyline(poly).removeShortSegments(min_segment_length, true);
         if (!isValidPerimeterLine(line, min_path_length)) {
             skipped_path_line = true;
             continue;
@@ -138,6 +139,7 @@ void Perimeter::compute(uint layer_num) {
     Distance beadWidth = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
     int perimeter_count = m_sb->setting<int>(PS::Perimeter::kCount);
     const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
+    const Distance min_segment_length = m_sb->setting<Distance>(PS::Perimeter::kMinSegmentLength);
     const PerimeterBoundarySelection boundary_selection =
         static_cast<PerimeterBoundarySelection>(m_sb->setting<int>(PS::Perimeter::kBoundarySelection));
 
@@ -150,7 +152,8 @@ void Perimeter::compute(uint layer_num) {
              ++perimeter_number) {
             bool skipped_path_line = false;
             QVector<Polygon> valid_path_lines =
-                appendValidPathLines(path_lines, m_computed_geometry, min_path_length, skipped_path_line);
+                appendValidPathLines(path_lines, m_computed_geometry, min_path_length, min_segment_length,
+                                     skipped_path_line);
 
             if (valid_path_lines.isEmpty()) {
                 break;
@@ -195,7 +198,7 @@ void Perimeter::compute(uint layer_num) {
 
         bool skipped_path_line = false;
         QVector<Polygon> valid_path_lines =
-            appendValidPathLines(path_lines, m_computed_geometry, min_path_length, skipped_path_line);
+            appendValidPathLines(path_lines, m_computed_geometry, min_path_length, min_segment_length, skipped_path_line);
 
         if (valid_path_lines.isEmpty()) {
             break;
@@ -388,6 +391,11 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 }
 
 Path Perimeter::createPath(Polyline line) {
+    line = line.removeShortSegments(m_sb->setting<Distance>(PS::Perimeter::kMinSegmentLength), true);
+    if (line.size() < 3) {
+        return Path();
+    }
+
     // ---------- No Settings Regions ----------
     if (m_settings_polygons.isEmpty()) {
         Path path;

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -272,6 +272,10 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 
             // Create path from polyline
             Path newPath = createPath(result);
+            if (newPath.size() == 0) {
+                return;
+            }
+
             newPath.setCCW(result.orientation()); // Set orientation of path
             newPath.getSegments().removeLast();   // Remove last segment of path to enable spiral path linking
 

--- a/src/step/layer/regions/skeleton.cpp
+++ b/src/step/layer/regions/skeleton.cpp
@@ -713,6 +713,11 @@ LSegmentList Skeleton::createSegments(const Point& start, const Point& end,
 }
 
 Path Skeleton::createPath(Polyline line) {
+    line = line.removeShortSegments(m_sb->setting<Distance>(PS::Skeleton::kMinSegmentLength));
+    if (line.size() < 2) {
+        return Path();
+    }
+
     // ---------- No Settings Regions ----------
     if (m_settings_polygons.isEmpty()) {
         Path path;

--- a/src/step/layer/regions/skin.cpp
+++ b/src/step/layer/regions/skin.cpp
@@ -35,13 +35,15 @@ PolygonList polylineFootprint(const Polyline& line, Distance bead_width, const P
     return footprint & clipping_geometry;
 }
 
-QVector<Polyline> printableLines(const QVector<Polyline>& lines, Distance min_path_length) {
+QVector<Polyline> printableLines(const QVector<Polyline>& lines, Distance min_path_length, Distance min_segment_length,
+                                 bool closed) {
     QVector<Polyline> printable;
     printable.reserve(lines.size());
 
     for (const Polyline& line : lines) {
-        if (line.size() > 1 && line.length() >= min_path_length)
-            printable.push_back(line);
+        Polyline cleaned_line = line.removeShortSegments(min_segment_length, closed);
+        if (cleaned_line.size() > (closed ? 2 : 1) && cleaned_line.length() >= min_path_length)
+            printable.push_back(cleaned_line);
     }
 
     return printable;
@@ -96,6 +98,7 @@ void Skin::compute(uint layer_num) {
 
     Distance beadWidth = m_sb->setting<Distance>(PS::Skin::kBeadWidth);
     Distance minPathLength = m_sb->setting<Distance>(PS::Skin::kMinPathLength);
+    Distance minSegmentLength = m_sb->setting<Distance>(PS::Skin::kMinSegmentLength);
     Angle patternAngle = m_sb->setting<Angle>(PS::Skin::kAngle);
 
     int top_count = m_sb->setting<int>(PS::Skin::kTopCount);
@@ -118,10 +121,11 @@ void Skin::compute(uint layer_num) {
 
     if (!m_skin_geometry.isEmpty()) {
         PolygonList skin_offset = m_skin_geometry.offset(-beadWidth / 2);
+        const InfillPatterns skin_pattern = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Skin::kPattern));
         QVector<Polyline> lines =
-            createPatternForArea(static_cast<InfillPatterns>(m_sb->setting<int>(PS::Skin::kPattern)), skin_offset,
-                                 beadWidth, beadWidth, patternAngle);
-        m_computed_geometry = printableLines(lines, minPathLength);
+            createPatternForArea(skin_pattern, skin_offset, beadWidth, beadWidth, patternAngle);
+        m_computed_geometry = printableLines(lines, minPathLength, minSegmentLength,
+                                             skin_pattern == InfillPatterns::kConcentric);
         m_geometry -= printableFootprint(m_computed_geometry, beadWidth, m_skin_geometry);
     }
 
@@ -140,7 +144,8 @@ void Skin::compute(uint layer_num) {
                 QVector<Polyline> lines =
                     createPatternForArea(gradualPattern, skin_offset, beadWidth,
                                          beadWidth / (percentage + densityStep * (end - i)), infillPatternAngle);
-                m_gradual_computed_geometry.push_back(printableLines(lines, minPathLength));
+                m_gradual_computed_geometry.push_back(
+                    printableLines(lines, minPathLength, minSegmentLength, gradualPattern == InfillPatterns::kConcentric));
                 m_geometry -=
                     printableFootprint(m_gradual_computed_geometry.back(), beadWidth, m_gradual_skin_geometry[i]);
             }
@@ -309,6 +314,13 @@ void Skin::optimizeHelper(PolylineOrderOptimizer poo, bool supportsG3, Point& cu
 }
 
 Path Skin::createPath(Polyline line) {
+    const InfillPatterns pattern = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Skin::kPattern));
+    const bool is_closed_path = pattern == InfillPatterns::kConcentric;
+
+    line = line.removeShortSegments(m_sb->setting<Distance>(PS::Skin::kMinSegmentLength), is_closed_path);
+    if (line.size() < (is_closed_path ? 3 : 2)) {
+        return Path();
+    }
 
     Distance width = m_sb->setting<Distance>(PS::Skin::kBeadWidth);
     Distance height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
@@ -335,7 +347,7 @@ Path Skin::createPath(Polyline line) {
     }
 
     //! Creates closing segment if infill pattern is concentric
-    if (static_cast<InfillPatterns>(m_sb->setting<int>(PS::Skin::kPattern)) == InfillPatterns::kConcentric) {
+    if (is_closed_path) {
         QSharedPointer<LineSegment> line_segment = QSharedPointer<LineSegment>::create(line.last(), line.first());
 
         line_segment->getSb()->setSetting(MS::Extruder::kInitialSpeed,

--- a/src/step/layer/regions/skin.cpp
+++ b/src/step/layer/regions/skin.cpp
@@ -300,7 +300,7 @@ void Skin::optimizeHelper(PolylineOrderOptimizer poo, bool supportsG3, Point& cu
     while (poo.getCurrentPolylineCount() > 0) {
         Polyline result = poo.linkNextPolyline(previouslyLinkedLines);
         if (result.size() > 0) {
-            Path newPath = createPath(result);
+            Path newPath = createPath(result, pattern);
             if (newPath.size() > 0) {
                 calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
                 PathModifierGenerator::GenerateTravel(newPath, current_location,
@@ -315,6 +315,10 @@ void Skin::optimizeHelper(PolylineOrderOptimizer poo, bool supportsG3, Point& cu
 
 Path Skin::createPath(Polyline line) {
     const InfillPatterns pattern = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Skin::kPattern));
+    return createPath(line, pattern);
+}
+
+Path Skin::createPath(Polyline line, InfillPatterns pattern) {
     const bool is_closed_path = pattern == InfillPatterns::kConcentric;
 
     line = line.removeShortSegments(m_sb->setting<Distance>(PS::Skin::kMinSegmentLength), is_closed_path);

--- a/src/step/layer/regions/support.cpp
+++ b/src/step/layer/regions/support.cpp
@@ -215,6 +215,12 @@ void Support::calculateModifiers(Path& path, bool supportsG3) {
 }
 
 Path Support::createPath(Polyline line) {
+    const bool is_closed_path = line.size() > 2 && line.first() == line.last();
+    line = line.removeShortSegments(m_sb->setting<Distance>(PS::Support::kMinSegmentLength), is_closed_path);
+    if (line.size() < (is_closed_path ? 4 : 2)) {
+        return Path();
+    }
+
     Distance bead_width = m_sb->setting<Distance>(PS::Layer::kBeadWidth);
     Distance layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
     Velocity speed = m_sb->setting<Velocity>(PS::Layer::kSpeed);

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -560,6 +560,7 @@ const QString Constants::ProfileSettings::Perimeter::kSpeed = "perimeter_speed";
 const QString Constants::ProfileSettings::Perimeter::kExtruderSpeed = "perimeter_extruder_speed";
 const QString Constants::ProfileSettings::Perimeter::kExtrusionMultiplier = "perimeter_extrusion_multiplier";
 const QString Constants::ProfileSettings::Perimeter::kMinPathLength = "perimeter_minimum_path_length";
+const QString Constants::ProfileSettings::Perimeter::kMinSegmentLength = "perimeter_minimum_segment_length";
 const QString Constants::ProfileSettings::Perimeter::kEnableLeadIn = "perimeter_lead_in";
 const QString Constants::ProfileSettings::Perimeter::kLeadInFirstLayerOnly = "perimeter_lead_in_first_layer";
 const QString Constants::ProfileSettings::Perimeter::kEnableLeadInX = "perimeter_lead_in_x";
@@ -577,6 +578,7 @@ const QString Constants::ProfileSettings::Inset::kSpeed = "inset_speed";
 const QString Constants::ProfileSettings::Inset::kExtruderSpeed = "inset_extruder_speed";
 const QString Constants::ProfileSettings::Inset::kExtrusionMultiplier = "inset_extrusion_multiplier";
 const QString Constants::ProfileSettings::Inset::kMinPathLength = "inset_minimum_path_length";
+const QString Constants::ProfileSettings::Inset::kMinSegmentLength = "inset_minimum_segment_length";
 const QString Constants::ProfileSettings::Inset::kOverlap = "inset_overlap_distance";
 const QString Constants::ProfileSettings::Inset::kEnableSpiralInset = "spiral_inset";
 
@@ -598,6 +600,7 @@ const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptMinWidthFilter
 const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptMaxWidth = "skeleton_adapt_max_width";
 const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptMaxWidthFilter = "skeleton_adapt_max_width_filter";
 const QString Constants::ProfileSettings::Skeleton::kMinPathLength = "skeleton_minimum_path_length";
+const QString Constants::ProfileSettings::Skeleton::kMinSegmentLength = "skeleton_minimum_segment_length";
 const QString Constants::ProfileSettings::Skeleton::kLeadInEnable = "skeleton_lead_in";
 const QString Constants::ProfileSettings::Skeleton::kLeadInDistance = "skeleton_lead_in_distance";
 const QString Constants::ProfileSettings::Skeleton::kLeadInSpeed = "skeleton_lead_in_speed";
@@ -618,6 +621,7 @@ const QString Constants::ProfileSettings::Skin::kExtruderSpeed = "skin_extruder_
 const QString Constants::ProfileSettings::Skin::kExtrusionMultiplier = "skin_extrusion_multiplier";
 const QString Constants::ProfileSettings::Skin::kOverlap = "skin_exterior_overlap";
 const QString Constants::ProfileSettings::Skin::kMinPathLength = "skin_minimum_path_length";
+const QString Constants::ProfileSettings::Skin::kMinSegmentLength = "skin_minimum_segment_length";
 const QString Constants::ProfileSettings::Skin::kInfillEnable = "skin_gradual_infill";
 const QString Constants::ProfileSettings::Skin::kInfillSteps = "skin_gradual_infill_steps";
 const QString Constants::ProfileSettings::Skin::kInfillPattern = "skin_gradual_infill_pattern";
@@ -642,6 +646,7 @@ const QString Constants::ProfileSettings::Infill::kExtrusionMultiplier = "infill
 const QString Constants::ProfileSettings::Infill::kCombineXLayers = "infill_combine_every_x_layers";
 const QString Constants::ProfileSettings::Infill::kCombineLayerShift = "infill_combine_layer_shift";
 const QString Constants::ProfileSettings::Infill::kMinPathLength = "infill_minimum_path_length";
+const QString Constants::ProfileSettings::Infill::kMinSegmentLength = "infill_minimum_segment_length";
 
 // Support
 const QString Constants::ProfileSettings::Support::kEnable = "support";
@@ -666,6 +671,7 @@ const QString Constants::ProfileSettings::Support::kInterfaceExpansion = "suppor
 const QString Constants::ProfileSettings::Support::kInterfaceRegion = "support_interface_region";
 const QString Constants::ProfileSettings::Support::kBaseLayers = "support_base_layers";
 const QString Constants::ProfileSettings::Support::kBaseExpansion = "support_base_expansion";
+const QString Constants::ProfileSettings::Support::kMinSegmentLength = "support_minimum_segment_length";
 const QString Constants::ProfileSettings::Support::kBaseRegion = "support_base_region";
 const QString Constants::ProfileSettings::Support::kBridgeSuppression = "support_bridge_suppression";
 const QString Constants::ProfileSettings::Support::kBridgeMaxLength = "support_bridge_max_length";


### PR DESCRIPTION
## Summary
- Add per-region minimum path segment length settings for perimeter, inset, skeleton, skin, infill, and support.
- Add `Polyline::removeShortSegments` to collapse short path segments before paths become G-code segments.
- Apply the cleanup during region path generation and regenerate the master settings config.

## Why
Smoothing the sliced polygon does not prevent later path generation, especially concentric offsets, from creating very short path segments. This adds a path-level cleanup control for each region type.

## Validation
- `git diff --check`
- `nix develop --command cmake --build build/generic-llvm-ninja -j 2`