### PR TITLE
feat(settings): allow hiding disabled setting rows

### DIFF
--- a/include/managers/preferences_manager.h
+++ b/include/managers/preferences_manager.h
@@ -133,6 +133,9 @@ class PreferencesManager : public QObject {
     //! \brief Returns the true-width preview vertex threshold.
     int getGCodePreviewVertexThresholdPreference();
 
+    //! \brief Returns how dependency-disabled settings are displayed.
+    DisabledSettingVisibility getDisabledSettingVisibilityPreference();
+
     //! \brief Return the user preference for warning about unsaved projects when closing
     bool getWarnUnsavedProjectOnClosePreference();
 
@@ -264,6 +267,9 @@ class PreferencesManager : public QObject {
     //! \brief Signal that any of the above units have changed
     void themeChanged();
 
+    //! \brief Signal emitted when dependency-disabled setting visibility is changed
+    void disabledSettingVisibilityChanged();
+
   public slots:
     //! \brief sets the unit used to scale when importing models
     //! \param du the unit text
@@ -360,6 +366,14 @@ class PreferencesManager : public QObject {
     //! \param threshold maximum estimated vertices to build for true-width preview
     void setGCodePreviewVertexThresholdPreference(int threshold);
 
+    //! \brief Sets how dependency-disabled settings are displayed.
+    //! \param visibility selected disabled setting visibility
+    void setDisabledSettingVisibilityPreference(DisabledSettingVisibility visibility);
+
+    //! \brief Sets how dependency-disabled settings are displayed from a UI index.
+    //! \param visibility selected visibility as an integer
+    void setDisabledSettingVisibilityPreference(int visibility);
+
     //! \brief Sets the preference for warning about unsaved projects when closing
     void setWarnUnsavedProjectOnClosePreference(bool warn);
 
@@ -432,6 +446,7 @@ class PreferencesManager : public QObject {
     bool m_use_true_widths_preference;
     GCodePreviewMode m_gcode_preview_mode_preference;
     int m_gcode_preview_vertex_threshold_preference;
+    DisabledSettingVisibility m_disabled_setting_visibility_preference;
     bool m_warn_unsaved_project_on_close_preference;
 
     //! \brief Preferences for window size and position

--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -662,6 +662,18 @@ enum class ForceMinimumLayerTime : uint8_t { kUse_Purge_Dwells, kSlow_Feedrate }
 
 enum class PreferenceChoice : uint8_t { kAsk = 0, kPerformAutomatically = 1, kSkipAutomatically = 2 };
 
+enum class DisabledSettingVisibility : uint8_t { kGrey = 0, kHide = 1 };
+
+inline QString toString(DisabledSettingVisibility visibility) {
+    switch (visibility) {
+        case DisabledSettingVisibility::kHide:
+            return "Hide";
+        case DisabledSettingVisibility::kGrey:
+        default:
+            return "Grey";
+    }
+}
+
 /*!
  * \enum GCodePreviewMode
  * \brief Controls how g-code visualization chooses between true bead meshes and lightweight lines.

--- a/include/widgets/settings/setting_row_base.h
+++ b/include/widgets/settings/setting_row_base.h
@@ -91,6 +91,9 @@ class SettingRowBase {
     //! \brief Show this row.
     virtual void show();
 
+    //! \brief Returns whether this row's widgets should currently be visible.
+    bool isShown() const;
+
     //! \brief Sets dependency logic for this row
     //! \param root: DependencyNode object that contains all dependency information
     void setDependencyLogic(DependencyNode root);
@@ -297,17 +300,41 @@ class SettingRowBase {
     //! \brief Remove this row's selected local overrides and reload the row.
     void resetLocalOverrides();
 
+    //! \brief Returns whether this row should be visible after all visibility controls are applied.
+    bool rowWidgetsVisible() const;
+
+    //! \brief Returns whether this row should accept input after all enabled controls are applied.
+    bool rowWidgetsEnabled() const;
+
+    //! \brief Applies current row enabled and visibility state to a widget.
+    void applyWidgetState(QWidget* widget) const;
+
+    //! \brief Applies current row enabled and visibility state to base widgets.
+    void applyBaseWidgetState();
+
+    //! \brief Applies current row enabled and visibility state to a row editor widget.
+    void registerRowWidget(QWidget* widget);
+
+    //! \brief Sets dependency-driven enabled state for this row.
+    void setDependencyEnabled(bool enabled);
+
     //! \brief Keys that can make this row locally overridden.
     QList<QString> m_local_override_keys;
 
     //! \brief Button used to remove selected local overrides.
     QScopedPointer<QToolButton> m_reset_button;
 
+    //! \brief Editor widgets that must follow row visibility and enabled state.
+    QList<QWidget*> m_row_widgets;
+
     //! \brief Whether this row is currently visible.
     bool m_row_visible;
 
     //! \brief Whether this row is currently enabled.
     bool m_row_enabled;
+
+    //! \brief Whether this row is currently enabled by dependency logic.
+    bool m_dependency_enabled;
 
     //! \brief Master json that this row was constructed from
     fifojson m_json;

--- a/include/windows/preferences_window.h
+++ b/include/windows/preferences_window.h
@@ -93,6 +93,7 @@ class PreferencesWindow : public QMainWindow {
     QComboBox* m_rotation_unit_combobox;
     QComboBox* m_theme_combobox;
     QComboBox* m_gcode_preview_mode_combobox;
+    QComboBox* m_disabled_setting_visibility_combobox;
     QSpinBox* m_gcode_preview_vertex_threshold_spinbox;
     QCheckBox* m_warn_unsaved_project_on_close_checkbox;
 

--- a/src/managers/preferences_manager.cpp
+++ b/src/managers/preferences_manager.cpp
@@ -88,6 +88,7 @@ PreferencesManager::PreferencesManager()
       m_file_shift_preference(PreferenceChoice::kPerformAutomatically), m_align_preference(PreferenceChoice::kAsk),
       m_hide_travel_preference(false), m_hide_support_preference(false), m_use_true_widths_preference(true),
       m_gcode_preview_mode_preference(GCodePreviewMode::kAuto), m_gcode_preview_vertex_threshold_preference(5000000),
+      m_disabled_setting_visibility_preference(DisabledSettingVisibility::kGrey),
       m_warn_unsaved_project_on_close_preference(true), m_themeName(ThemeName::kLightMode),
       m_theme(static_cast<int>(m_themeName)), m_rotation_unit(RotationUnit::kPitchRollYaw), m_dirty(false),
       m_is_maximized(false), m_window_size(-1, -1), m_window_pos(-1, -1), m_use_implicit_transforms(false),
@@ -240,6 +241,9 @@ void PreferencesManager::importPreferences(QString filepath) {
         if (j.contains("gcode_preview_vertex_threshold"))
             setGCodePreviewVertexThresholdPreference(j["gcode_preview_vertex_threshold"].get<int>());
 
+        if (j.contains("disabled_setting_visibility"))
+            setDisabledSettingVisibilityPreference(j["disabled_setting_visibility"].get<int>());
+
         if (j.contains("warn_unsaved_project_on_close"))
             setWarnUnsavedProjectOnClosePreference(j["warn_unsaved_project_on_close"]);
 
@@ -289,6 +293,7 @@ fifojson PreferencesManager::json() {
     j["use_true_widths"] = m_use_true_widths_preference;
     j["gcode_preview_mode"] = static_cast<int>(m_gcode_preview_mode_preference);
     j["gcode_preview_vertex_threshold"] = m_gcode_preview_vertex_threshold_preference;
+    j["disabled_setting_visibility"] = static_cast<int>(m_disabled_setting_visibility_preference);
     j["warn_unsaved_project_on_close"] = m_warn_unsaved_project_on_close_preference;
     j["hidden_settings"] = m_hidden_settings;
     j["rotation"] = m_rotation_unit;
@@ -364,6 +369,10 @@ GCodePreviewMode PreferencesManager::getGCodePreviewModePreference() { return m_
 
 int PreferencesManager::getGCodePreviewVertexThresholdPreference() {
     return m_gcode_preview_vertex_threshold_preference;
+}
+
+DisabledSettingVisibility PreferencesManager::getDisabledSettingVisibilityPreference() {
+    return m_disabled_setting_visibility_preference;
 }
 
 bool PreferencesManager::getWarnUnsavedProjectOnClosePreference() {
@@ -613,6 +622,25 @@ void PreferencesManager::setGCodePreviewModePreference(int mode) {
 void PreferencesManager::setGCodePreviewVertexThresholdPreference(int threshold) {
     m_gcode_preview_vertex_threshold_preference = std::max(0, threshold);
     m_dirty = true;
+}
+
+void PreferencesManager::setDisabledSettingVisibilityPreference(DisabledSettingVisibility visibility) {
+    switch (visibility) {
+        case DisabledSettingVisibility::kGrey:
+        case DisabledSettingVisibility::kHide:
+            m_disabled_setting_visibility_preference = visibility;
+            break;
+        default:
+            m_disabled_setting_visibility_preference = DisabledSettingVisibility::kGrey;
+            break;
+    }
+
+    m_dirty = true;
+    emit disabledSettingVisibilityChanged();
+}
+
+void PreferencesManager::setDisabledSettingVisibilityPreference(int visibility) {
+    setDisabledSettingVisibilityPreference(static_cast<DisabledSettingVisibility>(visibility));
 }
 
 void PreferencesManager::setWarnUnsavedProjectOnClosePreference(bool warn) {

--- a/src/widgets/settings/setting_bar.cpp
+++ b/src/widgets/settings/setting_bar.cpp
@@ -113,8 +113,10 @@ void SettingBar::filter(QString str) {
                 // Check if the current row's label matches.
                 if (cur_row->getLabelText().contains(str, Qt::CaseInsensitive)) {
                     cur_row->show();
-                    minor_hidden = false;
-                    major_hidden = false;
+                    if (cur_row->isShown()) {
+                        minor_hidden = false;
+                        major_hidden = false;
+                    }
                 }
                 else
                     cur_row->hide();
@@ -543,6 +545,8 @@ void SettingBar::setupEvents() {
     connect(m_tab_widget, &QTabWidget::currentChanged, this, &SettingBar::updateDisplayedLists);
     connect(m_combo_box, QOverload<const QString&>::of(&QComboBox::currentTextChanged), this,
             &SettingBar::updateSettings);
+    connect(PreferencesManager::getInstance().get(), &PreferencesManager::disabledSettingVisibilityChanged, this,
+            &SettingBar::enableDependRows);
 }
 
 // this function iterates through each tab of each pane, and make those rows enabled/disabled

--- a/src/widgets/settings/setting_check_box.cpp
+++ b/src/widgets/settings/setting_check_box.cpp
@@ -41,6 +41,7 @@ SettingCheckBox::SettingCheckBox(SettingTab* parent, QSharedPointer<SettingsBase
     // Set setting units
     m_unit_label.reset(new QLabel(""));
     layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
 }
 
 SettingRowBase* SettingCheckBox::createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
@@ -49,8 +50,8 @@ SettingRowBase* SettingCheckBox::createInstance(SettingTab* parent, QSharedPoint
 }
 
 void SettingCheckBox::setEnabled(bool enabled) {
-    dynamic_cast<QCheckBox*>(this)->setEnabled(enabled);
     SettingRowBase::setEnabled(enabled);
+    applyWidgetState(static_cast<QCheckBox*>(this));
 }
 
 void SettingCheckBox::setNotification(QString msg) {
@@ -67,13 +68,13 @@ void SettingCheckBox::clearNotification() {
 }
 
 void SettingCheckBox::hide() {
-    dynamic_cast<QCheckBox*>(this)->hide();
     SettingRowBase::hide();
+    applyWidgetState(static_cast<QCheckBox*>(this));
 }
 
 void SettingCheckBox::show() {
-    dynamic_cast<QCheckBox*>(this)->show();
     SettingRowBase::show();
+    applyWidgetState(static_cast<QCheckBox*>(this));
 }
 
 void SettingCheckBox::valueChanged(QVariant val) {

--- a/src/widgets/settings/setting_combo_box.cpp
+++ b/src/widgets/settings/setting_combo_box.cpp
@@ -53,6 +53,7 @@ SettingComboBox::SettingComboBox(SettingTab* parent, QSharedPointer<SettingsBase
     // Set setting units
     m_unit_label.reset(new QLabel(""));
     layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
 }
 
 SettingRowBase* SettingComboBox::createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
@@ -61,8 +62,8 @@ SettingRowBase* SettingComboBox::createInstance(SettingTab* parent, QSharedPoint
 }
 
 void SettingComboBox::setEnabled(bool enabled) {
-    dynamic_cast<QComboBox*>(this)->setEnabled(enabled);
     SettingRowBase::setEnabled(enabled);
+    applyWidgetState(static_cast<QComboBox*>(this));
 }
 
 void SettingComboBox::setNotification(QString msg) {
@@ -81,13 +82,13 @@ void SettingComboBox::clearNotification() {
 }
 
 void SettingComboBox::hide() {
-    dynamic_cast<QComboBox*>(this)->hide();
     SettingRowBase::hide();
+    applyWidgetState(static_cast<QComboBox*>(this));
 }
 
 void SettingComboBox::show() {
-    dynamic_cast<QComboBox*>(this)->show();
     SettingRowBase::show();
+    applyWidgetState(static_cast<QComboBox*>(this));
 }
 
 void SettingComboBox::valueChanged(QVariant val) {

--- a/src/widgets/settings/setting_double_spin_box.cpp
+++ b/src/widgets/settings/setting_double_spin_box.cpp
@@ -67,6 +67,7 @@ SettingDoubleSpinBox::SettingDoubleSpinBox(SettingTab* parent, QSharedPointer<Se
     // Set setting units
     m_unit_label.reset(new QLabel(unitText));
     layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
 }
 
 SettingRowBase* SettingDoubleSpinBox::createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
@@ -75,8 +76,8 @@ SettingRowBase* SettingDoubleSpinBox::createInstance(SettingTab* parent, QShared
 }
 
 void SettingDoubleSpinBox::setEnabled(bool enabled) {
-    dynamic_cast<QDoubleSpinBox*>(this)->setEnabled(enabled);
     SettingRowBase::setEnabled(enabled);
+    applyWidgetState(static_cast<QDoubleSpinBox*>(this));
 }
 
 void SettingDoubleSpinBox::setNotification(QString msg) {
@@ -93,13 +94,13 @@ void SettingDoubleSpinBox::clearNotification() {
 }
 
 void SettingDoubleSpinBox::hide() {
-    dynamic_cast<QDoubleSpinBox*>(this)->hide();
     SettingRowBase::hide();
+    applyWidgetState(static_cast<QDoubleSpinBox*>(this));
 }
 
 void SettingDoubleSpinBox::show() {
-    dynamic_cast<QDoubleSpinBox*>(this)->show();
     SettingRowBase::show();
+    applyWidgetState(static_cast<QDoubleSpinBox*>(this));
 }
 
 void SettingDoubleSpinBox::valueChanged(QVariant val) {

--- a/src/widgets/settings/setting_line_edit.cpp
+++ b/src/widgets/settings/setting_line_edit.cpp
@@ -40,6 +40,7 @@ SettingLineEdit::SettingLineEdit(SettingTab* parent, QSharedPointer<SettingsBase
     // Set setting units
     m_unit_label.reset(new QLabel(""));
     layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
 }
 
 SettingRowBase* SettingLineEdit::createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
@@ -48,8 +49,8 @@ SettingRowBase* SettingLineEdit::createInstance(SettingTab* parent, QSharedPoint
 }
 
 void SettingLineEdit::setEnabled(bool enabled) {
-    dynamic_cast<QLineEdit*>(this)->setEnabled(enabled);
     SettingRowBase::setEnabled(enabled);
+    applyWidgetState(static_cast<QLineEdit*>(this));
 }
 
 void SettingLineEdit::setNotification(QString msg) {
@@ -68,13 +69,13 @@ void SettingLineEdit::clearNotification() {
 }
 
 void SettingLineEdit::hide() {
-    dynamic_cast<QLineEdit*>(this)->hide();
     SettingRowBase::hide();
+    applyWidgetState(static_cast<QLineEdit*>(this));
 }
 
 void SettingLineEdit::show() {
-    dynamic_cast<QLineEdit*>(this)->show();
     SettingRowBase::show();
+    applyWidgetState(static_cast<QLineEdit*>(this));
 }
 
 void SettingLineEdit::valueChanged(QVariant val) {

--- a/src/widgets/settings/setting_numbered_list.cpp
+++ b/src/widgets/settings/setting_numbered_list.cpp
@@ -65,6 +65,7 @@ SettingNumberedList::SettingNumberedList(SettingTab* parent, QSharedPointer<Sett
     // Set setting units
     m_unit_label.reset(new QLabel(""));
     layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
 }
 
 SettingRowBase* SettingNumberedList::createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
@@ -73,8 +74,8 @@ SettingRowBase* SettingNumberedList::createInstance(SettingTab* parent, QSharedP
 }
 
 void SettingNumberedList::setEnabled(bool enabled) {
-    dynamic_cast<QTableWidget*>(this)->setEnabled(enabled);
     SettingRowBase::setEnabled(enabled);
+    applyWidgetState(static_cast<QTableWidget*>(this));
 }
 
 void SettingNumberedList::setNotification(QString msg) {
@@ -93,13 +94,13 @@ void SettingNumberedList::clearNotification() {
 }
 
 void SettingNumberedList::hide() {
-    dynamic_cast<QTableWidget*>(this)->hide();
     SettingRowBase::hide();
+    applyWidgetState(static_cast<QTableWidget*>(this));
 }
 
 void SettingNumberedList::show() {
-    dynamic_cast<QTableWidget*>(this)->show();
     SettingRowBase::show();
+    applyWidgetState(static_cast<QTableWidget*>(this));
 }
 
 void SettingNumberedList::valueChanged(QVariant val) {

--- a/src/widgets/settings/setting_plain_text_edit.cpp
+++ b/src/widgets/settings/setting_plain_text_edit.cpp
@@ -39,6 +39,7 @@ SettingPlainTextEdit::SettingPlainTextEdit(SettingTab* parent, QSharedPointer<Se
     // Set setting units
     m_unit_label.reset(new QLabel(""));
     layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
 }
 
 SettingRowBase* SettingPlainTextEdit::createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
@@ -47,8 +48,8 @@ SettingRowBase* SettingPlainTextEdit::createInstance(SettingTab* parent, QShared
 }
 
 void SettingPlainTextEdit::setEnabled(bool enabled) {
-    dynamic_cast<QPlainTextEdit*>(this)->setEnabled(enabled);
     SettingRowBase::setEnabled(enabled);
+    applyWidgetState(static_cast<QPlainTextEdit*>(this));
 }
 
 void SettingPlainTextEdit::setNotification(QString msg) {
@@ -67,13 +68,13 @@ void SettingPlainTextEdit::clearNotification() {
 }
 
 void SettingPlainTextEdit::hide() {
-    dynamic_cast<QPlainTextEdit*>(this)->hide();
     SettingRowBase::hide();
+    applyWidgetState(static_cast<QPlainTextEdit*>(this));
 }
 
 void SettingPlainTextEdit::show() {
-    dynamic_cast<QPlainTextEdit*>(this)->show();
     SettingRowBase::show();
+    applyWidgetState(static_cast<QPlainTextEdit*>(this));
 }
 
 void SettingPlainTextEdit::valueChanged(QVariant val) {

--- a/src/widgets/settings/setting_row_base.cpp
+++ b/src/widgets/settings/setting_row_base.cpp
@@ -25,7 +25,8 @@ namespace ORNL {
 
 SettingRowBase::SettingRowBase(QWidget* parent, QSharedPointer<SettingsBase> sb, QString key, fifojson json,
                                QGridLayout* layout, int index)
-    : m_index(index), m_layout(layout), m_key(key), m_sb(sb), m_row_visible(true), m_row_enabled(true), m_json(json) {
+    : m_index(index), m_layout(layout), m_key(key), m_sb(sb), m_row_visible(true), m_row_enabled(true),
+      m_dependency_enabled(true), m_json(json) {
     m_theme_path = PreferencesManager::getInstance()->getTheme().getFolderPath();
     m_local_override_keys = {m_key};
 
@@ -135,27 +136,77 @@ void SettingRowBase::setBases(QList<QSharedPointer<SettingsBase>> settings_bases
 
 QList<QSharedPointer<SettingsBase>> SettingRowBase::getBases() { return m_settings_bases; }
 
-void SettingRowBase::checkDependencies() { setEnabled(checkLogic(m_dependency_logic)); }
+void SettingRowBase::checkDependencies() { setDependencyEnabled(checkLogic(m_dependency_logic)); }
 
 void SettingRowBase::hide() {
     m_row_visible = false;
-    m_key_label->hide();
-    m_unit_label->hide();
-    updateResetButton();
+    applyBaseWidgetState();
 }
 
 void SettingRowBase::show() {
     m_row_visible = true;
-    m_key_label->show();
-    m_unit_label->show();
+    applyBaseWidgetState();
+}
+
+bool SettingRowBase::isShown() const { return rowWidgetsVisible(); }
+
+bool SettingRowBase::rowWidgetsVisible() const {
+    const bool show_disabled =
+        PreferencesManager::getInstance()->getDisabledSettingVisibilityPreference() == DisabledSettingVisibility::kGrey;
+    return m_row_visible && (m_dependency_enabled || show_disabled);
+}
+
+bool SettingRowBase::rowWidgetsEnabled() const { return m_row_enabled && m_dependency_enabled; }
+
+void SettingRowBase::applyWidgetState(QWidget* widget) const {
+    if (widget == nullptr)
+        return;
+
+    widget->setVisible(rowWidgetsVisible());
+    widget->setEnabled(rowWidgetsEnabled());
+}
+
+void SettingRowBase::applyBaseWidgetState() {
+    const bool visible = rowWidgetsVisible();
+    const bool enabled = rowWidgetsEnabled();
+
+    for (QWidget* widget : m_row_widgets) {
+        if (widget == nullptr)
+            continue;
+
+        widget->setVisible(visible);
+        widget->setEnabled(enabled);
+    }
+
+    if (!m_key_label.isNull()) {
+        m_key_label->setVisible(visible);
+        m_key_label->setEnabled(enabled);
+    }
+
+    if (!m_unit_label.isNull()) {
+        m_unit_label->setVisible(visible);
+        m_unit_label->setEnabled(enabled);
+    }
+
     updateResetButton();
+}
+
+void SettingRowBase::registerRowWidget(QWidget* widget) {
+    if (widget == nullptr || m_row_widgets.contains(widget))
+        return;
+
+    m_row_widgets.push_back(widget);
+    applyWidgetState(widget);
 }
 
 void SettingRowBase::setEnabled(bool enabled) {
     m_row_enabled = enabled;
-    m_key_label->setEnabled(enabled);
-    m_unit_label->setEnabled(enabled);
-    updateResetButton();
+    applyBaseWidgetState();
+}
+
+void SettingRowBase::setDependencyEnabled(bool enabled) {
+    m_dependency_enabled = enabled;
+    applyBaseWidgetState();
 }
 
 void SettingRowBase::setDependencyLogic(DependencyNode root) { m_dependency_logic = root; }
@@ -227,9 +278,9 @@ void SettingRowBase::updateResetButton() {
     if (m_reset_button.isNull())
         return;
 
-    const bool should_show = m_row_visible && hasLocalOverride();
+    const bool should_show = rowWidgetsVisible() && hasLocalOverride();
     m_reset_button->setVisible(should_show);
-    m_reset_button->setEnabled(should_show && m_row_enabled);
+    m_reset_button->setEnabled(should_show && rowWidgetsEnabled());
 }
 
 void SettingRowBase::resetLocalOverrides() {

--- a/src/widgets/settings/setting_spin_box.cpp
+++ b/src/widgets/settings/setting_spin_box.cpp
@@ -52,6 +52,7 @@ SettingSpinBox::SettingSpinBox(SettingTab* parent, QSharedPointer<SettingsBase> 
     // Set setting units
     m_unit_label.reset(new QLabel(""));
     layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
 }
 
 SettingRowBase* SettingSpinBox::createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
@@ -60,8 +61,8 @@ SettingRowBase* SettingSpinBox::createInstance(SettingTab* parent, QSharedPointe
 }
 
 void SettingSpinBox::setEnabled(bool enabled) {
-    dynamic_cast<QSpinBox*>(this)->setEnabled(enabled);
     SettingRowBase::setEnabled(enabled);
+    applyWidgetState(static_cast<QSpinBox*>(this));
 }
 
 void SettingSpinBox::setNotification(QString msg) {
@@ -79,13 +80,13 @@ void SettingSpinBox::clearNotification() {
 }
 
 void SettingSpinBox::hide() {
-    dynamic_cast<QSpinBox*>(this)->hide();
     SettingRowBase::hide();
+    applyWidgetState(static_cast<QSpinBox*>(this));
 }
 
 void SettingSpinBox::show() {
-    dynamic_cast<QSpinBox*>(this)->show();
     SettingRowBase::show();
+    applyWidgetState(static_cast<QSpinBox*>(this));
 }
 
 void SettingSpinBox::valueChanged(QVariant val) {

--- a/src/widgets/settings/vector2_input_widget.cpp
+++ b/src/widgets/settings/vector2_input_widget.cpp
@@ -84,21 +84,22 @@ Vector2InputWidget::Vector2InputWidget(SettingTab* parent, QSharedPointer<Settin
 
     m_unit_label.reset(new QLabel(PreferencesManager::getInstance()->getDistanceUnitText()));
     layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
 }
 
 void Vector2InputWidget::hide() {
-    QWidget::hide();
     SettingRowBase::hide();
+    applyWidgetState(static_cast<QWidget*>(this));
 }
 
 void Vector2InputWidget::show() {
-    QWidget::show();
     SettingRowBase::show();
+    applyWidgetState(static_cast<QWidget*>(this));
 }
 
 void Vector2InputWidget::setEnabled(bool enabled) {
-    QWidget::setEnabled(enabled);
     SettingRowBase::setEnabled(enabled);
+    applyWidgetState(static_cast<QWidget*>(this));
 }
 
 void Vector2InputWidget::valueChanged(QVariant val) { updateSetting(m_components[0].key, val.toDouble()); }

--- a/src/widgets/settings/vector3_input_widget.cpp
+++ b/src/widgets/settings/vector3_input_widget.cpp
@@ -83,21 +83,22 @@ Vector3InputWidget::Vector3InputWidget(SettingTab* parent, QSharedPointer<Settin
 
     m_unit_label.reset(new QLabel(""));
     layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
 }
 
 void Vector3InputWidget::hide() {
-    QWidget::hide();
     SettingRowBase::hide();
+    applyWidgetState(static_cast<QWidget*>(this));
 }
 
 void Vector3InputWidget::show() {
-    QWidget::show();
     SettingRowBase::show();
+    applyWidgetState(static_cast<QWidget*>(this));
 }
 
 void Vector3InputWidget::setEnabled(bool enabled) {
-    QWidget::setEnabled(enabled);
     SettingRowBase::setEnabled(enabled);
+    applyWidgetState(static_cast<QWidget*>(this));
 }
 
 void Vector3InputWidget::valueChanged(QVariant val) { updateSetting(m_components[0].key, val.toDouble()); }

--- a/src/windows/preferences_window.cpp
+++ b/src/windows/preferences_window.cpp
@@ -245,6 +245,32 @@ void PreferencesWindow::setupLayout() {
 
     parts_tab_layout->setRowStretch(3, 1);
 
+    // Settings tab
+    QWidget* settingsWidget = new QWidget(m_tab_widget);
+    m_tab_widget->addTab(settingsWidget, "Settings");
+
+    QGridLayout* settings_tab_layout = new QGridLayout();
+    settingsWidget->setLayout(settings_tab_layout);
+
+    m_disabled_setting_visibility_combobox = new QComboBox();
+    m_disabled_setting_visibility_combobox->addItem(toString(DisabledSettingVisibility::kGrey),
+                                                    static_cast<int>(DisabledSettingVisibility::kGrey));
+    m_disabled_setting_visibility_combobox->addItem(toString(DisabledSettingVisibility::kHide),
+                                                    static_cast<int>(DisabledSettingVisibility::kHide));
+
+    int disabledSettingVisibilityIndex = m_disabled_setting_visibility_combobox->findData(
+        static_cast<int>(PreferencesManager::getInstance()->getDisabledSettingVisibilityPreference()));
+    m_disabled_setting_visibility_combobox->setCurrentIndex(std::max(0, disabledSettingVisibilityIndex));
+
+    settings_tab_layout->addWidget(new QLabel("Disabled settings:"), 0, 0, Qt::AlignTop);
+    settings_tab_layout->addWidget(m_disabled_setting_visibility_combobox, 0, 1, Qt::AlignTop);
+    settings_tab_layout->setRowStretch(1, 1);
+
+    connect(m_disabled_setting_visibility_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this] {
+        PreferencesManager::getInstance()->setDisabledSettingVisibilityPreference(
+            m_disabled_setting_visibility_combobox->currentData().toInt());
+    });
+
     // Visualization tab
     QWidget* visualizationWidget = new QWidget(m_tab_widget);
     m_tab_widget->addTab(visualizationWidget, "Visualization");
@@ -467,6 +493,9 @@ void PreferencesWindow::importPreferences() {
         m_gcode_preview_mode_combobox->setCurrentIndex(std::max(0, previewModeIndex));
         m_gcode_preview_vertex_threshold_spinbox->setValue(
             m_preferences_manager->getGCodePreviewVertexThresholdPreference());
+        int disabledSettingVisibilityIndex = m_disabled_setting_visibility_combobox->findData(
+            static_cast<int>(m_preferences_manager->getDisabledSettingVisibilityPreference()));
+        m_disabled_setting_visibility_combobox->setCurrentIndex(std::max(0, disabledSettingVisibilityIndex));
 
         setPreferenceValue(m_boxes[0], m_preferences_manager->getProjectShiftPreference());
         setPreferenceValue(m_boxes[1], m_preferences_manager->getAlignPreference());


### PR DESCRIPTION
## Summary

Add an application preference that lets users choose whether dependency-disabled settings are shown greyed out or fully hidden.

## Related issues

- No related issues.

## Details

This adds a new Settings tab in Application Preferences with a Disabled settings option:
- Grey preserves the existing behavior.
- Hide removes dependency-disabled rows from the settings pane.

The preference is persisted through PreferencesManager import/export and emits a change signal so the settings UI updates immediately when the option changes.

The settings row implementation now tracks dependency-enabled state separately from user/search visibility. SettingRowBase applies row state to labels, unit labels, reset controls, and each registered editor widget so hidden disabled settings do not leave orphaned input boxes visible.

## Impact

This improves settings-pane usability by allowing users to reduce visual clutter from unavailable options.

Risk level: Low. The default remains Grey, preserving existing behavior unless the user opts into Hide. The row-state changes are scoped to settings UI visibility/enabled handling.

## Testing strategy

Built and tested slicer - hidden settings can now be greyed or completely hidden.