### PR TITLE
Spiral Contour Improvements

### DIFF
--- a/include/geometry/spiral_path.h
+++ b/include/geometry/spiral_path.h
@@ -194,12 +194,23 @@ inline Distance transitionDistance(Distance current_width, Distance next_width, 
 }
 
 inline Point prepareConnector(const Polyline& current_loop, Polyline& next_loop, Distance stop_distance) {
-    Point connector_start = stopPointOnClosingSegment(current_loop, stop_distance);
+    const Point rough_connector_start = stopPointOnClosingSegment(current_loop, stop_distance);
+    const bool smooth_closing_segment = hasSmoothClosingSegment(current_loop);
     if (next_loop.size() >= 3) {
-        rotateToClosestForwardExistingPoint(next_loop, connector_start, current_loop.back(), current_loop.front());
+        if (smooth_closing_segment) {
+            rotateToClosestForwardExistingPoint(next_loop, rough_connector_start, current_loop.back(),
+                                                current_loop.front());
+        }
+        else {
+            rotateToClosestPoint(next_loop, rough_connector_start);
+        }
     }
 
-    return connector_start;
+    if (smooth_closing_segment || next_loop.isEmpty()) {
+        return rough_connector_start;
+    }
+
+    return MathUtils::nearestPointOnSegment(current_loop.back(), current_loop.front(), next_loop.front()).first;
 }
 
 struct StitchLoop {
@@ -316,10 +327,16 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Dist
         if (loop_index + 1 < end) {
             Polyline next_loop = loops[loop_index + 1];
             Point rough_connector_start = detail::stopPointOnClosingSegment(loop, final_stop_distance);
-            detail::rotateToClosestForwardExistingPoint(next_loop, rough_connector_start, loop.back(), loop.front());
+            const bool smooth_closing_segment = detail::hasSmoothClosingSegment(loop);
+            if (smooth_closing_segment) {
+                detail::rotateToClosestForwardExistingPoint(next_loop, rough_connector_start, loop.back(), loop.front());
+            }
+            else {
+                detail::rotateToClosestPoint(next_loop, rough_connector_start);
+            }
             const Point next_start = next_loop.front();
             Point connector_start;
-            if (detail::hasSmoothClosingSegment(loop)) {
+            if (smooth_closing_segment) {
                 connector_start = rough_connector_start;
             }
             else {

--- a/include/geometry/spiral_path.h
+++ b/include/geometry/spiral_path.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include <qcontainerfwd.h>
 
 #include "geometry/point.h"
@@ -39,6 +41,171 @@ inline bool hasSmoothClosingSegment(const Polyline& line) {
 
     return MathUtils::nearCollinear(line[line.size() - 2], line.back(), line.front(), 45 * deg);
 }
+
+inline Polyline reversePreservingStart(const Polyline& line) {
+    if (line.size() < 2) {
+        return line;
+    }
+
+    Polyline reversed;
+    reversed.reserve(line.size());
+    reversed.push_back(line.front());
+    for (int i = line.size() - 1; i > 0; --i) {
+        reversed.push_back(line[i]);
+    }
+
+    return reversed;
+}
+
+inline void alignOrientation(Polyline& line, bool ccw) {
+    if (line.size() >= 3 && line.orientation() != ccw) {
+        line = reversePreservingStart(line);
+    }
+}
+
+inline void rotateToClosestPoint(Polyline& line, const Point& query_point) {
+    if (line.size() < 2) {
+        return;
+    }
+
+    double closest_distance = std::numeric_limits<double>::max();
+    int rotation_index = 0;
+    bool insert_split_point = false;
+    Point split_point;
+    int insertion_index = 0;
+
+    for (int i = 0, end = line.size(); i < end; ++i) {
+        const int next_index = (i + 1) % line.size();
+        auto [closest_point, distance] = MathUtils::nearestPointOnSegment(line[i], line[next_index], query_point);
+
+        if (distance < closest_distance) {
+            closest_distance = distance;
+            insert_split_point = false;
+
+            if (closest_point == line[i]) {
+                rotation_index = i;
+            }
+            else if (closest_point == line[next_index]) {
+                rotation_index = next_index;
+            }
+            else {
+                rotation_index = next_index;
+                insert_split_point = true;
+                split_point = closest_point;
+                insertion_index = next_index;
+            }
+        }
+    }
+
+    if (insert_split_point) {
+        const int previous_index = insertion_index == 0 ? line.size() - 1 : insertion_index - 1;
+        const int next_index = insertion_index % line.size();
+
+        if (split_point == line[previous_index]) {
+            rotation_index = previous_index;
+        }
+        else if (split_point == line[next_index]) {
+            rotation_index = next_index;
+        }
+        else {
+            line.insert(insertion_index, split_point);
+        }
+    }
+
+    for (int i = 0; i < rotation_index; ++i) {
+        line.move(0, line.size() - 1);
+    }
+}
+
+inline void rotateToClosestExistingPoint(Polyline& line, const Point& query_point) {
+    if (line.size() < 2) {
+        return;
+    }
+
+    double closest_distance = std::numeric_limits<double>::max();
+    int rotation_index = 0;
+
+    for (int i = 0, end = line.size(); i < end; ++i) {
+        const double distance = line[i].distance(query_point)();
+        if (distance < closest_distance) {
+            closest_distance = distance;
+            rotation_index = i;
+        }
+    }
+
+    for (int i = 0; i < rotation_index; ++i) {
+        line.move(0, line.size() - 1);
+    }
+}
+
+inline void rotateToClosestForwardExistingPoint(Polyline& line, const Point& query_point, const Point& direction_start,
+                                                const Point& direction_end) {
+    if (line.size() < 2) {
+        return;
+    }
+
+    const double direction_x = direction_end.x() - direction_start.x();
+    const double direction_y = direction_end.y() - direction_start.y();
+    const double direction_length_sq = (direction_x * direction_x) + (direction_y * direction_y);
+    if (direction_length_sq <= std::numeric_limits<double>::epsilon()) {
+        rotateToClosestExistingPoint(line, query_point);
+        return;
+    }
+
+    double closest_distance = std::numeric_limits<double>::max();
+    double closest_fallback_distance = std::numeric_limits<double>::max();
+    int rotation_index = 0;
+    int fallback_index = 0;
+    bool found_forward_point = false;
+
+    for (int i = 0, end = line.size(); i < end; ++i) {
+        const double candidate_x = line[i].x() - query_point.x();
+        const double candidate_y = line[i].y() - query_point.y();
+        const double projection = (candidate_x * direction_x) + (candidate_y * direction_y);
+        const double distance = line[i].distance(query_point)();
+
+        if (distance < closest_fallback_distance) {
+            closest_fallback_distance = distance;
+            fallback_index = i;
+        }
+
+        if (projection >= -std::numeric_limits<double>::epsilon() && distance < closest_distance) {
+            closest_distance = distance;
+            rotation_index = i;
+            found_forward_point = true;
+        }
+    }
+
+    if (!found_forward_point) {
+        rotation_index = fallback_index;
+    }
+
+    for (int i = 0; i < rotation_index; ++i) {
+        line.move(0, line.size() - 1);
+    }
+}
+
+inline Distance validWidthOrFallback(Distance width, Distance fallback_width) {
+    return width > 0 ? width : fallback_width;
+}
+
+inline Distance transitionDistance(Distance current_width, Distance next_width, Distance fallback_width) {
+    return (validWidthOrFallback(current_width, fallback_width) + validWidthOrFallback(next_width, fallback_width)) / 2;
+}
+
+inline Point prepareConnector(const Polyline& current_loop, Polyline& next_loop, Distance stop_distance) {
+    Point connector_start = stopPointOnClosingSegment(current_loop, stop_distance);
+    if (next_loop.size() >= 3) {
+        rotateToClosestForwardExistingPoint(next_loop, connector_start, current_loop.back(), current_loop.front());
+    }
+
+    return connector_start;
+}
+
+struct StitchLoop {
+    Polyline loop;
+    Distance width;
+};
 } // namespace detail
 
 /*!
@@ -53,17 +220,93 @@ inline Distance closedPolylineLength(const Polyline& line) {
 }
 
 /*!
+ * \brief Returns the point on a closed loop's closing segment where a spiral transition should begin.
+ */
+inline Point transitionStartPoint(const Polyline& line, Distance distance_before_start) {
+    return detail::stopPointOnClosingSegment(line, distance_before_start);
+}
+
+/*!
  * \brief Links ordered closed loops into one open spiral-style polyline.
  *
  * \param ordered_loops Closed loops without a repeated final point.
- * \param final_stop_distance Distance to leave unprinted before the loop start when closing smoothly.
+ * \param loop_widths Bead widths for the ordered loops.
+ * \param fallback_width Width used when a per-loop width is not supplied.
  * \return One polyline that walks each loop and transitions to the next loop before fully closing.
  */
-inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Distance final_stop_distance) {
+inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, const QVector<Distance>& loop_widths,
+                                    Distance fallback_width) {
+    QVector<detail::StitchLoop> loops;
+    loops.reserve(ordered_loops.size());
+    for (int i = 0, end = ordered_loops.size(); i < end; ++i) {
+        loops.push_back({ordered_loops[i], i < loop_widths.size() ? loop_widths[i] : fallback_width});
+    }
+
+    bool has_reference_orientation = false;
+    bool reference_orientation = false;
+    for (const detail::StitchLoop& stitch_loop : loops) {
+        if (stitch_loop.loop.size() >= 3) {
+            reference_orientation = stitch_loop.loop.orientation();
+            has_reference_orientation = true;
+            break;
+        }
+    }
+    if (has_reference_orientation) {
+        for (detail::StitchLoop& stitch_loop : loops) {
+            detail::alignOrientation(stitch_loop.loop, reference_orientation);
+        }
+    }
+
     Polyline spiral;
 
-    for (int loop_index = 0, end = ordered_loops.size(); loop_index < end; ++loop_index) {
-        const Polyline& loop = ordered_loops[loop_index];
+    while (!loops.isEmpty() && loops.front().loop.size() < 3) {
+        loops.removeFirst();
+    }
+
+    if (loops.isEmpty()) {
+        return spiral;
+    }
+
+    detail::StitchLoop current_loop = loops.takeFirst();
+    while (true) {
+        spiral += current_loop.loop;
+
+        while (!loops.isEmpty() && loops.front().loop.size() < 3) {
+            loops.removeFirst();
+        }
+
+        if (!loops.isEmpty()) {
+            detail::StitchLoop next_loop = loops.takeFirst();
+            const Distance stop_distance =
+                detail::transitionDistance(current_loop.width, next_loop.width, fallback_width);
+            const Point connector_start = detail::prepareConnector(current_loop.loop, next_loop.loop, stop_distance);
+
+            if (spiral.back() != connector_start) {
+                spiral += connector_start;
+            }
+
+            current_loop = next_loop;
+        }
+        else {
+            const Point final_stop = detail::stopPointOnClosingSegment(
+                current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width));
+
+            if (spiral.back() != final_stop) {
+                spiral += final_stop;
+            }
+            break;
+        }
+    }
+
+    return spiral;
+}
+
+inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Distance final_stop_distance) {
+    QVector<Polyline> loops = ordered_loops;
+    Polyline spiral;
+
+    for (int loop_index = 0, end = loops.size(); loop_index < end; ++loop_index) {
+        const Polyline& loop = loops[loop_index];
         if (loop.size() < 3) {
             continue;
         }
@@ -71,10 +314,13 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Dist
         spiral += loop;
 
         if (loop_index + 1 < end) {
-            const Point next_start = ordered_loops[loop_index + 1].front();
+            Polyline next_loop = loops[loop_index + 1];
+            Point rough_connector_start = detail::stopPointOnClosingSegment(loop, final_stop_distance);
+            detail::rotateToClosestForwardExistingPoint(next_loop, rough_connector_start, loop.back(), loop.front());
+            const Point next_start = next_loop.front();
             Point connector_start;
             if (detail::hasSmoothClosingSegment(loop)) {
-                connector_start = detail::stopPointOnClosingSegment(loop, final_stop_distance);
+                connector_start = rough_connector_start;
             }
             else {
                 connector_start = MathUtils::nearestPointOnSegment(loop.back(), loop.front(), next_start).first;
@@ -83,6 +329,8 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Dist
             if (spiral.back() != connector_start) {
                 spiral += connector_start;
             }
+
+            loops[loop_index + 1] = next_loop;
         }
         else {
             const Point final_stop = detail::stopPointOnClosingSegment(loop, final_stop_distance);
@@ -95,5 +343,6 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Dist
 
     return spiral;
 }
+
 } // namespace SpiralPath
 } // namespace ORNL

--- a/include/step/layer/regions/inset.h
+++ b/include/step/layer/regions/inset.h
@@ -50,6 +50,12 @@ class Inset : public RegionBase {
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
     void calculateModifiers(Path& path, bool supportsG3) override;
 
+    //! \brief Creates modifiers, optionally treating forward tip wipe as an open-loop wipe.
+    //! \param path Current path to add modifiers to
+    //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
+    //! \param open_loop_tip_wipe Whether forward tip wipe should be emitted from the open path end.
+    void calculateModifiers(Path& path, bool supportsG3, bool open_loop_tip_wipe);
+
     /**
      * @brief Create a path with localized settings applied to segments based on settings regions.
      * @param[in] line Polyline representing the path.

--- a/include/step/layer/regions/perimeter.h
+++ b/include/step/layer/regions/perimeter.h
@@ -53,6 +53,12 @@ class Perimeter : public RegionBase {
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
     void calculateModifiers(Path& path, bool supportsG3) override;
 
+    //! \brief Creates modifiers, optionally treating forward tip wipe as an open-loop wipe.
+    //! \param path Current path to add modifiers to
+    //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
+    //! \param open_loop_tip_wipe Whether forward tip wipe should be emitted from the open path end.
+    void calculateModifiers(Path& path, bool supportsG3, bool open_loop_tip_wipe);
+
     /**
      * @brief Create a path with localized settings applied to segments based on settings regions.
      * @param[in] line Polyline representing the path.

--- a/src/optimizers/polyline_order_optimizer.cpp
+++ b/src/optimizers/polyline_order_optimizer.cpp
@@ -439,7 +439,7 @@ Polyline PolylineOrderOptimizer::linkTo() {
 
 int PolylineOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
     Point queryPoint;
-    if (m_override_used)
+    if (m_optimization == PathOrderOptimization::kCustomPoint && m_override_used)
         queryPoint = m_override_location;
     else
         queryPoint = m_current_location;

--- a/src/step/layer/regions/inset.cpp
+++ b/src/step/layer/regions/inset.cpp
@@ -290,6 +290,21 @@ Distance adaptiveContourWidth(PolygonList geometry, Distance nominal_width, int 
                              [](const Distance& lhs, const Distance& rhs) { return lhs() < rhs(); });
 }
 
+double closedPolylineAreaAbs(const Polyline& line) {
+    if (line.size() < 3) {
+        return 0.0;
+    }
+
+    double area = 0.0;
+    for (int i = 0, end = line.size(); i < end; ++i) {
+        const Point& current = line[i];
+        const Point& next = line[(i + 1) % line.size()];
+        area += (current.x() * next.y()) - (next.x() * current.y());
+    }
+
+    return std::fabs(area) * 0.5;
+}
+
 double distanceXYToSegment(const Point& point, const Point& start, const Point& end) {
     const double dx = end.x() - start.x();
     const double dy = end.y() - start.y();
@@ -302,6 +317,26 @@ double distanceXYToSegment(const Point& point, const Point& start, const Point& 
     const double nearest_x = start.x() + t * dx;
     const double nearest_y = start.y() + t * dy;
     return std::hypot(point.x() - nearest_x, point.y() - nearest_y);
+}
+
+double closedPolylineMinDistance(const Polyline& lhs, const Polyline& rhs) {
+    if (lhs.isEmpty() || rhs.isEmpty()) {
+        return std::numeric_limits<double>::max();
+    }
+
+    double min_distance = std::numeric_limits<double>::max();
+    for (const Point& point : lhs) {
+        for (int i = 0, end = rhs.size(); i < end; ++i) {
+            min_distance = std::min(min_distance, distanceXYToSegment(point, rhs[i], rhs[(i + 1) % rhs.size()]));
+        }
+    }
+    for (const Point& point : rhs) {
+        for (int i = 0, end = lhs.size(); i < end; ++i) {
+            min_distance = std::min(min_distance, distanceXYToSegment(point, lhs[i], lhs[(i + 1) % lhs.size()]));
+        }
+    }
+
+    return min_distance;
 }
 
 bool pointOnClosedPolylineXY(const Point& point, const Polyline& line, double tolerance) {
@@ -462,27 +497,109 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
     }
 
     if (m_sb->setting<bool>(PS::Inset::kEnableSpiralInset)) {
-        Point spiral_query_location = current_location;
-        PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
-        configureOptimizer(spiral_poo, pointOrderOptimization);
-        spiral_poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kInset, pathOrderOptimization);
+        if (!m_sb->setting<bool>(PS::Inset::kAdaptive)) {
+            Point spiral_query_location = current_location;
+            PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
+            configureOptimizer(spiral_poo, pointOrderOptimization);
+            spiral_poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kInset, pathOrderOptimization);
 
-        QVector<Polyline> ordered_insets;
-        const Distance min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
+            QVector<Polyline> ordered_insets;
+            const Distance min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
+            const Distance bead_width = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
 
-        while (spiral_poo.getCurrentPolylineCount() > 0) {
-            if (!ordered_insets.isEmpty()) {
-                spiral_poo.setPointParameters(PointOrderOptimization::kNextClosest, false, 0, 0, false, 0, true);
+            while (spiral_poo.getCurrentPolylineCount() > 0) {
+                if (!ordered_insets.isEmpty()) {
+                    spiral_poo.setPointParameters(PointOrderOptimization::kNextClosest, false, 0, 0, false, 0,
+                                                  false);
+                }
+
+                Polyline result = spiral_poo.linkNextPolyline();
+
+                if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
+                    continue;
+                }
+
+                spiral_query_location = SpiralPath::transitionStartPoint(result, bead_width);
+                ordered_insets.push_back(result);
             }
 
-            Polyline result = spiral_poo.linkNextPolyline();
+            if (ordered_insets.isEmpty()) {
+                return;
+            }
 
+            if (ordered_insets.size() == 1) {
+                Polyline result = ordered_insets.first();
+
+                Path newPath = createPath(result);
+                newPath.setCCW(result.orientation());
+
+                if (newPath.calculateLength() < min_path_length) {
+                    return;
+                }
+
+                if (newPath.size() > 0) {
+                    calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+                    PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                          m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+                    current_location = newPath.back()->end();
+                    m_paths.push_back(newPath);
+                }
+
+                return;
+            }
+
+            Polyline result = SpiralPath::linkClosedPolylines(ordered_insets, bead_width);
+
+            if (result.size() < 3) {
+                return;
+            }
+
+            Path newPath = createPath(result);
+            newPath.setCCW(ordered_insets.front().orientation());
+
+            if (newPath.size() > 0) {
+                newPath.getSegments().removeLast();
+            }
+
+            if (newPath.calculateLength() < min_path_length) {
+                return;
+            }
+
+            if (newPath.size() > 0) {
+                calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
+                PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                      m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+                current_location = newPath.back()->end();
+                m_paths.push_back(newPath);
+            }
+
+            return;
+        }
+
+        QVector<Polyline> ordered_insets;
+        QVector<Distance> ordered_inset_widths;
+        bool has_spiral_orientation = false;
+        bool spiral_orientation = false;
+        const Distance min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
+
+        for (Polyline result : m_computed_geometry) {
             if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
                 continue;
             }
 
-            // Keep loop choice near the local seam to avoid jumping across the island on the next transition.
-            spiral_query_location = result.front();
+            if (!has_spiral_orientation) {
+                spiral_orientation = result.orientation();
+                has_spiral_orientation = true;
+            }
+            else if (result.orientation() != spiral_orientation) {
+                result = result.reverse();
+                result.move(result.size() - 1, 0);
+            }
+
+            const Distance result_width = beadWidthForSegment(result.front(), result[1], m_sb);
+            ordered_inset_widths.push_back(result_width);
             ordered_insets.push_back(result);
         }
 
@@ -490,8 +607,93 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
             return;
         }
 
+        if (ordered_insets.size() == 1) {
+            PolylineOrderOptimizer first_loop_poo(current_location, layerNumber);
+            configureOptimizer(first_loop_poo, pointOrderOptimization);
+            first_loop_poo.setGeometryToEvaluate({ordered_insets.first()}, RegionType::kInset,
+                                                 PathOrderOptimization::kNextClosest);
+            Polyline result = first_loop_poo.linkNextPolyline();
+            if (result.size() < 3) {
+                result = ordered_insets.first();
+            }
+
+            Path newPath = createPath(result);
+            newPath.setCCW(result.orientation());
+
+            if (newPath.calculateLength() < min_path_length) {
+                return;
+            }
+
+            if (newPath.size() > 0) {
+                calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+                PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                      m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+                current_location = newPath.back()->end();
+                m_paths.push_back(newPath);
+            }
+
+            return;
+        }
+
+        QVector<Polyline> remaining_insets = ordered_insets;
+        QVector<Distance> remaining_widths = ordered_inset_widths;
+        QVector<Polyline> outside_in_insets;
+        QVector<Distance> outside_in_widths;
+        outside_in_insets.reserve(ordered_insets.size());
+        outside_in_widths.reserve(ordered_inset_widths.size());
+
+        int next_index = 0;
+        double next_area = closedPolylineAreaAbs(remaining_insets.first());
+        for (int i = 1, end = remaining_insets.size(); i < end; ++i) {
+            const double area = closedPolylineAreaAbs(remaining_insets[i]);
+            if (area > next_area) {
+                next_area = area;
+                next_index = i;
+            }
+        }
+
+        outside_in_insets.push_back(remaining_insets.takeAt(next_index));
+        outside_in_widths.push_back(remaining_widths.takeAt(next_index));
+
+        while (!remaining_insets.isEmpty()) {
+            next_index = 0;
+            double next_distance = closedPolylineMinDistance(outside_in_insets.back(), remaining_insets.first());
+            double next_area_delta =
+                std::fabs(closedPolylineAreaAbs(outside_in_insets.back()) -
+                          closedPolylineAreaAbs(remaining_insets.first()));
+
+            for (int i = 1, end = remaining_insets.size(); i < end; ++i) {
+                const double distance = closedPolylineMinDistance(outside_in_insets.back(), remaining_insets[i]);
+                const double area_delta = std::fabs(closedPolylineAreaAbs(outside_in_insets.back()) -
+                                                    closedPolylineAreaAbs(remaining_insets[i]));
+                if (distance < next_distance ||
+                    (std::fabs(distance - next_distance) <= 1.0e-6 && area_delta < next_area_delta)) {
+                    next_distance = distance;
+                    next_area_delta = area_delta;
+                    next_index = i;
+                }
+            }
+
+            outside_in_insets.push_back(remaining_insets.takeAt(next_index));
+            outside_in_widths.push_back(remaining_widths.takeAt(next_index));
+        }
+
+        ordered_insets = outside_in_insets;
+        ordered_inset_widths = outside_in_widths;
+
+        PolylineOrderOptimizer first_loop_poo(current_location, layerNumber);
+        configureOptimizer(first_loop_poo, pointOrderOptimization);
+        first_loop_poo.setGeometryToEvaluate({ordered_insets.first()}, RegionType::kInset,
+                                             PathOrderOptimization::kNextClosest);
+        Polyline first_loop = first_loop_poo.linkNextPolyline();
+        if (first_loop.size() >= 3) {
+            ordered_insets[0] = first_loop;
+        }
+
+        const Distance nominal_width = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
         Polyline result =
-            SpiralPath::linkClosedPolylines(ordered_insets, m_sb->setting<Distance>(PS::Inset::kBeadWidth));
+            SpiralPath::linkClosedPolylines(ordered_insets, ordered_inset_widths, nominal_width);
 
         if (result.size() < 3) {
             return;
@@ -509,7 +711,7 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
         }
 
         if (newPath.size() > 0) {
-            calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+            calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
             PathModifierGenerator::GenerateTravel(newPath, current_location,
                                                   m_sb->setting<Velocity>(PS::Travel::kSpeed));
 
@@ -578,7 +780,9 @@ Path Inset::createPath(Polyline line) {
 
 QVector<Polyline> Inset::getComputedGeometry() { return m_computed_geometry; }
 
-void Inset::calculateModifiers(Path& path, bool supportsG3) {
+void Inset::calculateModifiers(Path& path, bool supportsG3) { calculateModifiers(path, supportsG3, false); }
+
+void Inset::calculateModifiers(Path& path, bool supportsG3, bool open_loop_tip_wipe) {
     if (m_sb->setting<bool>(ES::Ramping::kTrajectoryAngleEnabled)) {
         PathModifierGenerator::GenerateTrajectorySlowdown(path, m_sb);
     }
@@ -594,18 +798,29 @@ void Inset::calculateModifiers(Path& path, bool supportsG3) {
                                                 m_sb->setting<double>(MS::Slowdown::kSlowDownAreaModifier));
     }
     if (m_sb->setting<bool>(MS::TipWipe::kInsetEnable)) {
-        if (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kInsetDirection)) ==
-                TipWipeDirection::kForward ||
-            static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kInsetDirection)) ==
-                TipWipeDirection::kOptimal)
-            PathModifierGenerator::GenerateTipWipe(
-                path, PathModifiers::kForwardTipWipe, m_sb->setting<Distance>(MS::TipWipe::kInsetDistance),
-                m_sb->setting<Velocity>(MS::TipWipe::kInsetSpeed), m_sb->setting<Angle>(MS::TipWipe::kInsetAngle),
-                m_sb->setting<AngularVelocity>(MS::TipWipe::kInsetExtruderSpeed),
-                m_sb->setting<Distance>(MS::TipWipe::kInsetLiftHeight),
-                m_sb->setting<Distance>(MS::TipWipe::kInsetCutoffDistance));
-        else if (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kInsetDirection)) ==
-                 TipWipeDirection::kAngled) {
+        const TipWipeDirection wipe_direction =
+            static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kInsetDirection));
+        if (wipe_direction == TipWipeDirection::kForward ||
+            (!open_loop_tip_wipe && wipe_direction == TipWipeDirection::kOptimal)) {
+            if (open_loop_tip_wipe && wipe_direction == TipWipeDirection::kForward) {
+                PathModifierGenerator::GenerateForwardTipWipeOpenLoop(
+                    path, PathModifiers::kForwardTipWipe, m_sb->setting<Distance>(MS::TipWipe::kInsetDistance),
+                    m_sb->setting<Velocity>(MS::TipWipe::kInsetSpeed),
+                    m_sb->setting<AngularVelocity>(MS::TipWipe::kInsetExtruderSpeed),
+                    m_sb->setting<Distance>(MS::TipWipe::kInsetLiftHeight),
+                    m_sb->setting<Distance>(MS::TipWipe::kInsetCutoffDistance));
+            }
+            else {
+                PathModifierGenerator::GenerateTipWipe(
+                    path, PathModifiers::kForwardTipWipe, m_sb->setting<Distance>(MS::TipWipe::kInsetDistance),
+                    m_sb->setting<Velocity>(MS::TipWipe::kInsetSpeed),
+                    m_sb->setting<Angle>(MS::TipWipe::kInsetAngle),
+                    m_sb->setting<AngularVelocity>(MS::TipWipe::kInsetExtruderSpeed),
+                    m_sb->setting<Distance>(MS::TipWipe::kInsetLiftHeight),
+                    m_sb->setting<Distance>(MS::TipWipe::kInsetCutoffDistance));
+            }
+        }
+        else if (wipe_direction == TipWipeDirection::kAngled) {
             PathModifierGenerator::GenerateTipWipe(
                 path, PathModifiers::kAngledTipWipe, m_sb->setting<Distance>(MS::TipWipe::kInsetDistance),
                 m_sb->setting<Velocity>(MS::TipWipe::kInsetSpeed), m_sb->setting<Angle>(MS::TipWipe::kInsetAngle),

--- a/src/step/layer/regions/inset.cpp
+++ b/src/step/layer/regions/inset.cpp
@@ -290,21 +290,6 @@ Distance adaptiveContourWidth(PolygonList geometry, Distance nominal_width, int 
                              [](const Distance& lhs, const Distance& rhs) { return lhs() < rhs(); });
 }
 
-double closedPolylineAreaAbs(const Polyline& line) {
-    if (line.size() < 3) {
-        return 0.0;
-    }
-
-    double area = 0.0;
-    for (int i = 0, end = line.size(); i < end; ++i) {
-        const Point& current = line[i];
-        const Point& next = line[(i + 1) % line.size()];
-        area += (current.x() * next.y()) - (next.x() * current.y());
-    }
-
-    return std::fabs(area) * 0.5;
-}
-
 double distanceXYToSegment(const Point& point, const Point& start, const Point& end) {
     const double dx = end.x() - start.x();
     const double dy = end.y() - start.y();
@@ -317,26 +302,6 @@ double distanceXYToSegment(const Point& point, const Point& start, const Point& 
     const double nearest_x = start.x() + t * dx;
     const double nearest_y = start.y() + t * dy;
     return std::hypot(point.x() - nearest_x, point.y() - nearest_y);
-}
-
-double closedPolylineMinDistance(const Polyline& lhs, const Polyline& rhs) {
-    if (lhs.isEmpty() || rhs.isEmpty()) {
-        return std::numeric_limits<double>::max();
-    }
-
-    double min_distance = std::numeric_limits<double>::max();
-    for (const Point& point : lhs) {
-        for (int i = 0, end = rhs.size(); i < end; ++i) {
-            min_distance = std::min(min_distance, distanceXYToSegment(point, rhs[i], rhs[(i + 1) % rhs.size()]));
-        }
-    }
-    for (const Point& point : rhs) {
-        for (int i = 0, end = lhs.size(); i < end; ++i) {
-            min_distance = std::min(min_distance, distanceXYToSegment(point, lhs[i], lhs[(i + 1) % lhs.size()]));
-        }
-    }
-
-    return min_distance;
 }
 
 bool pointOnClosedPolylineXY(const Point& point, const Polyline& line, double tolerance) {
@@ -578,13 +543,24 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
             return;
         }
 
+        Point spiral_query_location = current_location;
+        PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
+        configureOptimizer(spiral_poo, pointOrderOptimization);
+        spiral_poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kInset, pathOrderOptimization);
+
         QVector<Polyline> ordered_insets;
         QVector<Distance> ordered_inset_widths;
         bool has_spiral_orientation = false;
         bool spiral_orientation = false;
         const Distance min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
 
-        for (Polyline result : m_computed_geometry) {
+        while (spiral_poo.getCurrentPolylineCount() > 0) {
+            if (!ordered_insets.isEmpty()) {
+                spiral_poo.setPointParameters(PointOrderOptimization::kNextClosest, false, 0, 0, false, 0, false);
+            }
+
+            Polyline result = spiral_poo.linkNextPolyline();
+
             if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
                 continue;
             }
@@ -601,6 +577,7 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
             const Distance result_width = beadWidthForSegment(result.front(), result[1], m_sb);
             ordered_inset_widths.push_back(result_width);
             ordered_insets.push_back(result);
+            spiral_query_location = SpiralPath::transitionStartPoint(result, result_width);
         }
 
         if (ordered_insets.isEmpty()) {
@@ -634,61 +611,6 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
             }
 
             return;
-        }
-
-        QVector<Polyline> remaining_insets = ordered_insets;
-        QVector<Distance> remaining_widths = ordered_inset_widths;
-        QVector<Polyline> outside_in_insets;
-        QVector<Distance> outside_in_widths;
-        outside_in_insets.reserve(ordered_insets.size());
-        outside_in_widths.reserve(ordered_inset_widths.size());
-
-        int next_index = 0;
-        double next_area = closedPolylineAreaAbs(remaining_insets.first());
-        for (int i = 1, end = remaining_insets.size(); i < end; ++i) {
-            const double area = closedPolylineAreaAbs(remaining_insets[i]);
-            if (area > next_area) {
-                next_area = area;
-                next_index = i;
-            }
-        }
-
-        outside_in_insets.push_back(remaining_insets.takeAt(next_index));
-        outside_in_widths.push_back(remaining_widths.takeAt(next_index));
-
-        while (!remaining_insets.isEmpty()) {
-            next_index = 0;
-            double next_distance = closedPolylineMinDistance(outside_in_insets.back(), remaining_insets.first());
-            double next_area_delta =
-                std::fabs(closedPolylineAreaAbs(outside_in_insets.back()) -
-                          closedPolylineAreaAbs(remaining_insets.first()));
-
-            for (int i = 1, end = remaining_insets.size(); i < end; ++i) {
-                const double distance = closedPolylineMinDistance(outside_in_insets.back(), remaining_insets[i]);
-                const double area_delta = std::fabs(closedPolylineAreaAbs(outside_in_insets.back()) -
-                                                    closedPolylineAreaAbs(remaining_insets[i]));
-                if (distance < next_distance ||
-                    (std::fabs(distance - next_distance) <= 1.0e-6 && area_delta < next_area_delta)) {
-                    next_distance = distance;
-                    next_area_delta = area_delta;
-                    next_index = i;
-                }
-            }
-
-            outside_in_insets.push_back(remaining_insets.takeAt(next_index));
-            outside_in_widths.push_back(remaining_widths.takeAt(next_index));
-        }
-
-        ordered_insets = outside_in_insets;
-        ordered_inset_widths = outside_in_widths;
-
-        PolylineOrderOptimizer first_loop_poo(current_location, layerNumber);
-        configureOptimizer(first_loop_poo, pointOrderOptimization);
-        first_loop_poo.setGeometryToEvaluate({ordered_insets.first()}, RegionType::kInset,
-                                             PathOrderOptimization::kNextClosest);
-        Polyline first_loop = first_loop_poo.linkNextPolyline();
-        if (first_loop.size() >= 3) {
-            ordered_insets[0] = first_loop;
         }
 
         const Distance nominal_width = m_sb->setting<Distance>(PS::Inset::kBeadWidth);

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -319,21 +319,6 @@ Distance adaptiveContourWidth(PolygonList geometry, Distance nominal_width, int 
                              [](const Distance& lhs, const Distance& rhs) { return lhs() < rhs(); });
 }
 
-double closedPolylineAreaAbs(const Polyline& line) {
-    if (line.size() < 3) {
-        return 0.0;
-    }
-
-    double area = 0.0;
-    for (int i = 0, end = line.size(); i < end; ++i) {
-        const Point& current = line[i];
-        const Point& next = line[(i + 1) % line.size()];
-        area += (current.x() * next.y()) - (next.x() * current.y());
-    }
-
-    return std::fabs(area) * 0.5;
-}
-
 double distanceXYToSegment(const Point& point, const Point& start, const Point& end) {
     const double dx = end.x() - start.x();
     const double dy = end.y() - start.y();
@@ -346,26 +331,6 @@ double distanceXYToSegment(const Point& point, const Point& start, const Point& 
     const double nearest_x = start.x() + t * dx;
     const double nearest_y = start.y() + t * dy;
     return std::hypot(point.x() - nearest_x, point.y() - nearest_y);
-}
-
-double closedPolylineMinDistance(const Polyline& lhs, const Polyline& rhs) {
-    if (lhs.isEmpty() || rhs.isEmpty()) {
-        return std::numeric_limits<double>::max();
-    }
-
-    double min_distance = std::numeric_limits<double>::max();
-    for (const Point& point : lhs) {
-        for (int i = 0, end = rhs.size(); i < end; ++i) {
-            min_distance = std::min(min_distance, distanceXYToSegment(point, rhs[i], rhs[(i + 1) % rhs.size()]));
-        }
-    }
-    for (const Point& point : rhs) {
-        for (int i = 0, end = lhs.size(); i < end; ++i) {
-            min_distance = std::min(min_distance, distanceXYToSegment(point, lhs[i], lhs[(i + 1) % lhs.size()]));
-        }
-    }
-
-    return min_distance;
 }
 
 bool pointOnClosedPolylineXY(const Point& point, const Polyline& line, double tolerance) {
@@ -689,13 +654,25 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 return;
             }
 
+            Point spiral_query_location = current_location;
+            PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
+            configureOptimizer(spiral_poo, pointOrderOptimization);
+            spiral_poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kPerimeter, pathOrderOptimization);
+
             QVector<Polyline> ordered_perimeters;
             QVector<Distance> ordered_perimeter_widths;
             bool has_spiral_orientation = false;
             bool spiral_orientation = false;
             const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
 
-            for (Polyline result : m_computed_geometry) {
+            while (spiral_poo.getCurrentPolylineCount() > 0) {
+                if (!ordered_perimeters.isEmpty()) {
+                    spiral_poo.setPointParameters(PointOrderOptimization::kNextClosest, false, 0, 0, false, 0,
+                                                  false);
+                }
+
+                Polyline result = spiral_poo.linkNextPolyline();
+
                 if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
                     continue;
                 }
@@ -712,6 +689,7 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 const Distance result_width = beadWidthForSegment(result.front(), result[1], m_sb);
                 ordered_perimeter_widths.push_back(result_width);
                 ordered_perimeters.push_back(result);
+                spiral_query_location = SpiralPath::transitionStartPoint(result, result_width);
             }
 
             if (ordered_perimeters.isEmpty()) {
@@ -745,64 +723,6 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 }
 
                 return;
-            }
-
-            QVector<Polyline> remaining_perimeters = ordered_perimeters;
-            QVector<Distance> remaining_widths = ordered_perimeter_widths;
-            QVector<Polyline> outside_in_perimeters;
-            QVector<Distance> outside_in_widths;
-            outside_in_perimeters.reserve(ordered_perimeters.size());
-            outside_in_widths.reserve(ordered_perimeter_widths.size());
-
-            int next_index = 0;
-            double next_area = closedPolylineAreaAbs(remaining_perimeters.first());
-            for (int i = 1, end = remaining_perimeters.size(); i < end; ++i) {
-                const double area = closedPolylineAreaAbs(remaining_perimeters[i]);
-                if (area > next_area) {
-                    next_area = area;
-                    next_index = i;
-                }
-            }
-
-            outside_in_perimeters.push_back(remaining_perimeters.takeAt(next_index));
-            outside_in_widths.push_back(remaining_widths.takeAt(next_index));
-
-            while (!remaining_perimeters.isEmpty()) {
-                next_index = 0;
-                double next_distance = closedPolylineMinDistance(outside_in_perimeters.back(),
-                                                                 remaining_perimeters.first());
-                double next_area_delta =
-                    std::fabs(closedPolylineAreaAbs(outside_in_perimeters.back()) -
-                              closedPolylineAreaAbs(remaining_perimeters.first()));
-
-                for (int i = 1, end = remaining_perimeters.size(); i < end; ++i) {
-                    const double distance =
-                        closedPolylineMinDistance(outside_in_perimeters.back(), remaining_perimeters[i]);
-                    const double area_delta =
-                        std::fabs(closedPolylineAreaAbs(outside_in_perimeters.back()) -
-                                  closedPolylineAreaAbs(remaining_perimeters[i]));
-                    if (distance < next_distance ||
-                        (std::fabs(distance - next_distance) <= 1.0e-6 && area_delta < next_area_delta)) {
-                        next_distance = distance;
-                        next_area_delta = area_delta;
-                        next_index = i;
-                    }
-                }
-
-                outside_in_perimeters.push_back(remaining_perimeters.takeAt(next_index));
-                outside_in_widths.push_back(remaining_widths.takeAt(next_index));
-            }
-
-            ordered_perimeters = outside_in_perimeters;
-            ordered_perimeter_widths = outside_in_widths;
-
-            PolylineOrderOptimizer first_loop_poo(current_location, layerNumber);
-            configureOptimizer(first_loop_poo, pointOrderOptimization);
-            first_loop_poo.setGeometryToEvaluate({ordered_perimeters.first()}, RegionType::kPerimeter,
-                                                 PathOrderOptimization::kNextClosest);
-            Polyline first_loop = first_loop_poo.linkNextPolyline();
-            if (first_loop.size() >= 3) {
-                ordered_perimeters[0] = first_loop;
             }
 
             const Distance nominal_width = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -319,6 +319,21 @@ Distance adaptiveContourWidth(PolygonList geometry, Distance nominal_width, int 
                              [](const Distance& lhs, const Distance& rhs) { return lhs() < rhs(); });
 }
 
+double closedPolylineAreaAbs(const Polyline& line) {
+    if (line.size() < 3) {
+        return 0.0;
+    }
+
+    double area = 0.0;
+    for (int i = 0, end = line.size(); i < end; ++i) {
+        const Point& current = line[i];
+        const Point& next = line[(i + 1) % line.size()];
+        area += (current.x() * next.y()) - (next.x() * current.y());
+    }
+
+    return std::fabs(area) * 0.5;
+}
+
 double distanceXYToSegment(const Point& point, const Point& start, const Point& end) {
     const double dx = end.x() - start.x();
     const double dy = end.y() - start.y();
@@ -331,6 +346,26 @@ double distanceXYToSegment(const Point& point, const Point& start, const Point& 
     const double nearest_x = start.x() + t * dx;
     const double nearest_y = start.y() + t * dy;
     return std::hypot(point.x() - nearest_x, point.y() - nearest_y);
+}
+
+double closedPolylineMinDistance(const Polyline& lhs, const Polyline& rhs) {
+    if (lhs.isEmpty() || rhs.isEmpty()) {
+        return std::numeric_limits<double>::max();
+    }
+
+    double min_distance = std::numeric_limits<double>::max();
+    for (const Point& point : lhs) {
+        for (int i = 0, end = rhs.size(); i < end; ++i) {
+            min_distance = std::min(min_distance, distanceXYToSegment(point, rhs[i], rhs[(i + 1) % rhs.size()]));
+        }
+    }
+    for (const Point& point : rhs) {
+        for (int i = 0, end = lhs.size(); i < end; ++i) {
+            min_distance = std::min(min_distance, distanceXYToSegment(point, lhs[i], lhs[(i + 1) % lhs.size()]));
+        }
+    }
+
+    return min_distance;
 }
 
 bool pointOnClosedPolylineXY(const Point& point, const Polyline& line, double tolerance) {
@@ -573,27 +608,109 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
             }
 
         if (m_sb->setting<bool>(PS::Perimeter::kEnableSpiralPerimeter)) {
-            Point spiral_query_location = current_location;
-            PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
-            configureOptimizer(spiral_poo, pointOrderOptimization);
-            spiral_poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kPerimeter, pathOrderOptimization);
+            if (!m_sb->setting<bool>(PS::Perimeter::kAdaptive)) {
+                Point spiral_query_location = current_location;
+                PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
+                configureOptimizer(spiral_poo, pointOrderOptimization);
+                spiral_poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kPerimeter, pathOrderOptimization);
 
-            QVector<Polyline> ordered_perimeters;
-            const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
+                QVector<Polyline> ordered_perimeters;
+                const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
+                const Distance bead_width = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
 
-            while (spiral_poo.getCurrentPolylineCount() > 0) {
-                if (!ordered_perimeters.isEmpty()) {
-                    spiral_poo.setPointParameters(PointOrderOptimization::kNextClosest, false, 0, 0, false, 0, true);
+                while (spiral_poo.getCurrentPolylineCount() > 0) {
+                    if (!ordered_perimeters.isEmpty()) {
+                        spiral_poo.setPointParameters(PointOrderOptimization::kNextClosest, false, 0, 0, false, 0,
+                                                      false);
+                    }
+
+                    Polyline result = spiral_poo.linkNextPolyline();
+
+                    if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
+                        continue;
+                    }
+
+                    spiral_query_location = SpiralPath::transitionStartPoint(result, bead_width);
+                    ordered_perimeters.push_back(result);
                 }
 
-                Polyline result = spiral_poo.linkNextPolyline();
+                if (ordered_perimeters.isEmpty()) {
+                    return;
+                }
 
+                if (ordered_perimeters.size() == 1) {
+                    Polyline result = ordered_perimeters.first();
+
+                    Path newPath = createPath(result);
+                    newPath.setCCW(result.orientation());
+
+                    if (newPath.calculateLength() < min_path_length) {
+                        return;
+                    }
+
+                    if (newPath.size() > 0) {
+                        calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+                        PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                              m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+                        current_location = newPath.back()->end();
+                        m_paths.push_back(newPath);
+                    }
+
+                    return;
+                }
+
+                Polyline result = SpiralPath::linkClosedPolylines(ordered_perimeters, bead_width);
+
+                if (result.size() < 3) {
+                    return;
+                }
+
+                Path newPath = createPath(result);
+                newPath.setCCW(ordered_perimeters.front().orientation());
+
+                if (newPath.size() > 0) {
+                    newPath.getSegments().removeLast();
+                }
+
+                if (newPath.calculateLength() < min_path_length) {
+                    return;
+                }
+
+                if (newPath.size() > 0) {
+                    calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
+                    PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                          m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+                    current_location = newPath.back()->end();
+                    m_paths.push_back(newPath);
+                }
+
+                return;
+            }
+
+            QVector<Polyline> ordered_perimeters;
+            QVector<Distance> ordered_perimeter_widths;
+            bool has_spiral_orientation = false;
+            bool spiral_orientation = false;
+            const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
+
+            for (Polyline result : m_computed_geometry) {
                 if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
                     continue;
                 }
 
-                // Keep loop choice near the local seam to avoid jumping across the island on the next transition.
-                spiral_query_location = result.front();
+                if (!has_spiral_orientation) {
+                    spiral_orientation = result.orientation();
+                    has_spiral_orientation = true;
+                }
+                else if (result.orientation() != spiral_orientation) {
+                    result = result.reverse();
+                    result.move(result.size() - 1, 0);
+                }
+
+                const Distance result_width = beadWidthForSegment(result.front(), result[1], m_sb);
+                ordered_perimeter_widths.push_back(result_width);
                 ordered_perimeters.push_back(result);
             }
 
@@ -601,8 +718,96 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 return;
             }
 
+            if (ordered_perimeters.size() == 1) {
+                PolylineOrderOptimizer first_loop_poo(current_location, layerNumber);
+                configureOptimizer(first_loop_poo, pointOrderOptimization);
+                first_loop_poo.setGeometryToEvaluate({ordered_perimeters.first()}, RegionType::kPerimeter,
+                                                     PathOrderOptimization::kNextClosest);
+                Polyline result = first_loop_poo.linkNextPolyline();
+                if (result.size() < 3) {
+                    result = ordered_perimeters.first();
+                }
+
+                Path newPath = createPath(result);
+                newPath.setCCW(result.orientation());
+
+                if (newPath.calculateLength() < min_path_length) {
+                    return;
+                }
+
+                if (newPath.size() > 0) {
+                    calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+                    PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                          m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+                    current_location = newPath.back()->end();
+                    m_paths.push_back(newPath);
+                }
+
+                return;
+            }
+
+            QVector<Polyline> remaining_perimeters = ordered_perimeters;
+            QVector<Distance> remaining_widths = ordered_perimeter_widths;
+            QVector<Polyline> outside_in_perimeters;
+            QVector<Distance> outside_in_widths;
+            outside_in_perimeters.reserve(ordered_perimeters.size());
+            outside_in_widths.reserve(ordered_perimeter_widths.size());
+
+            int next_index = 0;
+            double next_area = closedPolylineAreaAbs(remaining_perimeters.first());
+            for (int i = 1, end = remaining_perimeters.size(); i < end; ++i) {
+                const double area = closedPolylineAreaAbs(remaining_perimeters[i]);
+                if (area > next_area) {
+                    next_area = area;
+                    next_index = i;
+                }
+            }
+
+            outside_in_perimeters.push_back(remaining_perimeters.takeAt(next_index));
+            outside_in_widths.push_back(remaining_widths.takeAt(next_index));
+
+            while (!remaining_perimeters.isEmpty()) {
+                next_index = 0;
+                double next_distance = closedPolylineMinDistance(outside_in_perimeters.back(),
+                                                                 remaining_perimeters.first());
+                double next_area_delta =
+                    std::fabs(closedPolylineAreaAbs(outside_in_perimeters.back()) -
+                              closedPolylineAreaAbs(remaining_perimeters.first()));
+
+                for (int i = 1, end = remaining_perimeters.size(); i < end; ++i) {
+                    const double distance =
+                        closedPolylineMinDistance(outside_in_perimeters.back(), remaining_perimeters[i]);
+                    const double area_delta =
+                        std::fabs(closedPolylineAreaAbs(outside_in_perimeters.back()) -
+                                  closedPolylineAreaAbs(remaining_perimeters[i]));
+                    if (distance < next_distance ||
+                        (std::fabs(distance - next_distance) <= 1.0e-6 && area_delta < next_area_delta)) {
+                        next_distance = distance;
+                        next_area_delta = area_delta;
+                        next_index = i;
+                    }
+                }
+
+                outside_in_perimeters.push_back(remaining_perimeters.takeAt(next_index));
+                outside_in_widths.push_back(remaining_widths.takeAt(next_index));
+            }
+
+            ordered_perimeters = outside_in_perimeters;
+            ordered_perimeter_widths = outside_in_widths;
+
+            PolylineOrderOptimizer first_loop_poo(current_location, layerNumber);
+            configureOptimizer(first_loop_poo, pointOrderOptimization);
+            first_loop_poo.setGeometryToEvaluate({ordered_perimeters.first()}, RegionType::kPerimeter,
+                                                 PathOrderOptimization::kNextClosest);
+            Polyline first_loop = first_loop_poo.linkNextPolyline();
+            if (first_loop.size() >= 3) {
+                ordered_perimeters[0] = first_loop;
+            }
+
+            const Distance nominal_width = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
             Polyline result =
-                SpiralPath::linkClosedPolylines(ordered_perimeters, m_sb->setting<Distance>(PS::Perimeter::kBeadWidth));
+                SpiralPath::linkClosedPolylines(ordered_perimeters, ordered_perimeter_widths, nominal_width);
 
             if (result.size() < 3) {
                 return;
@@ -620,7 +825,7 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
             }
 
             if (newPath.size() > 0) {
-                calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+                calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
                 PathModifierGenerator::GenerateTravel(newPath, current_location,
                                                       m_sb->setting<Velocity>(PS::Travel::kSpeed));
 
@@ -693,7 +898,9 @@ Path Perimeter::createPath(Polyline line) {
 
 QVector<Polyline> Perimeter::getComputedGeometry() { return m_computed_geometry; }
 
-void Perimeter::calculateModifiers(Path& path, bool supportsG3) {
+void Perimeter::calculateModifiers(Path& path, bool supportsG3) { calculateModifiers(path, supportsG3, false); }
+
+void Perimeter::calculateModifiers(Path& path, bool supportsG3, bool open_loop_tip_wipe) {
     if (m_sb->setting<bool>(ES::Ramping::kTrajectoryAngleEnabled)) {
         PathModifierGenerator::GenerateTrajectorySlowdown(path, m_sb);
     }
@@ -708,19 +915,29 @@ void Perimeter::calculateModifiers(Path& path, bool supportsG3) {
                                                 m_sb->setting<double>(MS::Slowdown::kSlowDownAreaModifier));
     }
     if (m_sb->setting<bool>(MS::TipWipe::kPerimeterEnable)) {
-        if (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kPerimeterDirection)) ==
-                TipWipeDirection::kForward ||
-            static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kPerimeterDirection)) ==
-                TipWipeDirection::kOptimal)
-            PathModifierGenerator::GenerateTipWipe(path, PathModifiers::kForwardTipWipe,
-                                                   m_sb->setting<Distance>(MS::TipWipe::kPerimeterDistance),
-                                                   m_sb->setting<Velocity>(MS::TipWipe::kPerimeterSpeed),
-                                                   m_sb->setting<Angle>(MS::TipWipe::kPerimeterAngle),
-                                                   m_sb->setting<AngularVelocity>(MS::TipWipe::kPerimeterExtruderSpeed),
-                                                   m_sb->setting<Distance>(MS::TipWipe::kPerimeterLiftHeight),
-                                                   m_sb->setting<Distance>(MS::TipWipe::kPerimeterCutoffDistance));
-        else if (static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kPerimeterDirection)) ==
-                 TipWipeDirection::kAngled) {
+        const TipWipeDirection wipe_direction =
+            static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kPerimeterDirection));
+        if (wipe_direction == TipWipeDirection::kForward ||
+            (!open_loop_tip_wipe && wipe_direction == TipWipeDirection::kOptimal)) {
+            if (open_loop_tip_wipe && wipe_direction == TipWipeDirection::kForward) {
+                PathModifierGenerator::GenerateForwardTipWipeOpenLoop(
+                    path, PathModifiers::kForwardTipWipe, m_sb->setting<Distance>(MS::TipWipe::kPerimeterDistance),
+                    m_sb->setting<Velocity>(MS::TipWipe::kPerimeterSpeed),
+                    m_sb->setting<AngularVelocity>(MS::TipWipe::kPerimeterExtruderSpeed),
+                    m_sb->setting<Distance>(MS::TipWipe::kPerimeterLiftHeight),
+                    m_sb->setting<Distance>(MS::TipWipe::kPerimeterCutoffDistance));
+            }
+            else {
+                PathModifierGenerator::GenerateTipWipe(
+                    path, PathModifiers::kForwardTipWipe, m_sb->setting<Distance>(MS::TipWipe::kPerimeterDistance),
+                    m_sb->setting<Velocity>(MS::TipWipe::kPerimeterSpeed),
+                    m_sb->setting<Angle>(MS::TipWipe::kPerimeterAngle),
+                    m_sb->setting<AngularVelocity>(MS::TipWipe::kPerimeterExtruderSpeed),
+                    m_sb->setting<Distance>(MS::TipWipe::kPerimeterLiftHeight),
+                    m_sb->setting<Distance>(MS::TipWipe::kPerimeterCutoffDistance));
+            }
+        }
+        else if (wipe_direction == TipWipeDirection::kAngled) {
             PathModifierGenerator::GenerateTipWipe(path, PathModifiers::kAngledTipWipe,
                                                    m_sb->setting<Distance>(MS::TipWipe::kPerimeterDistance),
                                                    m_sb->setting<Velocity>(MS::TipWipe::kPerimeterSpeed),


### PR DESCRIPTION
## Summary

This PR improves spiral contour stitching for perimeters and insets.

- Adds width-aware linking for adaptive spiral contour transitions.
- Keeps single-contour spiral paths closed instead of cutting their final segment short.
- Uses single-segment contour-to-contour links and avoids point-order segment breaking during spiral transitions.
- Applies the corrected open-loop tip-wipe handling to both perimeters and insets.

## Root Cause

Spiral contour linking was treating all loops like stitched open paths, even when only one contour existed, and follow-up loop selection could split or rotate paths in a way that introduced extra transition segments. Adaptive contours also needed to pass their actual bead widths into the spiral linker so transition stop points matched the generated contour widths.

## Validation

- `git diff --check`
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer_obj`
