### PR TITLE
feat(graphics): preview cylindrical slicing geometry

### DIFF
--- a/include/graphics/objects/part_object.h
+++ b/include/graphics/objects/part_object.h
@@ -68,6 +68,8 @@ class PartObject : public GraphicsObject {
     QSharedPointer<AxesObject> axes();
     //! \brief Gets the plane object.
     QSharedPointer<PlaneObject> plane();
+    //! \brief Gets the cylindrical slicing preview object.
+    QSharedPointer<GraphicsObject> slicingCylinder();
     //! \brief Gets a layer settings range plane object.
     QSharedPointer<PlaneObject> layerSettingsRangePlane(int index = 0);
     //! \brief Gets all layer settings range plane objects.
@@ -122,6 +124,7 @@ class PartObject : public GraphicsObject {
     QSharedPointer<TextObject> m_label_object;
     QSharedPointer<AxesObject> m_axes_object;
     QSharedPointer<PlaneObject> m_plane_object;
+    QSharedPointer<GraphicsObject> m_slicing_cylinder_object;
     QVector<QSharedPointer<PlaneObject>> m_layer_settings_range_objects;
     //! \brief Optional overlay that draws silhouette and sharp feature edges over shaded parts.
     QSharedPointer<GraphicsObject> m_feature_edge_object;

--- a/include/graphics/view/part_view.h
+++ b/include/graphics/view/part_view.h
@@ -313,6 +313,22 @@ class PartView : public BaseView {
     //! \brief Updates the selected layer settings range plane visibility and placement.
     void updateLayerSettingsRangePlane();
 
+    //! \brief Updates all per-part slicing geometry previews for the active slicing mode.
+    void updateSlicingGeometryPreviews();
+
+    //! \brief Updates one per-part slicing geometry preview for the active slicing mode.
+    void updateSlicingGeometryPreview(QSharedPointer<PartObject> gop);
+
+    //! \brief Builds the effective global + local slicing settings for a part.
+    QSharedPointer<SettingsBase> slicingSettingsForPart(QSharedPointer<Part> part) const;
+
+    //! \brief Calculates the visible cylindrical slicing preview geometry for a part.
+    bool cylindricalSlicingPreviewGeometry(QSharedPointer<PartObject> gop, QVector3D& base_center, float& radius,
+                                           float& height) const;
+
+    //! \brief Returns the current planar slicing preview rotation.
+    QQuaternion slicingPlaneRotation() const;
+
     //! \brief Hides all layer settings range planes.
     void hideLayerSettingsRangePlanes();
 

--- a/src/graphics/objects/part_object.cpp
+++ b/src/graphics/objects/part_object.cpp
@@ -11,6 +11,7 @@
 
 #include <qcolor.h>
 #include <qhashfunctions.h>
+#include <qmatrix4x4.h>
 #include <qquaternion.h>
 #include <qset.h>
 #include <qsharedpointer.h>
@@ -24,6 +25,7 @@
 #include "graphics/objects/axes_object.h"
 #include "graphics/objects/cube/plane_object.h"
 #include "graphics/objects/text_object.h"
+#include "graphics/support/shape_factory.h"
 #include "part/part.h"
 #include "units/unit.h"
 #include "utilities/constants.h"
@@ -40,6 +42,8 @@ constexpr float kFeatureEdgeAlpha = 0.35f;
 constexpr size_t kTrianglePositionFloatCount = 9;
 //! \brief Number of floats used by one triangle's three RGBA vertex colors.
 constexpr size_t kTriangleColorFloatCount = 12;
+//! \brief Unit-radius, unit-height local geometry for scaled cylindrical slicing previews.
+constexpr float kSlicingCylinderPreviewBaseSize = 1.0f;
 
 struct EdgeSample {
     int start_index;
@@ -210,6 +214,18 @@ QSharedPointer<GraphicsObject> createFeatureEdgeObject(BaseView* view, QSharedPo
 
     return QSharedPointer<FeatureEdgeObject>::create(view, edge_vertices, edge_normals, edge_colors, GL_LINES);
 }
+
+QSharedPointer<GraphicsObject> createSlicingCylinderPreviewObject(BaseView* view) {
+    QColor color = QColor(127, 0, 255, 102);
+
+    std::vector<float> vertices;
+    std::vector<float> normals;
+    std::vector<float> colors;
+    ShapeFactory::appendCylinder(kSlicingCylinderPreviewBaseSize, kSlicingCylinderPreviewBaseSize, QMatrix4x4(), color,
+                                 vertices, colors, normals);
+
+    return QSharedPointer<GraphicsObject>::create(view, vertices, normals, colors);
+}
 } // namespace
 
 PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mode) {
@@ -305,6 +321,12 @@ PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mod
 
     this->adoptChild(gos);
     m_plane_object = gos;
+
+    auto slicing_cylinder = createSlicingCylinderPreviewObject(this->view());
+    slicing_cylinder->hide();
+
+    this->adoptChild(slicing_cylinder);
+    m_slicing_cylinder_object = slicing_cylinder;
 
     this->createLayerSettingsRangePlane();
 
@@ -452,6 +474,8 @@ QSharedPointer<TextObject> PartObject::label() { return m_label_object; }
 QSharedPointer<AxesObject> PartObject::axes() { return m_axes_object; }
 
 QSharedPointer<PlaneObject> PartObject::plane() { return m_plane_object; }
+
+QSharedPointer<GraphicsObject> PartObject::slicingCylinder() { return m_slicing_cylinder_object; }
 
 QSharedPointer<PlaneObject> PartObject::layerSettingsRangePlane(int index) {
     index = std::max(index, 0);

--- a/src/graphics/view/part_view.cpp
+++ b/src/graphics/view/part_view.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include <QMessageBox>
 #include <QStack>
@@ -51,6 +52,7 @@
 namespace ORNL {
 namespace {
 constexpr float kMinimumLayerSettingsRangeThickness = 0.01f;
+constexpr float kMinimumSlicingCylinderHeight = 0.01f;
 } // namespace
 
 PartView::PartView(QSharedPointer<SettingsBase> sb) {
@@ -107,11 +109,8 @@ void PartView::showLabels(bool show) {
 }
 
 void PartView::showSlicingPlanes(bool show) {
-    for (auto& gop : m_part_objects) {
-        gop->plane()->setHidden(!show);
-    }
-
     m_state.planes_shown = show;
+    updateSlicingGeometryPreviews();
 
     this->update();
 }
@@ -170,6 +169,7 @@ void PartView::centerPart(QString name) {
 void PartView::centerPart(QSharedPointer<PartObject> gop) {
     QVector3D printer_center = m_printer->printerCenter();
     gop->translateAbsolute(QVector3D(printer_center.x(), printer_center.y(), gop->translation().z()));
+    updateSlicingGeometryPreview(gop);
 }
 
 void PartView::dropPart(QSharedPointer<PartObject> gop) {
@@ -190,6 +190,7 @@ void PartView::dropPart(QSharedPointer<PartObject> gop) {
     trans.setZ(trans.z() - z_sub);
 
     gop->translateAbsolute(trans, true);
+    updateSlicingGeometryPreview(gop);
 }
 
 void PartView::shiftPart(QSharedPointer<PartObject> gop) {
@@ -198,6 +199,7 @@ restart_check:
     for (auto& egop : m_part_objects) {
         if (egop->doesMBBIntersect(gop)) {
             gop->translate(QVector3D(0.5, 0, 0));
+            updateSlicingGeometryPreview(gop);
             goto restart_check;
         }
     }
@@ -301,6 +303,7 @@ void PartView::centerSelectedParts() {
         QVector3D translation = gop->translation() + offset;
 
         gop->translateAbsolute(translation);
+        updateSlicingGeometryPreview(gop);
 
         this->blockModel();
         m_model->lookupByGraphic(gop)->setTranslation(translation);
@@ -314,6 +317,7 @@ void PartView::centerSelectedParts() {
 void PartView::dropSelectedParts() {
     for (auto& gop : m_selected_objects) {
         dropPart(gop);
+        updateSlicingGeometryPreview(gop);
 
         this->blockModel();
         m_model->lookupByGraphic(gop)->setTranslation(gop->translation() - m_printer->minimum());
@@ -403,6 +407,7 @@ void PartView::updatePrinterSettings(QSharedPointer<SettingsBase> sb) {
 
     m_focus->updateDimensions(m_printer->getDefaultZoom() * 0.1);
 
+    updateSlicingGeometryPreviews();
     this->postTransformCheck();
     this->update();
 }
@@ -428,13 +433,7 @@ void PartView::updateOverhangSettings(QSharedPointer<SettingsBase> sb) {
 void PartView::updateSlicingSettings(QSharedPointer<SettingsBase> sb) {
     m_sb = sb;
 
-    // Determine the slicing plane normal
-    QVector3D slicing_vector = {m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalX),
-                                m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalY),
-                                m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalZ)};
-    slicing_vector.normalize();
-
-    QQuaternion rotation = QQuaternion::fromDirection(slicing_vector, QVector3D(0, 0, 1));
+    QQuaternion rotation = slicingPlaneRotation();
 
     for (auto& gop : m_part_objects) {
         gop->plane()->setLockedRotationQuaternion(rotation);
@@ -443,6 +442,7 @@ void PartView::updateSlicingSettings(QSharedPointer<SettingsBase> sb) {
         }
     }
 
+    updateSlicingGeometryPreviews();
     updateLayerSettingsRangePlane();
 
     // Changing the plane affects the overhang angle
@@ -601,6 +601,7 @@ void PartView::handleLeftRelease(QPointF mouse_ndc_pos) {
     }
     this->permitModel();
 
+    updateSlicingGeometryPreviews();
     this->postTransformCheck();
     this->update();
 }
@@ -664,6 +665,7 @@ void PartView::handleLeftMove(QPointF mouse_ndc_pos) {
         }
 
         gop->translateAbsolute(v + m_state.part_trans_start[gop]);
+        updateSlicingGeometryPreview(gop);
         m_model->lookupByGraphic(gop)->setTranslation(gop->translation() - m_printer->minimum());
     }
 
@@ -770,6 +772,7 @@ void PartView::handleRightRelease(QPointF mouse_ndc_pos, QPointF global_pos) {
             }
 
             gop->rotateAbsolute(QQuaternion::fromEulerAngles(er));
+            updateSlicingGeometryPreview(gop);
         }
 
         auto tmp_selected = m_selected_objects;
@@ -797,6 +800,7 @@ void PartView::handleRightRelease(QPointF mouse_ndc_pos, QPointF global_pos) {
         }
         this->permitModel();
 
+        updateSlicingGeometryPreviews();
         this->update();
     }
     else {
@@ -923,8 +927,7 @@ void PartView::modelAdditionUpdate(QSharedPointer<PartMetaItem> pm) {
     gop->setOverhangAngle(m_sb->setting<Angle>(PS::Support::kThresholdAngle));
     if (m_state.overhangs_shown)
         gop->showOverhang(true);
-    if (m_state.planes_shown)
-        gop->plane()->show();
+    updateSlicingGeometryPreview(gop);
     if (m_state.names_shown)
         gop->label()->show();
     updateLayerSettingsRangePlane();
@@ -950,6 +953,7 @@ void PartView::modelReloadUpdate(QSharedPointer<PartMetaItem> pm) {
 
     gop = pm->graphicsPart();
     pm->setTransformation(tfm);
+    updateSlicingGeometryPreview(gop);
 
     m_selected_objects.insert(gop);
     this->setCursor(QCursor(Qt::OpenHandCursor));
@@ -1039,6 +1043,7 @@ void PartView::modelTranformUpdate(QSharedPointer<PartMetaItem> pm) {
     this->postTransformCheck();
 
     updateLayerSettingsRangePlane();
+    updateSlicingGeometryPreview(gop);
 
     this->update();
 }
@@ -1203,6 +1208,115 @@ QSharedPointer<PartObject> PartView::findObject(QSharedPointer<Part> part) {
     }
 
     return nullptr;
+}
+
+QQuaternion PartView::slicingPlaneRotation() const {
+    QVector3D slicing_vector = {m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalX),
+                                m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalY),
+                                m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalZ)};
+
+    if (slicing_vector.isNull())
+        slicing_vector = QVector3D(0.0f, 0.0f, 1.0f);
+    else
+        slicing_vector.normalize();
+
+    return QQuaternion::fromDirection(slicing_vector, QVector3D(0, 0, 1));
+}
+
+QSharedPointer<SettingsBase> PartView::slicingSettingsForPart(QSharedPointer<Part> part) const {
+    QSharedPointer<SettingsBase> part_sb = QSharedPointer<SettingsBase>::create(*m_sb);
+    if (!part.isNull())
+        part_sb->populate(part->getSb());
+
+    return part_sb;
+}
+
+bool PartView::cylindricalSlicingPreviewGeometry(QSharedPointer<PartObject> gop, QVector3D& base_center, float& radius,
+                                                 float& height) const {
+    if (gop.isNull() || gop->part().isNull() || gop->part()->rootMesh().isNull())
+        return false;
+
+    QSharedPointer<SettingsBase> part_sb = slicingSettingsForPart(gop->part());
+    const CylinderAxisSource axis_mode =
+        static_cast<CylinderAxisSource>(part_sb->setting<int>(PS::Slicing::kCylinderAxisSource));
+
+    QVector3D axis_center;
+    if (axis_mode == CylinderAxisSource::kCustomXY) {
+        axis_center.setX(part_sb->setting<Distance>(PS::Slicing::kCylinderAxisX)() * Constants::OpenGL::kObjectToView);
+        axis_center.setY(part_sb->setting<Distance>(PS::Slicing::kCylinderAxisY)() * Constants::OpenGL::kObjectToView);
+    }
+    else {
+        const QVector3D local_centroid =
+            gop->part()->rootMesh()->originalCentroid().toQVector3D() * Constants::OpenGL::kObjectToView;
+        axis_center = gop->transformation() * local_centroid;
+    }
+
+    const std::vector<Triangle> triangles = gop->triangles();
+    if (triangles.empty())
+        return false;
+
+    float min_z = std::numeric_limits<float>::max();
+    float max_z = std::numeric_limits<float>::lowest();
+    for (const Triangle& triangle : triangles) {
+        for (const QVector3D& point : {triangle.a, triangle.b, triangle.c}) {
+            min_z = std::min(min_z, point.z());
+            max_z = std::max(max_z, point.z());
+        }
+    }
+
+    Distance initial_radius = part_sb->setting<Distance>(PS::Slicing::kCylinderInnerRadius);
+    if (initial_radius < 0)
+        initial_radius = 0.0 * micron;
+
+    radius = initial_radius() * Constants::OpenGL::kObjectToView;
+    height = std::max(max_z - min_z, kMinimumSlicingCylinderHeight);
+    base_center = QVector3D(axis_center.x(), axis_center.y(), min_z);
+
+    return radius > 0.0f && height > 0.0f;
+}
+
+void PartView::updateSlicingGeometryPreview(QSharedPointer<PartObject> gop) {
+    if (gop.isNull())
+        return;
+
+    gop->plane()->hide();
+    if (!gop->slicingCylinder().isNull())
+        gop->slicingCylinder()->hide();
+
+    if (!m_state.planes_shown)
+        return;
+
+    const SlicingMode slicing_mode = static_cast<SlicingMode>(m_sb->setting<int>(PS::Slicing::kSlicingMode));
+    switch (slicing_mode) {
+        case SlicingMode::kCylindrical: {
+            QVector3D base_center;
+            float radius = 0.0f;
+            float height = 0.0f;
+            if (gop->slicingCylinder().isNull() ||
+                !cylindricalSlicingPreviewGeometry(gop, base_center, radius, height)) {
+                return;
+            }
+
+            QMatrix4x4 transform;
+            transform.translate(base_center);
+            transform.scale(QVector3D(radius, radius, height));
+            gop->slicingCylinder()->setTransformation(transform, false);
+            gop->slicingCylinder()->show();
+            break;
+        }
+        case SlicingMode::kPlanar:
+            gop->plane()->setLockedRotationQuaternion(slicingPlaneRotation());
+            gop->plane()->show();
+            break;
+        case SlicingMode::kImage:
+            break;
+    }
+}
+
+void PartView::updateSlicingGeometryPreviews() {
+    for (auto& gop : m_part_objects) {
+        updateSlicingGeometryPreview(gop);
+    }
 }
 
 void PartView::updateLayerSettingsRangePlane() {

--- a/src/widgets/main_toolbar.cpp
+++ b/src/widgets/main_toolbar.cpp
@@ -80,8 +80,8 @@ void MainToolbar::setupSubWidgets() {
     this->addWidget(m_shape_btn);
     this->addSeparator();
 
-    // Slicing Plane Button
-    m_slicing_planes_btn = buildIconButton(":/icons/slicing_plane.png", "Show slicing plane for each part", true);
+    // Slicing Geometry Button
+    m_slicing_planes_btn = buildIconButton(":/icons/slicing_plane.png", "Show slicing geometry for each part", true);
     this->addWidget(m_slicing_planes_btn);
     connect(m_slicing_planes_btn, &QToolButton::toggled, this,
             [this](bool checked) { emit showSlicingPlanes(checked); });

--- a/src/widgets/part_widget/part_widget.cpp
+++ b/src/widgets/part_widget/part_widget.cpp
@@ -147,8 +147,10 @@ void PartWidget::handleModifiedSetting(const QString& setting_key) {
                                                         PRS::Dimensions::kGridYDistance,
                                                         PRS::Dimensions::kGridYOffset};
 
-    static const auto material_settings = QSet<QString> {
-        PS::Slicing::kSlicePlaneNormalX, PS::Slicing::kSlicePlaneNormalY, PS::Slicing::kSlicePlaneNormalZ};
+    static const auto slicing_settings = QSet<QString> {
+        PS::Slicing::kSlicingMode,       PS::Slicing::kSlicePlaneNormalX,  PS::Slicing::kSlicePlaneNormalY,
+        PS::Slicing::kSlicePlaneNormalZ, PS::Slicing::kCylinderAxisSource, PS::Slicing::kCylinderAxisX,
+        PS::Slicing::kCylinderAxisY,     PS::Slicing::kCylinderInnerRadius};
 
     static const auto optimization_settings = QSet<QString> {PS::Optimizations::kIslandOrder,
                                                              PS::Optimizations::kCustomIslandXLocation,
@@ -170,7 +172,7 @@ void PartWidget::handleModifiedSetting(const QString& setting_key) {
     if (printer_settings.contains(setting_key)) {
         m_part_view->updatePrinterSettings(GSM->getGlobal());
     }
-    else if (material_settings.contains(setting_key)) {
+    else if (slicing_settings.contains(setting_key)) {
         m_part_view->updateSlicingSettings(GSM->getGlobal());
     }
     else if (optimization_settings.contains(setting_key)) {


### PR DESCRIPTION
## Summary

Adds mode-aware slicing geometry previews in the part view. The existing preview toggle now shows the planar slicing plane for planar slicing and a transparent purple cylinder for cylindrical slicing.

## Related issues

- No related issues.

## Details

This adds a cylindrical preview object to each `PartObject` and updates `PartView` so the preview geometry follows the selected `Slicing Mode`.

For planar slicing, the current transparent purple slicing plane behavior is preserved. For cylindrical slicing, the preview now displays a closed transparent purple cylinder whose center follows `Cylinder Axis Source`:
- `Part Centroid` uses the part centroid.
- `Custom XY` uses `Cylinder Axis - X` and `Cylinder Axis - Y`.

The preview cylinder radius is driven by `Cylinder Inner Radius`. Preview visibility and placement are refreshed when the slicing mode, slice plane normal, cylinder axis settings, cylinder inner radius, or part transforms change. The toolbar tooltip was also generalized from “slicing plane” to “slicing geometry” so it describes both preview modes.

## Impact

This improves the cylindrical slicing workflow by making the preview reflect the active slicing geometry instead of always displaying the planar slice plane. Users can visually confirm the selected cylinder axis location and inner radius before slicing.

Risk level: Low. The change is scoped to part-view preview graphics and setting-change refresh paths. It does not alter slicing path generation or G-code output.

## Testing strategy

Validated locally.