### PR TITLE
docs(contributing): use repo-relative paths for guide links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,30 +17,30 @@ This guide summarizes expectations for code style, formatting, documentation, an
 
 ---
 
-## [Conventional Branch Naming](/docs/contributing/conventional-branch.md)
+## [Conventional Branch Naming](docs/contributing/conventional-branch.md)
 
 Name branches with `<type>/<description>` for clarity and CI/CD automation.
 
-## [Conventional Commits](/docs/contributing/conventional-commits.md)
+## [Conventional Commits](docs/contributing/conventional-commits.md)
 
 Use structured commit messages (type, scope, description, optional breaking change).
 
-## [Pull Requests](/docs/contributing/pull-requests.md)
+## [Pull Requests](docs/contributing/pull-requests.md)
 
 Prepare focused PRs using the checklist & description template; we squash merge features/fixes.
 
-## [Issue Submissions](/docs/contributing/issue-submissions.md)
+## [Issue Submissions](docs/contributing/issue-submissions.md)
 
 Submit all tasks, bugs, and features as issues first for tracking and discussion.
 
-## [Style Guide](/docs/contributing/style-guide.md)
+## [Style Guide](docs/contributing/style-guide.md)
 
 Follow naming, layout, and structural conventions; favor clarity over cleverness.
 
-## [Formatting](/docs/contributing/formatting.md)
+## [Formatting](docs/contributing/formatting.md)
 
 Use `clang-format` before committing; never hand-adjust whitespace.
 
-## [Documentation](/docs/contributing/documentation.md)
+## [Documentation](docs/contributing/documentation.md)
 
 Document public APIs with Doxygen blocks (purpose, constraints, usage).


### PR DESCRIPTION
## Summary

- Fix seven CONTRIBUTING.md section links that used root-absolute `/docs/contributing/...` paths
- Those paths resolve against `github.com` (404) instead of this repository
- Switch to repo-relative `docs/contributing/...` targets

## Motivation

On GitHub, Markdown links starting with `/` are site-root absolute. The contributor guide linked seven local docs that currently 404 for anyone browsing CONTRIBUTING.md.

Orthogonal to #214 (wiki relative links).

## Verification

- Confirmed each target exists under `docs/contributing/`
- Docs-only change

## AI disclosure

Assisted by an AI coding tool (Hermes/Sera); human-reviewed before open.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes campaign=construction-am pilot=1 -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h  
**Claim:** `sera` · pilot-1 construction-am