### PR TITLE
docs(wiki): fix relative links to sibling markdown pages

### DIFF
--- a/docs/wiki/Adding-a-New-User-Setting.md
+++ b/docs/wiki/Adding-a-New-User-Setting.md
@@ -70,7 +70,7 @@ Run CMake/build, or run the generator directly:
 python3 scripts/generate_master_config.py resources/settings resources/configs/master.conf resources/configs/setting_inputs.conf
 ```
 
-See [Generating the Master Settings File](Generating-the-Master-Settings-File) for more information.
+See [Generating the Master Settings File](Generating-the-Master-Settings-File.md) for more information.
 
 ### 3. Add the setting to the `Constants` class.
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -26,7 +26,7 @@ Windows limits file paths to 260 characters by default, which can break builds w
 
 **WSL2** provides a native Linux experience inside Windows. We recommend using **Ubuntu 24.04**.
 
-- **For ORNL-managed machines**, follow the [ORNL-specific WSL2 guide](ORNL-WSL2-Installation).
+- **For ORNL-managed machines**, follow the [ORNL-specific WSL2 guide](ORNL-WSL2-Installation.md).
 - **For all others**:
   
   1. Open a **PowerShell** window.
@@ -106,7 +106,7 @@ Authenticate with GitHub securely using SSH keys:
 
    > If prompted, type `yes` to confirm the SSH connection. If nothing happens, click this link:
 
-   🔧 [Troubleshooting SSH Connection Issues](Troubleshooting#connection-issues)
+   🔧 [Troubleshooting SSH Connection Issues](Troubleshooting.md#connection-issues)
 
 
 ## 7. Install Nix


### PR DESCRIPTION
## Summary
- Fix broken relative wiki links missing .md suffix.
- Include Troubleshooting anchor link.

## Verification
- Target files exist under docs/wiki/.

## Claim
`Claim: bartok` (seed). Follow-ups: `Claim: sera`.
