### PR TITLE
Fix skeleton compute crashes

### DIFF
--- a/include/optimizers/island_order_optimizer.h
+++ b/include/optimizers/island_order_optimizer.h
@@ -112,6 +112,12 @@ class IslandBaseOrderOptimizer {
      */
     int computeNextClosest();
 
+    /*! \brief Computes the island order with following logic:
+     *          Each time move to the farthest polygon from current position
+     *  \return Index of next island
+     */
+    int computeNextFarthest();
+
     /*! \brief The index of the island that has the nearest end point from a start point
      *  \return Index of next island
      *  \param start_point Starting point to consider for calculation

--- a/src/optimizers/island_order_optimizer.cpp
+++ b/src/optimizers/island_order_optimizer.cpp
@@ -41,14 +41,19 @@ IslandBaseOrderOptimizer::IslandBaseOrderOptimizer(Point current_positon,
     m_island_list = m_part_island_list.keys();
 }
 
-void IslandBaseOrderOptimizer::setStartPoint(Point start_point) { m_start = start_point; }
+void IslandBaseOrderOptimizer::setStartPoint(Point start_point) {
+    m_start = start_point;
+    m_tsp_result.clear();
+}
 
 void IslandBaseOrderOptimizer::setIslands(QList<QSharedPointer<IslandBase>> island_list) {
     m_island_list = island_list;
+    m_tsp_result.clear();
 }
 
 void IslandBaseOrderOptimizer::setOrderOptimization(IslandOrderOptimization order_optimization) {
     m_order_optimization = order_optimization;
+    m_tsp_result.clear();
 }
 
 int IslandBaseOrderOptimizer::getLastIslandBaseVisited() { return m_last_island_visited; }
@@ -72,9 +77,9 @@ int IslandBaseOrderOptimizer::computeNextIndex() {
             index = this->computeNextClosest();
             break;
 
-        //! Brute force approach for Traveling Salesman Problem (but finding the largest distance)
+        //! Keep finding the farthest island from the current one
         case IslandOrderOptimization::kNextFarthest:
-            index = this->computeExtremumDistance(false);
+            index = this->computeNextFarthest();
             break;
 
         //! An approximate algorithm (Christofides) for Traveling Salesman Problem, much faster than brute force & DP
@@ -224,6 +229,12 @@ void IslandBaseOrderOptimizer::removeValue(QVector<int>& index_list, int value) 
 int IslandBaseOrderOptimizer::computeNextClosest() {
     //! \note Start with the polygon that is closest to starting point
     int first_island_index = this->extremumIslandBase(m_start, true);
+    return first_island_index;
+}
+
+int IslandBaseOrderOptimizer::computeNextFarthest() {
+    //! \note Start with the polygon that is farthest from starting point
+    int first_island_index = this->extremumIslandBase(m_start, false);
     return first_island_index;
 }
 

--- a/src/step/layer/regions/skeleton.cpp
+++ b/src/step/layer/regions/skeleton.cpp
@@ -577,7 +577,7 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
         return;
 
     Polyline path;
-    QVector<QPair<SkeletonVertex, SkeletonVertex>> edges_to_remove;
+    QVector<SkeletonEdge> edges_to_remove;
     QVector<SkeletonVertex> touched_vertices;
 
     auto trackVertex = [&touched_vertices](SkeletonVertex vertex) {
@@ -589,7 +589,7 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
     SkeletonVertex source = boost::source(e, m_skeleton_graph);
     SkeletonVertex target = boost::target(e, m_skeleton_graph);
     path << m_skeleton_graph[source] << m_skeleton_graph[target];
-    edges_to_remove.push_back({source, target});
+    edges_to_remove.push_back(e);
     trackVertex(source);
     trackVertex(target);
 
@@ -597,16 +597,14 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
         source = boost::source(e, m_skeleton_graph);
         target = boost::target(e, m_skeleton_graph);
         path << m_skeleton_graph[target];
-        edges_to_remove.push_back({source, target});
+        edges_to_remove.push_back(e);
         trackVertex(source);
         trackVertex(target);
     }
 
-    // Edge descriptors from the collected path can become stale as soon as the graph is mutated.
-    // Remove by endpoint pair after all path points have been copied, then prune isolated vertices.
-    for (const auto& edge : edges_to_remove) {
-        if (boost::edge(edge.first, edge.second, m_skeleton_graph).second)
-            boost::remove_edge(edge.first, edge.second, m_skeleton_graph);
+    // Remove the exact collected edges after all path points have been copied, then prune isolated vertices.
+    for (const SkeletonEdge& edge : edges_to_remove) {
+        boost::remove_edge(edge, m_skeleton_graph);
     }
 
     for (SkeletonVertex vertex : touched_vertices) {

--- a/src/step/layer/regions/skeleton.cpp
+++ b/src/step/layer/regions/skeleton.cpp
@@ -83,6 +83,9 @@ void Skeleton::compute(uint layer_num) {
     m_layer_num = layer_num;
 
     m_paths.clear();
+    m_skeleton_geometry.clear();
+    m_skeleton_graph.clear();
+    m_computed_geometry.clear();
 
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kSkeletonNum));
 
@@ -570,31 +573,45 @@ void Skeleton::extractSimplePaths() {
 }
 
 void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
+    if (path_.isEmpty())
+        return;
+
     Polyline path;
+    QVector<QPair<SkeletonVertex, SkeletonVertex>> edges_to_remove;
+    QVector<SkeletonVertex> touched_vertices;
+
+    auto trackVertex = [&touched_vertices](SkeletonVertex vertex) {
+        if (!touched_vertices.contains(vertex))
+            touched_vertices.push_back(vertex);
+    };
 
     SkeletonEdge e = path_.takeFirst();
-    path << m_skeleton_graph[e.m_source] << m_skeleton_graph[e.m_target];
-    remove_edge(e, m_skeleton_graph);
-
-    //! Remove isolated vertices
-    if (boost::degree(e.m_source, m_skeleton_graph) == 0) {
-        remove_vertex(e.m_source, m_skeleton_graph);
-    }
-    if (boost::degree(e.m_target, m_skeleton_graph) == 0) {
-        remove_vertex(e.m_target, m_skeleton_graph);
-    }
+    SkeletonVertex source = boost::source(e, m_skeleton_graph);
+    SkeletonVertex target = boost::target(e, m_skeleton_graph);
+    path << m_skeleton_graph[source] << m_skeleton_graph[target];
+    edges_to_remove.push_back({source, target});
+    trackVertex(source);
+    trackVertex(target);
 
     for (SkeletonEdge& e : path_) {
-        path << m_skeleton_graph[e.m_target];
-        remove_edge(e, m_skeleton_graph);
+        source = boost::source(e, m_skeleton_graph);
+        target = boost::target(e, m_skeleton_graph);
+        path << m_skeleton_graph[target];
+        edges_to_remove.push_back({source, target});
+        trackVertex(source);
+        trackVertex(target);
+    }
 
-        //! Remove isolated vertices
-        if (boost::degree(e.m_source, m_skeleton_graph) == 0) {
-            remove_vertex(e.m_source, m_skeleton_graph);
-        }
-        if (boost::degree(e.m_target, m_skeleton_graph) == 0) {
-            remove_vertex(e.m_target, m_skeleton_graph);
-        }
+    // Edge descriptors from the collected path can become stale as soon as the graph is mutated.
+    // Remove by endpoint pair after all path points have been copied, then prune isolated vertices.
+    for (const auto& edge : edges_to_remove) {
+        if (boost::edge(edge.first, edge.second, m_skeleton_graph).second)
+            boost::remove_edge(edge.first, edge.second, m_skeleton_graph);
+    }
+
+    for (SkeletonVertex vertex : touched_vertices) {
+        if (boost::degree(vertex, m_skeleton_graph) == 0)
+            boost::remove_vertex(vertex, m_skeleton_graph);
     }
 
     m_computed_geometry.append(path);


### PR DESCRIPTION
## Summary
Fixes the compute-time skeleton crash reproduced with `New-Impact-Limiter-Bottom.s2p` and avoids a factorial post-compute path in `Next Farthest` island ordering.

## Changes
- Clear skeleton graph/output state for each compute.
- Avoid stale Boost graph edge descriptors by copying endpoints before graph mutation.
- Make `Next Farthest` select greedily instead of invoking longest brute-force TSP.
- Clear cached TSP results when optimizer inputs change.

## Validation
- Built `ornlslicer` with CMake/Ninja in the Nix dev shell.
- Sliced the provided project successfully through compute, postprocess, G-code generation, parsing, and visualization.
- Generated `/tmp/ornl-slice-repro/New-Impact-Limiter-Bottom.gcode`.