### PR TITLE
Add images to settings tooltips

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ This directory is the canonical documentation source for ORNLSlicer.
 - [Troubleshooting](wiki/Troubleshooting.md)
 - [Generating the Master Settings File](wiki/Generating-the-Master-Settings-File.md)
 - [Adding a New User Setting](wiki/Adding-a-New-User-Setting.md)
+- [Adding Images to Settings Tooltips](wiki/Adding-Images-to-Settings-Tooltips.md)
 - [Relevant Papers](wiki/Relevant-Papers.md)
 - [License and Library Licenses](wiki/License-and-Library-Licenses.md)
 - [Citation and Copyright Information](wiki/Citation-and-Copyright-Information.md)

--- a/docs/architecture/settings-system.md
+++ b/docs/architecture/settings-system.md
@@ -144,6 +144,13 @@ the corresponding grouped widget while retaining the scalar component keys.
 `SettingBar` separately builds dependency trees from the `depends` metadata and
 connects parent rows to rows that must be re-evaluated.
 
+Tooltip text is passed through the generated metadata and wrapped as Qt rich
+text by `SettingRowBase`, so small bundled images can be embedded in the
+existing `tooltip` field for `Printer`, `Material`, `Profile`, and
+`Experimental` settings. Use the
+[settings tooltip image procedure](../wiki/Adding-Images-to-Settings-Tooltips.md)
+when adding those assets.
+
 This separation matters when extending the UI:
 
 - A new setting using an existing scalar type usually requires YAML and a C++

--- a/docs/wiki/Adding-Images-to-Settings-Tooltips.md
+++ b/docs/wiki/Adding-Images-to-Settings-Tooltips.md
@@ -1,0 +1,96 @@
+# Adding Images to Settings Tooltips
+
+Settings tooltips come from the `tooltip` field in
+`resources/settings/*.yaml`. The same metadata path is used for `Printer`,
+`Material`, `Profile`, and `Experimental` settings, so this procedure applies
+to all four major settings categories.
+
+The settings generator does not support a separate `tooltip_image` field. Add
+images by embedding a small Qt rich-text image tag in the existing `tooltip`
+string.
+
+## Procedure
+
+1. Add the image asset.
+
+   Put tooltip-specific images under a stable Qt resource path, grouped by
+   major settings category:
+
+   | Major | Recommended asset path |
+   | --- | --- |
+   | `Printer` | `resources/tooltips/printer/<setting_name>.png` |
+   | `Material` | `resources/tooltips/material/<setting_name>.png` |
+   | `Profile` | `resources/tooltips/profile/<setting_name>.png` |
+   | `Experimental` | `resources/tooltips/experimental/<setting_name>.png` |
+
+   Prefer PNG images around 240-320 px wide. Name each file after the setting
+   key so the tooltip stays easy to audit. Static GIF files can be used when
+   the deployed Qt build includes GIF image support, but animated GIFs should be
+   avoided because rich-text tooltips display them as still images.
+
+2. Register the image in a Qt resource file.
+
+   If this is the first tooltip image, create `resources/tooltips/tooltips.qrc`:
+
+   ```xml
+   <RCC>
+       <qresource prefix="/tooltips">
+           <file>profile/layer_height.png</file>
+       </qresource>
+   </RCC>
+   ```
+
+   For later images, add another `<file>` entry under the same
+   `/tooltips` prefix. The build already collects `resources/**.qrc`, so no
+   CMake source-list edit is needed.
+
+3. Edit the setting tooltip.
+
+   Find the setting in the matching YAML file:
+
+   | Major | YAML files |
+   | --- | --- |
+   | `Printer` | `resources/settings/*_printer_*.yaml` |
+   | `Material` | `resources/settings/*_material_*.yaml` |
+   | `Profile` | `resources/settings/*_profile_*.yaml` |
+   | `Experimental` | `resources/settings/*_experimental_*.yaml` |
+
+   Add the image to the existing `tooltip` value:
+
+   ```yaml
+   tooltip: "Thickness of each layer.<br><br><img src=':/tooltips/profile/layer_height.png' width='260' height='146'>"
+   ```
+
+   Keep the tooltip on one physical line. Use single quotes inside HTML
+   attributes so the outer JSON-style YAML string can stay double-quoted.
+
+4. Regenerate the generated settings files.
+
+   ```bash
+   python3 scripts/generate_master_config.py resources/settings resources/configs/master.conf resources/configs/setting_inputs.conf
+   ```
+
+5. Validate in the UI.
+
+   Build and run ORNLSlicer, then hover the setting label. Confirm the text and
+   image render for the intended `Printer`, `Material`, `Profile`, or
+   `Experimental` setting. If the setting can be local, also check a locally
+   overridden row because the tooltip is wrapped with an extra local-override
+   message.
+
+## Tooltip Markup Rules
+
+- Use Qt resource paths such as `:/tooltips/profile/layer_height.png`; do not
+  use local filesystem paths or remote URLs.
+- Prefer PNG. GIF can work as a static image, but do not rely on GIF animation
+  in settings tooltips.
+- Do not include outer `<html>`, `<body>`, or `<p>` tags. Settings rows add
+  those wrappers automatically.
+- Use `<br><br>` before the image for spacing.
+- Specify `width` and `height` on the `<img>` tag so large source images do not
+  create oversized tooltips.
+- For grouped settings in an `inputs:` section, add the image to the input
+  `tooltip`; the grouped row uses that tooltip instead of an individual
+  component tooltip.
+- Do not add new YAML fields unless `scripts/generate_master_config.py`, the
+  generated config format, and the settings UI are updated together.

--- a/docs/wiki/Adding-a-New-User-Setting.md
+++ b/docs/wiki/Adding-a-New-User-Setting.md
@@ -33,7 +33,9 @@ Each setting entry has these fields:
   - time
   - unitless_float
   - voltage
-* `tooltip`: Short description of what the setting does.
+* `tooltip`: Short description of what the setting does. Tooltips can include a
+  small Qt resource image using rich-text markup; see
+  [Adding Images to Settings Tooltips](Adding-Images-to-Settings-Tooltips.md).
 * `depends`: Structured dependency object used to decide when a setting is enabled or disabled. Use `{}` for no
   dependency.
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -18,5 +18,6 @@ The canonical documentation entry point is the [Documentation Index](../README.m
 - [Troubleshooting](Troubleshooting.md)
 - [Generating the Master Settings File](Generating-the-Master-Settings-File.md)
 - [Adding a New User Setting](Adding-a-New-User-Setting.md)
+- [Adding Images to Settings Tooltips](Adding-Images-to-Settings-Tooltips.md)
 - [Conventional Commits](../contributing/conventional-commits.md)
 - [Issue Submissions](../contributing/issue-submissions.md)

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -4032,7 +4032,7 @@
   "spiral_perimeter": {
       "display":"Enable Spiral Perimeter",
       "type":"boolean",
-      "tooltip":"If selected, spiral perimeters will be generated",
+      "tooltip":"If selected, spiral perimeters will be generated.<br><br><img src=':/tooltips/profile/spiral_perimeter.png' width='260' height='146'>",
       "depends":{"AND":[{"slicing_mode":0},{"perimeter":true}]},
       "options":"",
       "default":false,

--- a/resources/settings/021_profile_perimeter.yaml
+++ b/resources/settings/021_profile_perimeter.yaml
@@ -235,7 +235,7 @@ settings:
   - name: "spiral_perimeter"
     display: "Enable Spiral Perimeter"
     type: "boolean"
-    tooltip: "If selected, spiral perimeters will be generated"
+    tooltip: "If selected, spiral perimeters will be generated.<br><br><img src=':/tooltips/profile/spiral_perimeter.png' width='260' height='146'>"
     depends: {"AND":[{"slicing_mode":0},{"perimeter":true}]}
     options: []
     default: false

--- a/resources/settings/README.md
+++ b/resources/settings/README.md
@@ -14,6 +14,10 @@ The generator intentionally supports a small YAML subset and uses only the Pytho
 values on one line, use JSON-style values for dependency objects, and use either `options: []` or a block list for enum
 options.
 
+Tooltips come from the `tooltip` field and may include compact Qt rich-text image tags that reference bundled resources.
+See [Adding Images to Settings Tooltips](../../docs/wiki/Adding-Images-to-Settings-Tooltips.md) for the project
+procedure.
+
 Grouped UI controls live in an optional top-level `inputs:` section. Use those entries to group existing scalar settings
 into composite rows such as `vector2` and `vector3` without making one component setting carry the display name and
 tooltip for the whole group.

--- a/resources/tooltips/profile/spiral_perimeter.png
+++ b/resources/tooltips/profile/spiral_perimeter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e44a094a3ed8fcbade75b99488d585a2c5855ce2aeab398af8ca92f555e80fb
+size 11261

--- a/resources/tooltips/tooltips.qrc
+++ b/resources/tooltips/tooltips.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/tooltips">
+        <file>profile/spiral_perimeter.png</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
## Summary

- Documented the procedure for adding bundled images to settings tooltips across Printer, Material, Profile, and Experimental settings.
- Added a tooltip resource bundle and a spiral perimeter diagram asset.
- Updated the Profile > Perimeter > Enable Spiral Perimeter tooltip to include the new image and regenerated `master.conf`.

## Validation

- `git diff --check HEAD~1..HEAD`
- `python3 -m xml.etree.ElementTree resources/tooltips/tooltips.qrc`
- `python3 scripts/generate_master_config.py resources/settings /tmp/ornlslicer-master-pr-check.conf /tmp/ornlslicer-setting-inputs-pr-check.conf`
- `cmp -s resources/configs/master.conf /tmp/ornlslicer-master-pr-check.conf`
- `cmp -s resources/configs/setting_inputs.conf /tmp/ornlslicer-setting-inputs-pr-check.conf`