### PR TITLE
feat: add architecture documentation and detailed subsystem descriptions

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,23 +1,74 @@
 # AGENTS.md
 
-## Project overview
+## Core Workflow
 
-ORNLSlicer is a 3D printing slicer developed by Oak Ridge National Laboratory (ORNL) that focuses on high-performance slicing for large-format additive manufacturing. It is designed to handle complex geometries and optimize print paths for improved print quality and reduced print times.
+- Run `git status --short --branch` first; preserve unrelated user changes.
+- Start from the exact artifact the user named: file, branch, PR, commit,
+  staged diff, failing command, or error text.
+- Read [`ARCHITECTURE.md`](../ARCHITECTURE.md) before changing code, then follow
+  the linked architecture page for the subsystem you touch.
+- Use `rg` to trace declarations, call sites, state owners, worker boundaries,
+  and final consumers before editing behavior.
+- Keep diffs narrow. Avoid unrelated cleanup, broad formatting, and hand-edits
+  to generated files.
 
+## Routing
 
-## Development expectations
+| Work | Source Of Truth |
+| --- | --- |
+| Startup, CLI, import, project save/load, threading | [`application-runtime.md`](../docs/architecture/application-runtime.md) |
+| Slicing modes, cross-sectioning, pathing, modifiers | [`slicing-pipeline.md`](../docs/architecture/slicing-pipeline.md) |
+| Settings, templates, dependencies, migrations, settings UI | [`settings-system.md`](../docs/architecture/settings-system.md) |
+| Writers, parsers, G-code metadata, preview, export | [`gcode-and-visualization.md`](../docs/architecture/gcode-and-visualization.md) |
+| Public API contracts | Header Doxygen and [`documentation.md`](../docs/contributing/documentation.md) |
+| Commits, PRs, contributor workflow | [`CONTRIBUTING.md`](../CONTRIBUTING.md) and [`docs/contributing/`](../docs/contributing/) |
 
-- Document any behavior changes in the codebase with an update to the relevant documentation.
+Implementation is usually paired between [`include/`](../include/) and
+[`src/`](../src/). Settings source is [`resources/settings/`](../resources/settings/);
+generated settings config is [`resources/configs/`](../resources/configs/).
 
+## Repo-Specific Rules
 
-## Git and PR conventions
+- Prefer existing session, settings, GUI, and worker patterns over new parallel
+  state. Keep blocking mesh, project, slicing, and G-code work off the GUI
+  thread.
+- CMake uses globbed source/resource lists. Re-run configure after adding or
+  deleting `.cpp`, `.h`, or resource files, or after stale source/PCH build
+  failures.
+- `resources/settings/*.yaml` is the settings source of truth. Regenerate both
+  config outputs with:
+  `python3 scripts/generate_master_config.py resources/settings resources/configs/master.conf resources/configs/setting_inputs.conf`
+- Validate generated settings JSON with:
+  `jq empty resources/configs/master.conf resources/configs/setting_inputs.conf`
 
-- Always create branches from `develop` to ensure a clean history and avoid merge conflicts.
-- Name branches as `<type>/<description>`. Use one of `feat`, `fix`, `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`, `test` for `<type>`, and keep `<description>` short, hyphenated, and issue-linked when applicable (for example, `feat/123-add-login-feature`).
-- Format commit messages using the Conventional Commit format: `<type>(<scope>): <description>`. Use the same `<type>` values as branch names, and keep `<scope>` optional but descriptive of the area of the codebase affected (for example, `feat(auth): add login feature`).
-- Title pull requests using the same Conventional Commit format as commit messages, and include a description of the change in the PR body using the PR template in `.github/pull_request_template.md`.
+## Validation Commands
 
+- Configure: `nix develop .#ornlslicerDev -L --command cmake --preset generic-llvm-ninja`
+- Build app: `nix develop .#ornlslicerDev -L --command cmake --build build/generic-llvm-ninja --config Debug --target ornlslicer`
+- Narrow compile check: `nix develop .#ornlslicerDev -L --command cmake --build build/generic-llvm-ninja --config Debug --target ornlslicer_obj`
+- Docs-only check: `git diff --check -- <touched-files>`
+
+Use `build/generic-llvm-ninja`, not top-level `build/`. If stronger validation
+cannot run, state the exact blocker and the lighter checks that did run.
 
 ## Formatting
 
-- Always leave a blank line after a heading when writing in Markdown.
+- Format changed C++ files with repository `.clang-format`; there is no
+  repo-local formatter wrapper in `scripts/`.
+- Keep pure formatting separate from behavior changes unless limited to touched
+  lines.
+- For Markdown, use relative links, keep one blank line after headings, and run
+  `git diff --check`.
+
+## Docs, Git, And Reviews
+
+- Keep architecture content in `ARCHITECTURE.md` or `docs/architecture/`; do not
+  duplicate long explanations here.
+- Update architecture docs when ownership, runtime flow, threading, settings
+  generation, or extension points change.
+- Use Conventional Commits and [`.github/pull_request_template.md`](../.github/pull_request_template.md).
+- Before committing or drafting a PR, inspect the exact diff; if the user says
+  staged only, inspect only the staged diff.
+- For reviews, stay bounded to the named artifact, lead with actionable
+  findings, cite file/line references, and say clearly when there are no
+  findings.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,146 @@
+# ORNLSlicer Architecture
+
+## Purpose
+
+This document is the high-level map of the ORNLSlicer codebase. Use it to find
+the subsystem that owns a behavior, then follow the linked architecture pages
+for implementation detail. Public API details remain in Doxygen comments, and
+task-focused user and contributor material remains in the
+[`docs/` index](docs/README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+The descriptions here reflect the current code. Update them when ownership,
+runtime flow, or an extension seam changes.
+
+## System at a Glance
+
+```mermaid
+flowchart LR
+    Entry["src/main.cpp"] --> GUI["GUI: MainWindow"]
+    Entry --> CLI["CLI: MainControl"]
+    GUI --> Session["SessionManager"]
+    CLI --> Session
+    GUI --> Settings["SettingsManager"]
+    CLI --> Settings
+    Session --> Input["Mesh and project loaders"]
+    Input --> Parts["Part and mesh model"]
+    Parts --> Slice["Slicing pipeline"]
+    Settings --> Slice
+    Slice -->|"toolpath modes"| Writer["Writer and temporary G-code"]
+    Slice -->|"image mode"| Images["Image slices"]
+    Writer --> Loader["GCodeLoader"]
+    Imported["Imported G-code"] --> Loader
+    Loader --> Output["Preview, statistics, and export"]
+```
+
+[`src/main.cpp`](src/main.cpp) selects one of two application shells. Runs with
+command-line arguments use `QCoreApplication` and `MainControl`; runs without
+arguments use `QApplication` and `MainWindow`. Both paths share the session,
+settings, and slicing subsystems. Toolpath modes also share writer and G-code
+parsing services.
+
+## Repository Map
+
+| Area | Responsibility |
+| --- | --- |
+| [`include/`](include/) and [`src/`](src/) | Project headers and matching implementations, grouped by subsystem |
+| [`resources/settings/`](resources/settings/) | Canonical YAML metadata for user settings |
+| [`resources/configs/`](resources/configs/) | Generated settings data and Qt resource manifests |
+| [`resources/`](resources/) | Other embedded icons, shaders, styles, and textures |
+| [`templates/`](templates/) | Installed printer and process templates |
+| [`docs/`](docs/README.md) | User, contributor, and detailed architecture documentation |
+| [`scripts/`](scripts/) | Settings generation, packaging, and maintenance utilities |
+| [`cmake/`](cmake/) and [`CMakeLists.txt`](CMakeLists.txt) | Native build configuration and generated build metadata |
+| [`nix/`](nix/) and [`flake.nix`](flake.nix) | Reproducible packages, dependencies, and development shells |
+
+The directory pairing between `include/` and `src/` is the quickest way to find
+an implementation after locating a public type. Cross-cutting constants, enums,
+units, and Qt/JSON conversion helpers live under `utilities/` and `units/`.
+
+## Major Boundaries
+
+### Application and Session
+
+`MainWindow` owns the GUI composition, while `MainControl` coordinates the
+headless path. `SessionManager` is the shared owner of loaded `Part` objects,
+raw model data needed for project persistence, recent-session state, and the
+active slicer. Loader classes provide established Qt worker boundaries, with a
+synchronous CLI mesh-loading path and a synchronous project-version preflight.
+The current `SessionLoader` also reads and mutates manager-owned state from its
+worker before signaling completion, an exception described in the detailed
+runtime page.
+
+See [Application Runtime](docs/architecture/application-runtime.md) for startup,
+ownership, persistence, and worker boundaries.
+
+### Settings
+
+`SettingsManager` loads embedded setting metadata, holds the active global
+settings, manages templates, and applies version migrations. Settings snapshots
+start with defaults and selected templates, apply global adjustments, then add
+mode-specific local scope. The planar pipeline applies part, layer-range, and
+spatial settings-region overrides.
+
+See [Settings System](docs/architecture/settings-system.md) for the source and
+generation pipeline, runtime scopes, UI construction, and migration rules.
+
+### Slicing and Pathing
+
+`SessionManager::doSlice()` selects planar, cylindrical, or image slicing.
+Cylindrical settings choose radial or helical path generation. Planar and
+cylindrical slicers preprocess geometry into `Step` objects. Planar mode
+computes region pathing on `StepThread` workers; cylindrical modes generate
+their direct paths during preprocessing. Toolpath modes then postprocess paths
+and modifiers and emit G-code through a selected writer. Image slicing
+generates image files during preprocessing and skips ordinary G-code output.
+
+See [Slicing Pipeline](docs/architecture/slicing-pipeline.md) for phase order,
+the path data model, concrete slicer differences, and extension points.
+
+### G-Code and Visualization
+
+`WriterBase` implementations translate paths into machine-specific text.
+`GCodeLoader` parses generated or imported files, calculates metadata, creates
+visual segments, and sends independent outputs to the text view, OpenGL preview,
+layer-time display, and export UI.
+
+See [G-code and Visualization](docs/architecture/gcode-and-visualization.md) for
+writer/parser selection, the preview path, and syntax integration points.
+
+## Detailed Architecture
+
+- [Application Runtime](docs/architecture/application-runtime.md): GUI and CLI
+  startup, manager ownership, model/project persistence, and Qt worker
+  boundaries.
+- [Slicing Pipeline](docs/architecture/slicing-pipeline.md): slicer selection,
+  preprocessing, step computation, path hierarchy, postprocessing, and output.
+- [Settings System](docs/architecture/settings-system.md): canonical metadata,
+  generated artifacts, settings scopes, widgets, templates, and migrations.
+- [G-code and Visualization](docs/architecture/gcode-and-visualization.md):
+  machine writers, parsers, G-code loading, OpenGL preview, and export data.
+
+## Where a Change Belongs
+
+| Change | Start Here |
+| --- | --- |
+| Application startup, model import, project save/load, or cross-thread UI flow | [Application Runtime](docs/architecture/application-runtime.md) |
+| Cross-sectioning, a slicing mode, a region algorithm, path ordering, or path modifiers | [Slicing Pipeline](docs/architecture/slicing-pipeline.md) |
+| A setting definition, dependency, template, local override, or migration | [Settings System](docs/architecture/settings-system.md) |
+| A machine syntax, G-code parser, preview segment, filter, statistic, or export behavior | [G-code and Visualization](docs/architecture/gcode-and-visualization.md) |
+| A public function or class contract | Source comments and the [Doxygen guide](docs/contributing/documentation.md) |
+
+## Architectural Guardrails
+
+- Use the existing managers for session, settings, preferences, and GUI
+  lifecycles instead of introducing parallel global state.
+- Keep blocking mesh, project, slicing, and G-code work off the GUI thread.
+  Preserve established worker entry points and signal/slot UI notifications;
+  treat `SessionLoader`'s direct manager access as an exception, not precedent.
+- Follow the existing `QSharedPointer` ownership style for model and toolpath
+  objects; use Qt parent ownership for widgets and other `QObject` trees.
+- Treat `resources/settings/*.yaml` as source. Regenerate
+  `resources/configs/master.conf` and
+  `resources/configs/setting_inputs.conf`; do not hand-edit them.
+- Keep this file at subsystem level. Put implementation flow in the linked
+  architecture pages and function-level contracts beside the source.
+- When a change moves an ownership boundary or extension seam, update the
+  affected architecture page in the same change.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Core capabilities include:
 ## Documentation
 
 - Start here: [Documentation Index](docs/README.md)
+- Architecture map: [ARCHITECTURE.md](ARCHITECTURE.md)
 - User guide: [ORNLSlicer User Guide](docs/ornlslicer-user-guide.pdf)
 - Developer onboarding: [Getting Started](docs/wiki/Getting-Started.md)
 - Contributor workflow: [Contributing](CONTRIBUTING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,14 @@ This directory is the canonical documentation source for ORNLSlicer.
 - [Contributing Guide](../CONTRIBUTING.md)
 - [Legacy Wiki Content](wiki/Home.md)
 
+## Architecture
+
+- [Architecture Overview](../ARCHITECTURE.md)
+- [Application Runtime](architecture/application-runtime.md)
+- [Slicing Pipeline](architecture/slicing-pipeline.md)
+- [Settings System](architecture/settings-system.md)
+- [G-code and Visualization](architecture/gcode-and-visualization.md)
+
 ## Contributor Docs
 
 - [Conventional Branch Naming](contributing/conventional-branch.md)

--- a/docs/architecture/application-runtime.md
+++ b/docs/architecture/application-runtime.md
@@ -1,0 +1,192 @@
+# Application Runtime
+
+This page describes application startup, shared runtime ownership, model and
+project loading, and the Qt thread boundaries around those operations. See the
+[architecture overview](../../ARCHITECTURE.md) for the higher-level system map.
+
+## Entry Point
+
+[`src/main.cpp`](../../src/main.cpp) registers the Qt metatypes used by queued
+signals, then selects the application shell from the argument count.
+
+| Mode | Application | Controller | Behavior |
+| --- | --- | --- | --- |
+| GUI, no extra arguments | `QApplication` | `MainWindow` | Initializes icons, shaders, styles, and configs from Qt resources, builds the UI, and enters the GUI event loop |
+| CLI, one or more arguments | `QCoreApplication` | `MainControl` | Parses arguments into `SettingsBase`, loads input geometry or a project, slices it, parses the result when required, and writes the requested output |
+
+The shells differ, but neither owns a separate slicing implementation. Both use
+the same `SessionManager`, `SettingsManager`, and concrete slicers. Toolpath
+modes also share the writer and G-code loader; image slicing bypasses them.
+
+```mermaid
+flowchart TD
+    Main["src/main.cpp"] -->|"no extra arguments"| Window["MainWindow"]
+    Main -->|"arguments present"| Control["MainControl"]
+    Window --> Managers["Shared managers"]
+    Control --> Managers
+    Managers --> Load["Load model or project"]
+    Load --> Slice["SessionManager::doSlice()"]
+    Slice -->|"toolpath"| Parse["GCodeLoader"]
+    Slice -->|"image"| Images["Image output"]
+    Parse --> Result["GUI preview/export or CLI output"]
+    Images --> Result
+```
+
+### GUI Startup
+
+[`MainWindow::continueStartup()`](../../src/windows/main_window.cpp) performs
+the application-level GUI setup:
+
+1. Import user preferences through `PreferencesManager`.
+2. Discover installed and user template directories and load their settings.
+3. Construct the active global settings from recent selections.
+4. Create the windows, views, settings controls, toolbars, dialogs, and signal
+   connections owned by the main window.
+
+`MainWindow` is a singleton and a UI composition root, not the owner of session
+or setting data. Widgets call or subscribe to the shared managers for model and
+configuration state.
+
+### CLI Startup
+
+[`MainControl`](../../src/console/main_control.cpp) receives the converted
+command-line `SettingsBase`. It configures console settings, loads models or a
+project through `SessionManager`, waits for the expected `partAdded` signals,
+and calls `SessionManager::doSlice()`.
+
+After slicing, non-image workflows pass the generated file through
+`GCodeLoader`. That parse is still required in CLI mode because it can apply
+minimum-layer-time changes and produces the selected syntax metadata used to
+name the final output.
+
+## Shared Ownership
+
+### Session Manager
+
+[`SessionManager`](../../include/managers/session_manager.h), commonly accessed
+through `CSM`, is the session coordination hub. It owns or coordinates:
+
+- loaded `Part` objects and their meshes, settings, transforms, and computed
+  steps;
+- raw input model bytes retained for project archives;
+- the last session-file path, which may be an autosave, and recent model,
+  project, G-code, and settings locations;
+- project load/save operations;
+- active slicer selection, cancellation, progress forwarding, and slice
+  completion;
+- the temporary G-code output location.
+
+Changes that affect model lifetime or the transition from loaded parts to
+slicing should begin in
+[`session_manager.cpp`](../../src/managers/session_manager.cpp). Project archive
+layout and entry serialization primarily live in `SessionLoader`, alongside
+the session JSON helpers in `SessionManager`.
+
+### Settings and Preferences
+
+[`SettingsManager`](../../include/managers/settings/settings_manager.h),
+accessed through `GSM`, owns settings metadata, active global values, templates,
+and settings migration. `PreferencesManager` owns workstation/user choices such
+as display units, themes, import behavior, and visualization preferences. These
+are separate lifecycles: process settings affect generated toolpaths, while
+preferences primarily affect application behavior and presentation.
+
+The settings pipeline is described in [Settings System](settings-system.md).
+
+### Main Window
+
+`MainWindow` owns the Qt widget tree and connects worker results to their GUI
+consumers. Important children include `PartWidget`, `GCodeWidget`, `SettingBar`,
+`LayerBar`, `GcodeBar`, `LayerTimesWindow`, and `GcodeExport`. Qt parent ownership
+handles most widget destruction.
+
+Avoid putting durable model or settings state in a widget when an existing
+manager already owns that state. Widgets should present state and send user
+intent across the existing manager APIs and signals.
+
+## Model Loading
+
+[`SessionManager::loadModel()`](../../src/managers/session_manager.cpp) supports
+two execution paths:
+
+- GUI and other asynchronous callers create a
+  [`MeshLoader`](../../include/threading/mesh_loader.h), connect its `newMesh`
+  and error signals, and call `start()`.
+- Synchronous callers use `MeshLoader::LoadMeshes()` directly. The CLI uses this
+  path for explicitly supplied model files so its input count can be tracked
+  deterministically.
+
+`MeshLoader` uses Assimp for STL, 3MF, OBJ, AMF, and other supported mesh
+formats. STEP/STP input follows a separate OpenCASCADE path, is triangulated,
+and is converted into the project's CGAL-backed mesh types. The loader also
+returns the raw bytes. `SessionManager` wraps loaded meshes in `Part` objects,
+assigns unique names, retains the raw bytes for project persistence, and emits
+`partAdded` after the session state is ready.
+
+Keep format-specific mesh construction in `MeshLoader` or the types under
+`geometry/mesh/`. Keep session naming, lifetime, and notification in
+`SessionManager`.
+
+## Project Persistence
+
+ORNLSlicer project files use the legacy `.s2p` extension and are ZIP archives.
+[`SessionLoader`](../../src/threading/session_loader.cpp) saves and restores:
+
+- active model files under the archive's model directory;
+- session JSON containing part names, geometry references/types, original
+  dimensions, and transforms;
+- active global settings;
+- per-part settings and layer ranges;
+- a human-readable version marker.
+
+`SessionManager` creates the loader and updates recent-project state. It reads
+the archive's global settings once before starting the worker so version
+migration can be confirmed. The main archive save/load then runs through
+`SessionLoader` on its `QThread`.
+
+`SessionLoader` is an important exception to a signal-only worker handoff. Its
+save path reads `CSM`, `GSM`, and `Part` state directly, and its load path
+mutates those shared objects from the worker thread. `SessionLoader` itself
+signals completion and errors, while the manager calls it makes can also emit
+normal state notifications such as project-part counts and `partAdded`. Treat
+changes here as thread-sensitive and do not assume the worker owns an isolated
+project-data snapshot.
+
+When changing the project shape, update save and load together. Decide whether
+the new data belongs to session JSON, the global settings entry, per-part local
+settings, or an embedded model file, and preserve compatibility with older
+archives where practical.
+
+## Worker Boundaries
+
+| Worker | Mechanism | Produces |
+| --- | --- | --- |
+| `MeshLoader` | `QThread` subclass, plus a synchronous static helper | Mesh objects and raw model bytes |
+| `SessionLoader` | `QThread` subclass | ZIP archive changes and direct shared session/settings access; completion and errors are signaled |
+| `GCodeLoader` | `QThread` subclass | Parsed text, visual segments, statistics, and export metadata |
+| `AbstractSlicingThread` | `QObject` moved to an internal `QThread` | Preprocessing, step scheduling, postprocessing, and G-code output |
+| `StepThread` | `QObject` with its own internal `QThread` | `Step::compute()` completion |
+
+Qt queued connections are part of the architecture. Custom payload types not
+already known to Qt must be registered in `src/main.cpp` before crossing those
+connections. Most workers report data and status through signals for GUI-side
+consumers. The synchronous
+`MeshLoader::LoadMeshes()` CLI path and `SessionLoader`'s direct manager access
+are current exceptions, not a general pattern to copy.
+
+Do not update widgets from a loader, slicer, or step worker. Do not add blocking
+file or geometry work to a GUI slot when it fits one of the existing worker
+paths.
+
+## Common Change Paths
+
+- New mesh input behavior: `MeshLoader`, `geometry/mesh/`, then
+  `SessionManager::loadModel()` if session semantics change.
+- New project data: `SessionLoader` save/load and the corresponding
+  `SessionManager` session JSON helpers in the same change.
+- New top-level GUI surface: `MainWindow` for composition, then a focused widget
+  or window class for the behavior.
+- New CLI behavior: `CommandLineConverter` for option conversion and
+  `MainControl` for orchestration; keep slicing logic in the shared pipeline.
+- New cross-thread payload: register the metatype in `src/main.cpp`, define a
+  clear owner, and connect cleanup with the worker lifecycle.

--- a/docs/architecture/gcode-and-visualization.md
+++ b/docs/architecture/gcode-and-visualization.md
@@ -1,0 +1,210 @@
+# G-Code and Visualization
+
+This page describes machine-specific G-code generation, parser selection,
+`GCodeLoader`, preview data, and the OpenGL view boundary. See the
+[architecture overview](../../ARCHITECTURE.md) for the surrounding system and
+[Slicing Pipeline](slicing-pipeline.md) for the upstream path model.
+
+## Generation Boundary
+
+Toolpath geometry is machine-neutral until it reaches a writer. A `Path`
+contains `SegmentBase` objects, and generated segment types normally delegate
+their text output to a
+[`WriterBase`](../../include/gcode/writers/writer_base.h) implementation. The
+current `BezierSegment` is a parser/preview representation whose `writeGCode()`
+returns no text. G5/Bezier motion is therefore import-and-preview-only in this
+path, and not every parsed segment can be round-tripped through generation.
+
+[`AbstractSlicingThread::setGcodeOutput()`](../../src/threading/abs_slicing_thread.cpp)
+reads the active `GcodeSyntax` and constructs the corresponding writer and
+`GcodeMeta`. The common output lifecycle is:
+
+1. `writeGCodeSetup()` writes the slicer/syntax identifier, embedded settings,
+   and initial machine setup.
+2. The concrete slicer walks its ordered steps or layers. Layer, island,
+   region, path, and segment types call the selected writer for syntax-specific
+   text.
+3. `writeGCodeShutdown()` writes machine shutdown and the settings footer where
+   the syntax supports it.
+
+[`GcodeMeta`](../../include/gcode/gcode_meta.h) carries syntax-level facts used
+by both generation and parsing, including comment delimiters, units, file
+suffix, and travel representation. Keep these facts out of geometry code.
+
+Concrete writer classes live under
+[`include/gcode/writers/`](../../include/gcode/writers/) and
+[`src/gcode/writers/`](../../src/gcode/writers/). `WriterBase` supplies shared
+formatting and lifecycle hooks; subclasses override only the behavior that
+differs for a controller or machine family.
+
+## Parse and Fan-Out Flow
+
+Generated files and imported G-code converge at
+[`GCodeLoader`](../../src/threading/gcode_loader.cpp).
+
+```mermaid
+flowchart LR
+    File["Generated or imported G-code"] --> Loader["GCodeLoader"]
+    Loader --> Parser["CommonParser or syntax parser"]
+    Parser --> Commands["Layered GcodeCommand data"]
+    Commands --> Segments["Visual SegmentBase layers"]
+    Loader --> Text["G-code text and colors"]
+    Loader --> Stats["Times, volume, mass, distances"]
+    Loader --> Export["Output path and GcodeMeta"]
+    Segments --> View["GCodeWidget / GCodeView"]
+    Text --> Bar["GcodeBar"]
+    Stats --> Times["LayerTimesWindow and status"]
+    Export --> Dialog["GcodeExport or MainControl"]
+```
+
+`GCodeLoader` is a `QThread` subclass. Its `run()` method:
+
+1. reads the file and searches the header for the syntax identifier;
+2. selects `CommonParser` or a specialized parser;
+3. parses settings/header/footer data and layered `GcodeCommand` motion data;
+4. applies minimum-layer-time modification when enabled;
+5. computes time, volume, mass, and distance statistics;
+6. converts motion commands into display-space line, arc, travel, and other
+   visual segments with line/layer metadata;
+7. emits independent payloads for visualization, text, statistics, status, and
+   export.
+
+If no syntax identifier is found, the loader falls back to `CommonParser`
+configured with Marlin rules. The current no-header branch does not also assign
+the loader's selected export metadata, so imported files without a recognized
+header should not be assumed to have deterministic export units or naming.
+Generated writers should always emit the standard syntax header.
+
+## Parser Layers
+
+[`ParserBase`](../../include/gcode/parsers/parser_base.h) provides shared parser
+state and the abstract contract. [`CommonParser`](../../include/gcode/parsers/common_parser.h)
+implements the common header/footer, motion, timing, and file-adjustment path.
+Syntax-specific parsers under `gcode/parsers/` extend or specialize that
+behavior for controller dialects that cannot use the common rules.
+
+Parser output is not the OpenGL object itself. It is layered `GcodeCommand`
+data, which `GCodeLoader` interprets into the same `SegmentBase` family used by
+the rest of the application. During that conversion, the loader attaches:
+
+- display type and color derived from region/modifier comments;
+- bead width, height, and display length from effective settings;
+- source line and layer numbers for selection and text synchronization;
+- user-facing segment information such as position, speed, extrusion state,
+  and length.
+
+That separation keeps dialect parsing independent from OpenGL buffer
+construction.
+
+## Loader Consumers
+
+In GUI mode, `MainWindow::importGCodeHelper()` connects loader signals to the
+following consumers:
+
+| Signal Payload | Consumer | Responsibility |
+| --- | --- | --- |
+| Layered visual segments | `GCodeWidget::addGCode()` / `MainWindow` | Hand data to `GCodeView`; a separate `MainWindow` connection initializes `GcodeBar` layer/segment ranges |
+| Full text, formats, and layer-start lines | `GcodeBar` | Display and navigate source text |
+| Layer timing and feed-rate modifiers | `LayerTimesWindow` | Show original/adjusted layer timing |
+| File path and `GcodeMeta` | `GcodeExport` | Name and export the final controller file |
+| Summary/status text | `MainWindow` | Display time, mass, distance, and errors |
+
+CLI mode connects only the outputs needed to write the final file and report
+progress; it does not construct an OpenGL view.
+
+## Graphics Architecture
+
+[`BaseView`](../../include/graphics/base_view.h) is the shared `QOpenGLWidget`
+base. It owns camera controls, shaders, render roots, common input handling, and
+picking support. Domain-specific views decide which graphics object tree to
+attach.
+
+### Part View
+
+[`PartView`](../../include/graphics/view/part_view.h) renders the loaded model
+state represented by `PartMetaModel`. `PartObject` owns the drawable part mesh,
+feature edges, overhang appearance, transforms, and the current planar or
+cylindrical slicing-geometry preview. Printer, grid, axis, label, and settings
+range objects provide the surrounding editing context.
+
+Part visualization is driven by session/model state. It does not render parsed
+G-code.
+
+### G-Code View
+
+[`GCodeView`](../../include/graphics/view/gcode_view.h) owns the parsed preview
+state: visible layer/segment ranges, hidden display types, selection/highlight,
+printer context, optional ghosted parts, and true-width preference.
+
+[`GCodeObject`](../../include/graphics/objects/gcode_object.h) batches all
+preview segments into shared OpenGL buffers instead of creating one graphics
+object per move. It preserves per-segment metadata for visibility, color,
+selection, picking, and source-line correlation.
+
+Preview rendering has two main representations:
+
+- true-width printable moves expand segments into bead meshes;
+- lightweight preview draws batched line geometry, including tessellated arcs.
+
+The toolbar's true-width toggle requests bead geometry. The user's
+`GCodePreviewMode` and vertex threshold then decide whether a full true-width
+object is built. `GCodeView` can add a true-width overlay for a small visible
+subset while retaining a lightweight base object for a large file. Travel
+moves use a separate line buffer only in the mixed true-width representation;
+the lightweight representation keeps all moves in the primary shared line
+buffer.
+
+Keep parsed geometry and line/layer metadata stable across both rendering
+representations so filtering, picking, and text synchronization behave the same
+regardless of preview quality.
+
+## Adding a G-Code Syntax
+
+A complete syntax integration normally touches all of these seams:
+
+1. Add the `GcodeSyntax` value and stable string mapping in
+   `include/utilities/enums.h` (plus JSON conversion where required).
+2. Add a `GcodeMeta` entry with correct units, delimiters, suffix, and travel
+   semantics.
+3. Register that metadata in `GcodeMetaList::SyntaxToMetaHash`; temporary output
+   suffix selection indexes this mapping in `SessionManager::doSlice()`.
+4. Add a `WriterBase` subclass or deliberately reuse an existing writer.
+5. Route writer selection in `AbstractSlicingThread::setGcodeOutput()`.
+6. Make the emitted syntax header identify the new syntax.
+7. Add a parser subclass when `CommonParser` cannot represent the dialect.
+8. Route header detection and parser/meta selection in `GCodeLoader::setParser()`.
+9. Add settings metadata and migrations for any serialized enum-position
+   change.
+10. Exercise generation, parser reload, visual segments, statistics, and export
+   naming together.
+
+Some syntaxes are import-only, share writers/parsers, or require specialized
+saver threads. Document such exceptions beside their selection switch instead
+of relying on enum naming alone.
+
+## Adding Preview Behavior
+
+- A new semantic region/modifier display type needs a stable comment emitted by
+  writers, detection and color assignment in `GCodeLoader`, enum/filter support,
+  and matching UI controls.
+- A new motion command needs parser output plus `generateVisualSegment()`
+  geometry, metadata, and both lightweight/true-width rendering support where
+  applicable.
+- A new part-editing overlay belongs in `PartView`/`PartObject`; a parsed
+  toolpath overlay belongs in `GCodeView`/`GCodeObject`.
+- Performance changes should preserve source line numbers and segment ordering;
+  those are the bridge between the text editor, picking, and metadata display.
+
+## Guardrails
+
+- Do not put controller formatting in `SegmentBase` subclasses when the writer
+  can own it.
+- Keep syntax units and file properties in `GcodeMeta`, shared by writer and
+  parser paths.
+- Treat writer generation and parser reload as one compatibility contract.
+- Keep `GCodeLoader` off the GUI thread and return UI-ready payloads through
+  signals.
+- Batch G-code rendering. Per-move `GraphicsObject` allocation does not scale to
+  production files.
+- Preserve a lightweight fallback for previews whose true-width vertex estimate
+  exceeds the configured threshold.

--- a/docs/architecture/settings-system.md
+++ b/docs/architecture/settings-system.md
@@ -1,0 +1,208 @@
+# Settings System
+
+This page describes the settings source files, generated artifacts, runtime
+containers, override scopes, UI construction, templates, and migrations. See
+the [architecture overview](../../ARCHITECTURE.md) for the surrounding system.
+For a task-oriented walkthrough, see
+[Adding a New User Setting](../wiki/Adding-a-New-User-Setting.md).
+
+## Source and Generation Pipeline
+
+Canonical setting metadata lives in
+[`resources/settings/*.yaml`](../../resources/settings/). The files are read in
+sorted path order, and entries remain in file order so the source layout also
+controls generated/UI ordering.
+
+```mermaid
+flowchart LR
+    YAML["resources/settings/*.yaml"] --> Generator["scripts/generate_master_config.py"]
+    Generator --> Master["resources/configs/master.conf"]
+    Generator --> Inputs["resources/configs/setting_inputs.conf"]
+    Master --> QRC["resources/configs/configs.qrc"]
+    Inputs --> QRC
+    Versions["resources/configs/versions.conf"] --> QRC
+    QRC --> Manager["SettingsManager"]
+    Manager --> Runtime["SettingsBase values"]
+    Manager --> UI["SettingBar and SettingTab rows"]
+```
+
+[`scripts/generate_master_config.py`](../../scripts/generate_master_config.py)
+validates the project's supported YAML subset and writes two JSON artifacts:
+
+- `master.conf` contains each scalar setting's key, display metadata, type,
+  dependency expression, options, default, categories, constant metadata, and
+  local-setting flag.
+- `setting_inputs.conf` describes composite input rows, currently vector-style
+  widgets whose components remain independently stored scalar settings.
+
+[`resources/configs/configs.qrc`](../../resources/configs/configs.qrc) embeds
+both generated files and `versions.conf`. The GUI entry path initializes this
+resource bundle before any settings singleton is constructed.
+
+The CMake `generate_master_config` target runs the generator automatically when
+`ORNLSLICER_AUTO_GENERATE_MASTER_CONFIG` is enabled. The direct command is:
+
+```bash
+python3 scripts/generate_master_config.py \
+  resources/settings \
+  resources/configs/master.conf \
+  resources/configs/setting_inputs.conf
+```
+
+Read [`resources/settings/README.md`](../../resources/settings/README.md) and
+[Generating the Master Settings File](../wiki/Generating-the-Master-Settings-File.md)
+before changing the schema or generator.
+
+## Runtime Ownership
+
+[`SettingsManager`](../../include/managers/settings/settings_manager.h),
+accessed through `GSM`, is the settings lifecycle owner. Its constructor loads:
+
+- `:/configs/master.conf` into the master metadata `SettingsBase`;
+- `:/configs/setting_inputs.conf` into composite-input metadata;
+- every master default into the active global `SettingsBase`;
+- `:/configs/versions.conf` as the current template/settings version.
+
+The manager also owns discovered global templates, layer-bar templates, console
+settings, the active layer-bar template name, and the signals used to refresh
+settings controls. GUI global-template selections are tracked by `SettingBar`
+and `SessionManager`'s recent-setting history rather than that layer-bar name.
+
+[`SettingsBase`](../../include/configs/settings_base.h) is the common value
+container. It stores JSON-backed key/value data and provides typed `setting<T>`
+and `setSetting<T>` access, overlay through `populate`, removal through
+`splice`, and global/local adjustment passes.
+
+Use the narrowest settings object available to a calculation. Code that is
+computing one layer or region should normally consume the settings snapshot
+passed into that object, not reach back to `GSM->getGlobal()` and bypass local
+overrides.
+
+## Effective Settings Scopes
+
+Settings are layered before path computation. For the planar pipeline, the
+effective order is:
+
+1. Master defaults initialize the active global settings.
+2. Selected printer, material, profile, and experimental templates overlay the
+   active global values.
+3. `SettingsBase::makeGlobalAdjustments()` resolves programmatic constraints on
+   the copied global snapshot.
+4. A `Part` settings base overlays the adjusted global values for that part.
+5. Matching [`SettingsRange`](../../include/configs/settings_range.h) values
+   overlay the copied part settings for a layer index.
+6. `SettingsBase::makeLocalAdjustments()` resolves programmatic local
+   constraints for that layer.
+7. Settings parts are cross-sectioned into `SettingsPolygon` objects and passed
+   to islands/regions for spatially bounded overrides.
+
+```text
+master defaults
+  -> selected global templates
+    -> global adjustments
+      -> part overrides
+        -> layer-range overrides
+          -> local adjustments
+            -> spatial settings polygons inside affected regions
+```
+
+[`Preprocessor`](../../src/slicing/preprocessor.cpp) constructs the adjusted
+global plus part snapshot. [`BufferedSlicer`](../../src/slicing/buffered_slicer.cpp)
+applies matching ranges, local adjustments, and settings-part geometry for each
+planar slice.
+
+| Mode | Effective Settings Scope |
+| --- | --- |
+| Planar | Adjusted global copy, part overrides, matching layer ranges, local adjustments, and settings-part polygons |
+| Radial/helical | Adjusted global copy, part overrides, and per-layer local adjustments; no layer ranges or settings-part polygons currently |
+| Image | Active global settings read directly during image generation |
+
+Inspect the concrete slicer when adding a new override mechanism; the planar
+scope is not automatically available to other modes.
+
+The settings scopes have distinct persistence:
+
+- `.s2c` templates serialize template values, and a project's global entry
+  serializes the active global values;
+- recently selected global template names are workstation history, not part of
+  the project archive;
+- a `Part` owns its local `SettingsBase`;
+- a `Part` also owns its layer `SettingsRange` map;
+- a settings-type `Part` carries values whose geometry becomes spatial
+  settings polygons during planar preprocessing.
+
+## Settings UI
+
+[`SettingBar::setupGlobalSettings()`](../../src/widgets/settings/setting_bar.cpp)
+walks the master metadata. It creates/fetches the `SettingPane` and `SettingTab`
+for each major/minor category, finds any composite input metadata through
+`SettingsManager::getSettingInput()`, and asks `SettingTab` to create the row.
+
+[`SettingTab`](../../src/widgets/settings/setting_tab.cpp) maps scalar metadata
+types to concrete `SettingRowBase` subclasses. Composite input metadata selects
+the corresponding grouped widget while retaining the scalar component keys.
+`SettingBar` separately builds dependency trees from the `depends` metadata and
+connects parent rows to rows that must be re-evaluated.
+
+This separation matters when extending the UI:
+
+- A new setting using an existing scalar type usually requires YAML and a C++
+  constant, not a new widget.
+- A new scalar input type requires generator validation, a row class, and the
+  `SettingTab` creation mapping.
+- A new grouped input requires generator metadata/validation and grouped-widget
+  handling while preserving stable scalar storage keys.
+- A dependency feature belongs in the metadata parser and `SettingBar`
+  dependency tree, not in one arbitrary row subclass.
+
+## Templates and Versions
+
+Global setting templates use the legacy `.s2c` extension. Layer-setting
+templates use `.s2l`. `SettingsManager` discovers templates in installed and
+user-selected directories, groups global values by major category, and overlays
+the chosen template from each category into the active global settings.
+
+[`resources/configs/versions.conf`](../../resources/configs/versions.conf)
+contains the current `master_version`. When a template or project global entry
+has an older version, `SettingsManager::checkVersion()` delegates to
+[`SettingsVersionControl`](../../src/managers/settings/settings_version_control.cpp)
+to roll it forward.
+
+Add a migration when a saved value's meaning changes, including:
+
+- renaming or removing a setting key;
+- changing the positional value of a serialized enum;
+- splitting or combining behavior represented in old templates;
+- changing a default when existing files must preserve their former behavior.
+
+Update the version only with a complete roll-forward path. Loading an older
+project may rewrite its global settings entry after migration, so migration
+code must be safe for both standalone templates and project archives.
+
+## Adding or Changing a Setting
+
+1. Edit the appropriate YAML file under `resources/settings/`; keep the key
+   stable and place it in the intended UI order.
+2. Add or update its constant in `include/utilities/constants.h` and
+   `src/utilities/constants.cpp` when C++ reads it.
+3. Regenerate both `master.conf` and `setting_inputs.conf`.
+4. Wire the setting into the narrowest owning subsystem and read it from the
+   effective settings snapshot at that scope.
+5. Add a version migration when existing saved numeric values or keys would be
+   reinterpreted.
+6. Validate generator output and at least one runtime path that exercises the
+   intended global/local scope.
+
+## Guardrails
+
+- Never hand-edit `master.conf` or `setting_inputs.conf`; both are generated and
+  should change only as a consequence of YAML/generator changes.
+- Do not add a YAML key without keeping the matching C++ constant string exact
+  where code consumes it.
+- Do not reorder serialized enum values without a settings migration.
+- Do not mark a setting `local` unless the consuming path reads effective local
+  settings.
+- Keep composite UI controls backed by stable scalar keys so project and
+  template formats remain flat and compatible.
+- Preserve backward-compatible defaults unless a behavior change is explicitly
+  intended and migrated.

--- a/docs/architecture/slicing-pipeline.md
+++ b/docs/architecture/slicing-pipeline.md
@@ -1,0 +1,257 @@
+# Slicing Pipeline
+
+This page describes slicer selection, geometry preprocessing, toolpath
+computation, the path data model, and G-code handoff. See the
+[architecture overview](../../ARCHITECTURE.md) for the surrounding application
+and [G-code and Visualization](gcode-and-visualization.md) for the downstream
+writer/parser path.
+
+## Slicer Selection
+
+[`SessionManager::doSlice()`](../../src/managers/session_manager.cpp) reads the
+active settings, validates mode-specific constraints, chooses the temporary
+output suffix, and emits `startSlice` to the active slicer.
+
+| `SlicingMode` | Additional Selection | Implementation | Output Model |
+| --- | --- | --- | --- |
+| `kPlanar` | None | `PlanarSlicer` | Cross-sectioned layers with islands and regions |
+| `kCylindrical` | `CylindricalPathPattern::kRadial` | `RadialSlicer` | Concentric radial paths stored directly on `RadialLayer` |
+| `kCylindrical` | `CylindricalPathPattern::kHelical` | `HelicalSlicer` | Rising helical paths stored directly on `HelicalLayer` |
+| `kImage` | None | `ImageSlicer` | Image slices rather than ordinary machine G-code |
+
+Cylindrical slicing currently requires the Arc Specialties G-code syntax. The
+guard lives in `SessionManager::doSlice()`, and the cylindrical slicers select
+`ArcSpecialtiesWriter` directly. User-facing cylindrical behavior is documented
+in [Cylindrical Slicing](../cylindrical-slicing.md).
+
+`SessionManager::changeSlicer()` replaces the slicer when the mode or
+cylindrical pattern changes, clears existing part steps, and reconnects
+the start trigger plus progress/status and completion signals. Cancellation is
+requested separately through `SessionManager::cancelSlice()`, which calls the
+active slicer's `setCancel()` method.
+
+## Pipeline Phases
+
+The concrete slicers derive from
+[`TraditionalAST`](../../include/threading/traditional_ast.h), which derives from
+[`AbstractSlicingThread`](../../include/threading/abs_slicing_thread.h).
+`AbstractSlicingThread` is a `QObject` moved to an internal `QThread`; it owns
+the cancellation flag, output file, selected writer, bounds, and common G-code
+setup/shutdown behavior.
+
+```mermaid
+flowchart LR
+    Select["Select slicer and writer"] --> Pre["preProcess()"]
+    Pre --> Queue["Queue dirty Step objects"]
+    Queue --> Compute["StepThread: Step::compute()"]
+    Compute --> Post["postProcess()"]
+    Post --> Skip{"skip G-code?"}
+    Skip -->|"no"| Setup["writeGCodeSetup()"]
+    Setup --> Body["Concrete writeGCode()"]
+    Body --> Shutdown["writeGCodeShutdown()"]
+    Shutdown --> Complete["sliceComplete"]
+    Skip -->|"yes"| Complete
+```
+
+### Preprocess
+
+Toolpath slicers convert meshes and effective settings into their `Step` model.
+Image slicing writes image stencils during preprocessing without populating the
+ordinary toolpath-step hierarchy.
+
+Planar slicing uses [`Preprocessor`](../../src/slicing/preprocessor.cpp) and
+[`BufferedSlicer`](../../src/slicing/buffered_slicer.cpp). `Preprocessor`
+provides ordered hooks around the whole-part cross-sectioning loop:
+
+1. initial processing across all build, clipping, and settings parts;
+2. per-part setup and effective settings construction;
+3. per-mesh copying and clipping;
+4. step construction from each `BufferedSlicer::SliceMeta` result;
+5. post-cross-section processing after each mesh's slice loop;
+6. a status update after all meshes for one part have been processed;
+7. final processing after all parts have steps.
+
+`PlanarSlicer` builds `Layer` objects, splits layer geometry into polymer
+islands, and adds optional support, raft, brim, skirt, laser-scan, and
+thermal-scan structures. It then uses `LayerOrderOptimizer` to group compatible
+steps from multiple parts into `GlobalLayer` objects.
+
+Radial and helical slicers have specialized preprocessors. They copy and clip
+meshes, compute horizontal cross-sections, generate circular or helical
+polylines against those sections, and store resulting `Path` objects directly
+on their specialized layers. They intentionally do not create polymer islands
+or regions.
+
+Image slicing owns its image-generation preprocessing and does not use the
+ordinary machine G-code body.
+
+### Compute
+
+[`TraditionalAST::doSlice()`](../../src/threading/traditional_ast.cpp) collects
+dirty steps from every non-clipping part. It creates up to
+`QThread::idealThreadCount()`
+[`StepThread`](../../src/threading/step_thread.cpp) workers, assigns one step to
+each worker, and feeds the next queued step to a worker when it emits
+`completed`.
+
+Each `StepThread` worker calls only `Step::compute()`. In the common planar and
+scan hierarchy, computation therefore belongs in the step, island, region, and
+pathing types, not in a GUI callback. `TraditionalAST` owns queue progress and
+decides when it is safe to start postprocessing.
+
+The specialized modes are intentional exceptions to that common hierarchy.
+`RadialLayer::compute()` and `HelicalLayer::compute()` are currently no-ops
+because their paths are generated during preprocessing and modified later.
+Image slicing creates no `Step` objects; it generates VTK image stencils during
+preprocessing with its own `std::jthread` worker pool.
+
+### Postprocess
+
+Postprocessing performs work that depends on computed paths or cross-step
+ordering.
+
+- Planar `GlobalLayer` objects have already been assembled and ordered by
+  `LayerOrderOptimizer` in the preprocessor's final hook. Postprocessing
+  unorients each global layer, orders and connects its islands/paths and
+  travels, applies path modifiers, and restores printer coordinates.
+- Radial and helical slicing apply modifiers over their directly owned paths
+  while preserving the current tool location between layers.
+- Concrete slicers emit postprocess progress and honor the shared cancellation
+  flag before output begins.
+
+### Write
+
+For slicers that do not set `m_skip_gcode`, `AbstractSlicingThread` writes the
+file header, settings header, and initial machine setup through its selected
+`WriterBase`. The concrete slicer then walks its ordered steps or global layers
+and delegates segment output to the writer. The base class appends shutdown and,
+where supported, the settings footer.
+
+The completed temporary file is returned to `SessionManager`, then normally
+sent to `GCodeLoader` for parsing, visualization, statistics, possible
+layer-time adjustment, and export.
+
+## Settings Scope by Mode
+
+The slicers do not all consume the same override scopes.
+
+| Mode | Effective Settings Scope |
+| --- | --- |
+| Planar | Adjusted global copy, part overrides, matching layer ranges, local adjustments, and spatial settings polygons |
+| Radial/helical | Adjusted global copy, part overrides, and per-layer local adjustments; layer ranges and settings-part polygons are not currently applied |
+| Image | Active global values read directly while generating image stencils |
+
+When adding an override mechanism, trace the concrete slicer's preprocessing
+instead of assuming the planar settings path is shared by every mode.
+
+## Toolpath Data Model
+
+[`Part`](../../include/part/part.h) owns meshes for geometry and `StepPair`
+groups for computed output. A `StepPair` can associate a printing `Layer` with a
+corresponding `ScanLayer` at the same sequence position.
+
+The common planar toolpath hierarchy is:
+
+```text
+Part
+└── StepPair
+    ├── Layer (printing)
+    │   └── IslandBase
+    │       └── RegionBase
+    │           └── Path
+    │               └── SegmentBase
+    └── ScanLayer (optional)
+        └── IslandBase
+            └── RegionBase
+                └── Path
+                    └── SegmentBase
+```
+
+Responsibilities are deliberately layered:
+
+- [`Step`](../../include/step/step.h) is a computable and writable unit with
+  settings, geometry, orientation, and dirty state.
+- [`Layer`](../../include/step/layer/layer.h) owns islands, inter-island order,
+  travel connection, modifiers, and orientation restoration.
+- [`IslandBase`](../../include/step/layer/island/island_base.h) groups regions
+  for one connected area and coordinates region computation/optimization.
+- [`RegionBase`](../../include/step/layer/regions/region_base.h) implements a
+  pathing purpose such as perimeter, inset, skin, infill, skeleton, support, or
+  scan behavior and owns the resulting paths.
+- [`Path`](../../include/geometry/path.h) is an ordered collection of shared
+  `SegmentBase` objects.
+- [`SegmentBase`](../../include/geometry/segment_base.h) and its line, arc,
+  travel, scan, and other subclasses carry geometric and process data and
+  delegate machine text to the writer.
+
+`GlobalLayer` is not a `Step`. It is a planar cross-part aggregate that groups
+`StepPair` objects for ordering, postprocessing, and G-code generation.
+
+`RadialLayer` and `HelicalLayer` derive through `Layer`, but their specialized
+implementations own `Path` objects directly. Do not assume every layer has an
+island/region hierarchy.
+
+## Geometry and Coordinates
+
+- `geometry/mesh/` owns closed/open mesh representations and mesh utilities.
+- `cross_section/` turns meshes and planes into stitched polygon geometry.
+- `geometry/` owns points, polylines, polygons, polygon lists, paths, planes,
+  and common path modification utilities.
+- `slicing/` coordinates preprocessing, buffered cross-sectioning, step
+  additions, and shared slicer utilities.
+- `optimizers/` owns ordering algorithms at layer, island, path, polyline, and
+  point levels.
+
+Planar layers may be flattened for path computation and later reoriented into
+printer coordinates. Preserve the existing orientation, shift, and minimum-Z
+restoration stages when adding geometry operations. Applying an operation in
+the wrong coordinate space commonly produces correct-looking 2-D paths at the
+wrong 3-D location.
+
+## Extending the Pipeline
+
+### Add or Change a Slicing Mode
+
+1. Define or reuse the mode and any submode in `utilities/enums.h` and settings
+   metadata.
+2. Implement a concrete `TraditionalAST` or `AbstractSlicingThread` subclass
+   with preprocess, postprocess, and output behavior.
+3. Route it through `SessionManager::changeSlicer()` and define mode-specific
+   validation in `doSlice()`.
+4. Establish its step model explicitly: common islands/regions or a documented
+   direct-path specialization.
+5. Forward status and completion through the shared base, and honor direct
+   `setCancel()` requests and the shared cancellation flag.
+
+### Add a Region or Island
+
+1. Derive from `RegionBase` or `IslandBase` under `step/layer/`.
+2. Add the enum/string mappings used for ordering, comments, and
+   visualization.
+3. Construct the type during preprocessing or a `LayerAdditions` stage.
+4. Implement computation, optimization, modifiers, and writer delegation.
+5. Confirm that settings-region and layer-range overrides reach the new type.
+
+### Add a Segment or Modifier
+
+Keep geometry and process metadata on the segment, and keep syntax formatting
+on `WriterBase` implementations. A new segment must be handled by generation,
+ordering/modification code, G-code writing, parsing where applicable, and the
+preview path. See [G-code and Visualization](gcode-and-visualization.md) before
+adding syntax-specific behavior to a geometry class.
+
+## Invariants to Preserve
+
+- The slicer and each `StepThread` own separate worker threads; GUI state stays
+  on the GUI thread.
+- Build, clipping, support, and settings parts have different preprocessing
+  roles. Do not treat every loaded part as printable geometry.
+- In toolpath modes, effective settings are copied before supported local
+  adjustments; avoid mutating the global settings object from a region
+  algorithm. Check the mode-specific scope before relying on an override.
+- Cross-part ordering belongs to `GlobalLayer`/`LayerOrderOptimizer`, not to a
+  single part's `Layer`.
+- Not every layer uses islands and regions; check the concrete slicer before
+  relying on that hierarchy.
+- Progress/status and completion are forwarded through slicer signals;
+  cancellation is a direct `SessionManager` request to the active slicer.


### PR DESCRIPTION
## Summary

Adds a root-level architecture guide for ORNLSlicer and detailed subsystem documentation under `docs/architecture/`.

This PR gives contributors a current-state map of the application runtime, slicing pipeline, settings system, and G-code/visualization boundaries. It also links the new architecture docs from the root `README.md` and `docs/README.md` so they are discoverable from the main documentation entry points.

## Related issues

- Closes #199

## Details

This is a documentation-focused change that introduces `ARCHITECTURE.md` as the high-level system map for the repository.

The root architecture document summarizes:
- the major runtime paths for GUI and CLI usage
- repository structure and ownership boundaries
- how application/session state, settings, slicing, G-code generation, and visualization fit together
- where common types of future changes should be made
- guardrails for keeping subsystem responsibilities separate

More detailed subsystem notes were added under `docs/architecture/`:
- `application-runtime.md` covers startup, `SessionManager`, settings/preferences ownership, model loading, project persistence, and worker boundaries.
- `slicing-pipeline.md` documents slicer selection, preprocess/compute/postprocess/write phases, mode-specific behavior, toolpath data structures, and extension points.
- `settings-system.md` explains YAML-driven settings generation, runtime settings ownership, effective settings scopes, UI/template behavior, and how to add or change settings.
- `gcode-and-visualization.md` documents the writer/parser boundary, G-code loading flow, parser layers, preview consumers, graphics responsibilities, and syntax-extension considerations.

The existing documentation indexes were updated so contributors can find the new architecture material from both the repository root and the docs landing page.

## Impact

This change has no intended runtime, slicing, configuration, or UI behavior impact.

The main impact is maintainability: contributors now have a navigable architecture reference that explains where core responsibilities live before they modify slicing, settings, session, G-code, or visualization code.

Risk level: Low.

The change is documentation-only. The primary risk is stale or inaccurate architecture prose, which was mitigated by checking the documents against the current source structure and validating the generated Markdown/link hygiene.


## Testing strategy

Validation performed:
- `git diff --check origin/develop...HEAD`
  - Passed with no whitespace errors.
- Markdown validation script over the 7 touched Markdown files:
  - confirmed final newlines
  - confirmed balanced fenced code blocks
  - confirmed relative Markdown links resolve

No build or runtime test was run because this PR only changes documentation.