### PR TITLE
Error Checking for Settings Values

### DIFF
--- a/include/widgets/settings/double_spin_subtypes/setting_speed_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_speed_spin_box.h
@@ -3,6 +3,7 @@
 #include <qgridlayout.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
+#include <qstring.h>
 #include <qtmetamacros.h>
 #include <qvariant.h>
 
@@ -46,5 +47,18 @@ class SettingSpeedSpinBox : public SettingDoubleSpinBox {
     //! \brief Slot to handle setting reload when user changes units or
     //! selects new setting profile
     virtual void reloadValue() override;
+
+    //! \brief Checks speed-specific dynamic dependencies.
+    void checkDynamicDependencies() override;
+
+  private:
+    //! \brief Returns this row's effective speed value in base units.
+    Velocity effectiveSpeed() const;
+
+    //! \brief Returns whether selected settings bases agree on this row's effective value.
+    bool hasConsistentEffectiveSpeed() const;
+
+    //! \brief Returns a warning message when this row violates the active XY speed range.
+    QString speedLimitWarning() const;
 };
 } // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_speed_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_speed_spin_box.h
@@ -55,10 +55,16 @@ class SettingSpeedSpinBox : public SettingDoubleSpinBox {
     //! \brief Returns this row's effective speed value in base units.
     Velocity effectiveSpeed() const;
 
+    //! \brief Returns this row's effective speed value for one selected base in base units.
+    Velocity effectiveSpeed(int settings_base_index) const;
+
     //! \brief Returns whether selected settings bases agree on this row's effective value.
     bool hasConsistentEffectiveSpeed() const;
 
     //! \brief Returns a warning message when this row violates the active XY speed range.
     QString speedLimitWarning() const;
+
+    //! \brief Returns a warning message for one selected base when this row violates the active XY speed range.
+    QString speedLimitWarning(int settings_base_index) const;
 };
 } // namespace ORNL

--- a/include/widgets/settings/setting_bar.h
+++ b/include/widgets/settings/setting_bar.h
@@ -196,6 +196,9 @@ class SettingBar : public QWidget {
      */
     void reloadSettingRow(const QString& setting_key);
 
+    //! \brief Rechecks warning-only dependencies that are not part of row visibility logic.
+    void refreshDynamicDependencies();
+
     //! \brief Setup the static widgets and their layouts.
     void setupWidget();
 

--- a/include/widgets/settings/setting_bar.h
+++ b/include/widgets/settings/setting_bar.h
@@ -199,6 +199,9 @@ class SettingBar : public QWidget {
     //! \brief Rechecks warning-only dependencies that are not part of row visibility logic.
     void refreshDynamicDependencies();
 
+    //! \brief Reloads rows after unit changes and refreshes dynamic warnings once.
+    void reloadRowsForUnitChange();
+
     //! \brief Setup the static widgets and their layouts.
     void setupWidget();
 
@@ -259,5 +262,8 @@ class SettingBar : public QWidget {
 
     //! \brief Prevents restored undo/redo values from being treated like fresh row edits.
     bool m_restoring_settings = false;
+
+    //! \brief Defers full dynamic warning refreshes while rows are reloaded in bulk.
+    bool m_suppress_dynamic_dependency_refresh = false;
 };
 } // Namespace ORNL

--- a/include/widgets/settings/setting_double_spin_box.h
+++ b/include/widgets/settings/setting_double_spin_box.h
@@ -86,20 +86,41 @@ class SettingDoubleSpinBox : public QDoubleSpinBox, public SettingRowBase {
     //! \brief Returns this row's effective value in base units.
     double effectiveDouble() const;
 
+    //! \brief Returns this row's effective value for one selected base in base units.
+    double effectiveDouble(int settings_base_index) const;
+
     //! \brief Returns another setting's effective value in base units.
     double effectiveDouble(const QString& key) const;
+
+    //! \brief Returns another setting's effective value for one selected base in base units.
+    double effectiveDouble(const QString& key, int settings_base_index) const;
 
     //! \brief Returns another boolean setting's effective value.
     bool effectiveBool(const QString& key) const;
 
+    //! \brief Returns another boolean setting's effective value for one selected base.
+    bool effectiveBool(const QString& key, int settings_base_index) const;
+
     //! \brief Returns another integer setting's effective value.
     int effectiveInt(const QString& key) const;
+
+    //! \brief Returns another integer setting's effective value for one selected base.
+    int effectiveInt(const QString& key, int settings_base_index) const;
 
     //! \brief Returns whether selected settings bases agree on this row's effective value.
     bool hasConsistentEffectiveDouble() const;
 
+    //! \brief Returns the number of effective settings contexts to evaluate.
+    int effectiveSettingsBaseCount() const;
+
     //! \brief Returns a warning message when this row violates a dynamic dependency.
     QString dynamicDependencyWarning() const;
+
+    //! \brief Returns a warning message for one selected base when this row violates a dynamic dependency.
+    QString dynamicDependencyWarning(int settings_base_index) const;
+
+    //! \brief Applies warning styling and optionally shows the transient tooltip.
+    void applyNotification(QString msg, bool show_tooltip);
 
     //! \brief Number of units of precision for child derived types with units
     //! Currently, all the same

--- a/include/widgets/settings/setting_double_spin_box.h
+++ b/include/widgets/settings/setting_double_spin_box.h
@@ -68,6 +68,9 @@ class SettingDoubleSpinBox : public QDoubleSpinBox, public SettingRowBase {
     //! selects new setting profile
     virtual void reloadValue() override;
 
+    //! \brief Checks double-based setting dependencies enforced through warnings.
+    void checkDynamicDependencies() override;
+
   protected:
     //! \brief Sets error notification when dynamic dependency check fails
     //! \param msg: Message to display
@@ -79,6 +82,24 @@ class SettingDoubleSpinBox : public QDoubleSpinBox, public SettingRowBase {
     //! \brief Overridden behavior to prevent wheel event from changing the value when not focused
     //! \param event: captured wheel event
     void wheelEvent(QWheelEvent* event) override;
+
+    //! \brief Returns this row's effective value in base units.
+    double effectiveDouble() const;
+
+    //! \brief Returns another setting's effective value in base units.
+    double effectiveDouble(const QString& key) const;
+
+    //! \brief Returns another boolean setting's effective value.
+    bool effectiveBool(const QString& key) const;
+
+    //! \brief Returns another integer setting's effective value.
+    int effectiveInt(const QString& key) const;
+
+    //! \brief Returns whether selected settings bases agree on this row's effective value.
+    bool hasConsistentEffectiveDouble() const;
+
+    //! \brief Returns a warning message when this row violates a dynamic dependency.
+    QString dynamicDependencyWarning() const;
 
     //! \brief Number of units of precision for child derived types with units
     //! Currently, all the same

--- a/include/widgets/settings/setting_row_base.h
+++ b/include/widgets/settings/setting_row_base.h
@@ -85,6 +85,9 @@ class SettingRowBase {
     //! \brief Check dependencies and enable/disable as appropriate
     void checkDependencies();
 
+    //! \brief Check dependencies enforced through dynamic feedback.
+    virtual void checkDynamicDependencies();
+
     //! \brief Hide this row.
     virtual void hide();
 
@@ -131,9 +134,6 @@ class SettingRowBase {
   protected:
     //! \brief Function to handle value changes for each widget type
     virtual void valueChanged(QVariant val) = 0;
-
-    //! \brief Check dependencies enforced through dynamic feedback
-    void checkDynamicDependencies();
 
     //! \brief Notify before a setting key is written by this row.
     void notifyValueAboutToChange(const QString& key);

--- a/src/widgets/settings/double_spin_subtypes/setting_distance_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_distance_spin_box.cpp
@@ -75,6 +75,6 @@ void SettingDistanceSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    emit warnParent(warningCountDelta(!consistent, m_warn));
+    checkDynamicDependencies();
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_speed_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_speed_spin_box.cpp
@@ -4,6 +4,7 @@
 #include <qhashfunctions.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
+#include <qstring.h>
 #include <qtmetamacros.h>
 #include <qvariant.h>
 
@@ -16,6 +17,39 @@
 #include "widgets/settings/setting_row_base.h"
 
 namespace ORNL {
+namespace {
+bool isActiveSpeedLimit(Velocity speed) { return speed > 0; }
+
+QString masterString(const fifojson& json, const std::string& key) {
+    return QString::fromStdString(json.at(key).get<std::string>());
+}
+
+bool isXYSpeedLimitKey(const QString& key) {
+    return key == PRS::MachineSpeed::kMinXYSpeed || key == PRS::MachineSpeed::kMaxXYSpeed;
+}
+
+bool isPrinterXYMotionSpeed(const QString& key, const fifojson& json) {
+    if (isXYSpeedLimitKey(key))
+        return false;
+
+    const QString major = masterString(json, Constants::Settings::Master::kMajor);
+    const QString minor = masterString(json, Constants::Settings::Master::kMinor);
+
+    if (major == Constants::Settings::SettingTab::kPrinter)
+        return false;
+
+    if (major == Constants::Settings::SettingTab::kMaterial &&
+        (minor == "Extruder" || minor == "Purge" || minor == "Retraction"))
+        return false;
+
+    return true;
+}
+
+QString formatVelocity(Velocity speed) {
+    const Velocity unit = PreferencesManager::getInstance()->getVelocityUnit();
+    return QString::number(speed.to(unit), 'g', 6) + " " + PreferencesManager::getInstance()->getVelocityUnitText();
+}
+} // namespace
 
 SettingSpeedSpinBox::SettingSpeedSpinBox(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                          fifojson json, QGridLayout* layout, int index)
@@ -66,6 +100,99 @@ void SettingSpeedSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    emit warnParent(warningCountDelta(!consistent, m_warn));
+    checkDynamicDependencies();
+}
+
+void SettingSpeedSpinBox::checkDynamicDependencies() {
+    if (!m_dependency_enabled) {
+        clearNotification();
+        styleLabel(true);
+        emit warnParent(warningCountDelta(false, m_warn));
+        return;
+    }
+
+    if (!hasConsistentEffectiveSpeed()) {
+        setNotification("Multiple Values");
+        styleLabel(false);
+        emit warnParent(warningCountDelta(true, m_warn));
+        return;
+    }
+
+    const QString warning = speedLimitWarning();
+    const bool warning_active = !warning.isEmpty();
+    if (warning_active) {
+        setNotification(warning);
+        styleLabel(false);
+        m_key_label->setToolTip("<html><body><p><b>" + warning + "</b></p><p>" +
+                                QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) +
+                                "</p></body></html>");
+    }
+    else {
+        clearNotification();
+        styleLabel(true);
+    }
+
+    emit warnParent(warningCountDelta(warning_active, m_warn));
+}
+
+Velocity SettingSpeedSpinBox::effectiveSpeed() const {
+    const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
+    const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
+
+    if (!m_settings_bases.isEmpty())
+        return Velocity(effectiveValueHelper<double>(m_key, 0, global_value));
+
+    return Velocity(global_value);
+}
+
+bool SettingSpeedSpinBox::hasConsistentEffectiveSpeed() const {
+    if (m_settings_bases.size() <= 1)
+        return true;
+
+    const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
+    const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
+    const double first_value = effectiveValueHelper<double>(m_key, 0, global_value);
+
+    for (int index = 1, end = m_settings_bases.size(); index < end; ++index) {
+        if (effectiveValueHelper<double>(m_key, index, global_value) != first_value)
+            return false;
+    }
+
+    return true;
+}
+
+QString SettingSpeedSpinBox::speedLimitWarning() const {
+    if (m_sb.isNull())
+        return QString();
+
+    const Velocity min_xy_speed(effectiveDouble(PRS::MachineSpeed::kMinXYSpeed));
+    const Velocity max_xy_speed(effectiveDouble(PRS::MachineSpeed::kMaxXYSpeed));
+    const bool has_min = isActiveSpeedLimit(min_xy_speed);
+    const bool has_max = isActiveSpeedLimit(max_xy_speed);
+    const bool invalid_range = has_min && has_max && min_xy_speed > max_xy_speed;
+
+    if (isXYSpeedLimitKey(m_key)) {
+        if (invalid_range)
+            return QString("Minimum XY Speed (") + formatVelocity(min_xy_speed) +
+                   ") is greater than Maximum XY Speed (" + formatVelocity(max_xy_speed) + ").";
+
+        return QString();
+    }
+
+    if (!isPrinterXYMotionSpeed(m_key, m_json) || invalid_range)
+        return QString();
+
+    const Velocity current_speed = effectiveSpeed();
+    const QString display = masterString(m_json, Constants::Settings::Master::kDisplay);
+
+    if (has_min && current_speed < min_xy_speed)
+        return display + " (" + formatVelocity(current_speed) + ") is below Minimum XY Speed (" +
+               formatVelocity(min_xy_speed) + ").";
+
+    if (has_max && current_speed > max_xy_speed)
+        return display + " (" + formatVelocity(current_speed) + ") exceeds Maximum XY Speed (" +
+               formatVelocity(max_xy_speed) + ").";
+
+    return QString();
 }
 } // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_speed_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_speed_spin_box.cpp
@@ -112,7 +112,7 @@ void SettingSpeedSpinBox::checkDynamicDependencies() {
     }
 
     if (!hasConsistentEffectiveSpeed()) {
-        setNotification("Multiple Values");
+        applyNotification("Multiple Values", false);
         styleLabel(false);
         emit warnParent(warningCountDelta(true, m_warn));
         return;
@@ -121,7 +121,7 @@ void SettingSpeedSpinBox::checkDynamicDependencies() {
     const QString warning = speedLimitWarning();
     const bool warning_active = !warning.isEmpty();
     if (warning_active) {
-        setNotification(warning);
+        applyNotification(warning, false);
         styleLabel(false);
         m_key_label->setToolTip("<html><body><p><b>" + warning + "</b></p><p>" +
                                 QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) +
@@ -135,12 +135,14 @@ void SettingSpeedSpinBox::checkDynamicDependencies() {
     emit warnParent(warningCountDelta(warning_active, m_warn));
 }
 
-Velocity SettingSpeedSpinBox::effectiveSpeed() const {
+Velocity SettingSpeedSpinBox::effectiveSpeed() const { return effectiveSpeed(0); }
+
+Velocity SettingSpeedSpinBox::effectiveSpeed(int settings_base_index) const {
     const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
     const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
 
     if (!m_settings_bases.isEmpty())
-        return Velocity(effectiveValueHelper<double>(m_key, 0, global_value));
+        return Velocity(effectiveValueHelper<double>(m_key, settings_base_index, global_value));
 
     return Velocity(global_value);
 }
@@ -162,11 +164,21 @@ bool SettingSpeedSpinBox::hasConsistentEffectiveSpeed() const {
 }
 
 QString SettingSpeedSpinBox::speedLimitWarning() const {
+    for (int index = 0, end = effectiveSettingsBaseCount(); index < end; ++index) {
+        const QString warning = speedLimitWarning(index);
+        if (!warning.isEmpty())
+            return warning;
+    }
+
+    return QString();
+}
+
+QString SettingSpeedSpinBox::speedLimitWarning(int settings_base_index) const {
     if (m_sb.isNull())
         return QString();
 
-    const Velocity min_xy_speed(effectiveDouble(PRS::MachineSpeed::kMinXYSpeed));
-    const Velocity max_xy_speed(effectiveDouble(PRS::MachineSpeed::kMaxXYSpeed));
+    const Velocity min_xy_speed(effectiveDouble(PRS::MachineSpeed::kMinXYSpeed, settings_base_index));
+    const Velocity max_xy_speed(effectiveDouble(PRS::MachineSpeed::kMaxXYSpeed, settings_base_index));
     const bool has_min = isActiveSpeedLimit(min_xy_speed);
     const bool has_max = isActiveSpeedLimit(max_xy_speed);
     const bool invalid_range = has_min && has_max && min_xy_speed > max_xy_speed;
@@ -182,7 +194,7 @@ QString SettingSpeedSpinBox::speedLimitWarning() const {
     if (!isPrinterXYMotionSpeed(m_key, m_json) || invalid_range)
         return QString();
 
-    const Velocity current_speed = effectiveSpeed();
+    const Velocity current_speed = effectiveSpeed(settings_base_index);
     const QString display = masterString(m_json, Constants::Settings::Master::kDisplay);
 
     if (has_min && current_speed < min_xy_speed)

--- a/src/widgets/settings/double_spin_subtypes/setting_time_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_time_spin_box.cpp
@@ -68,6 +68,6 @@ void SettingTimeSpinBox::reloadValue() {
     this->blockSignals(false);
     emit modified(m_key);
 
-    emit warnParent(warningCountDelta(!consistent, m_warn));
+    checkDynamicDependencies();
 }
 } // namespace ORNL

--- a/src/widgets/settings/setting_bar.cpp
+++ b/src/widgets/settings/setting_bar.cpp
@@ -36,6 +36,20 @@ constexpr int kMaxVisibleSettingBaseItems = 16;
 constexpr int kSettingBaseItemHeightFallback = 22;
 
 bool supportsCylindricalSlicing(GcodeSyntax syntax) { return syntax == GcodeSyntax::kArcSpecialties; }
+
+class DynamicDependencyRefreshBlocker {
+  public:
+    explicit DynamicDependencyRefreshBlocker(bool& suppressed)
+        : m_suppressed(suppressed), m_previous_suppressed(suppressed) {
+        m_suppressed = true;
+    }
+
+    ~DynamicDependencyRefreshBlocker() { m_suppressed = m_previous_suppressed; }
+
+  private:
+    bool& m_suppressed;
+    bool m_previous_suppressed;
+};
 } // namespace
 
 SettingBar::SettingBar(QHash<QString, QString> selectedSettingBases)
@@ -62,8 +76,6 @@ SettingPane* SettingBar::getPane(QString major) {
     paneMapping[m_tab_widget->count()] = major;
     m_tab_widget->addTab(m_panes[major], major);
 
-    connect(PreferencesManager::getInstance().get(), &PreferencesManager::anyUnitChanged, m_panes[major],
-            &SettingPane::reload);
     connect(m_panes[major], &SettingPane::settingAboutToChange, this, &SettingBar::forwardSettingAboutToChange);
     connect(m_panes[major], &SettingPane::settingModified, this, &SettingBar::forwardModifiedSetting);
     connect(m_panes[major], &SettingPane::forwardHideTab, this, &SettingBar::forwardHideTab);
@@ -164,45 +176,49 @@ void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<Setti
         m_current_editing->setText("Currently editing <font color=\"" % accentColor % "\">" % name_and_bases.first %
                                    "</font> settings");
 
-    // If vector is empty, ensure all tabs that aren't user hidden can be seen.
-    if (settings_bases.size() == 0) {
-        m_range_selected = false;
-        for (QString key : m_panes.keys()) {
-            QList<QString> hiddenSettings = PreferencesManager::getInstance()->getHiddenSettings(key);
-            SettingPane* cur_pane = m_panes.value(key);
+    {
+        DynamicDependencyRefreshBlocker blocker(m_suppress_dynamic_dependency_refresh);
 
-            for (SettingTab* cur_tab : cur_pane->getTabs()) {
-                cur_tab->settingsBasesSelected(settings_bases, inherited_bases);
-                if (!hiddenSettings.contains(cur_tab->getName())) {
-                    cur_tab->show();
-                    for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows()) {
-                        cur_row->show();
+        // If vector is empty, ensure all tabs that aren't user hidden can be seen.
+        if (settings_bases.size() == 0) {
+            m_range_selected = false;
+            for (QString key : m_panes.keys()) {
+                QList<QString> hiddenSettings = PreferencesManager::getInstance()->getHiddenSettings(key);
+                SettingPane* cur_pane = m_panes.value(key);
+
+                for (SettingTab* cur_tab : cur_pane->getTabs()) {
+                    cur_tab->settingsBasesSelected(settings_bases, inherited_bases);
+                    if (!hiddenSettings.contains(cur_tab->getName())) {
+                        cur_tab->show();
+                        for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows()) {
+                            cur_row->show();
+                        }
                     }
                 }
             }
         }
-    }
-    else {
-        m_range_selected = true;
-        for (QString key : m_panes.keys()) {
-            QList<QString> hiddenSettings = PreferencesManager::getInstance()->getHiddenSettings(key);
-            SettingPane* cur_pane = m_panes.value(key);
+        else {
+            m_range_selected = true;
+            for (QString key : m_panes.keys()) {
+                QList<QString> hiddenSettings = PreferencesManager::getInstance()->getHiddenSettings(key);
+                SettingPane* cur_pane = m_panes.value(key);
 
-            for (SettingTab* cur_tab : cur_pane->getTabs()) {
-                if (!hiddenSettings.contains(cur_tab->getName())) {
-                    int settingsHidden = 0;
-                    QList<QSharedPointer<SettingRowBase>> rows = cur_tab->getRows();
-                    for (QSharedPointer<SettingRowBase> cur_row : rows) {
-                        if (!cur_row->isLocal()) {
-                            cur_row->hide();
-                            ++settingsHidden;
+                for (SettingTab* cur_tab : cur_pane->getTabs()) {
+                    if (!hiddenSettings.contains(cur_tab->getName())) {
+                        int settingsHidden = 0;
+                        QList<QSharedPointer<SettingRowBase>> rows = cur_tab->getRows();
+                        for (QSharedPointer<SettingRowBase> cur_row : rows) {
+                            if (!cur_row->isLocal()) {
+                                cur_row->hide();
+                                ++settingsHidden;
+                            }
                         }
+
+                        if (settingsHidden == rows.size())
+                            cur_tab->hide();
+
+                        cur_tab->settingsBasesSelected(settings_bases, inherited_bases);
                     }
-
-                    if (settingsHidden == rows.size())
-                        cur_tab->hide();
-
-                    cur_tab->settingsBasesSelected(settings_bases, inherited_bases);
                 }
             }
         }
@@ -284,14 +300,16 @@ void SettingBar::updateSettings(QString text) {
         GSM->removeCurrentSettings(paneMapping[m_tab_widget->currentIndex()],
                                    mostRecentSetting[paneMapping[m_tab_widget->currentIndex()]]);
         GSM->constructActiveGlobal(paneMapping[m_tab_widget->currentIndex()], text);
-        for (SettingTab* tab : m_panes[paneMapping[m_tab_widget->currentIndex()]]->getTabs()) {
-            tab->setSettingBase(GSM->getGlobal());
-            tab->reload();
+        {
+            DynamicDependencyRefreshBlocker blocker(m_suppress_dynamic_dependency_refresh);
+            for (SettingTab* tab : m_panes[paneMapping[m_tab_widget->currentIndex()]]->getTabs()) {
+                tab->setSettingBase(GSM->getGlobal());
+                tab->reload();
+            }
         }
         mostRecentSetting[paneMapping[m_tab_widget->currentIndex()]] = text;
         CSM->setMostRecentSettingHistory(paneMapping[m_tab_widget->currentIndex()], text);
         enableDependRows();
-        refreshDynamicDependencies();
         emit settingsBaseChanged(text);
     }
 }
@@ -316,14 +334,16 @@ void SettingBar::displayNewSetting(QStringList settingCategories, QString settin
 
     reloadDisplayedList();
 
-    for (SettingPane* cur_pane : m_panes) {
-        for (SettingTab* cur_tab : cur_pane->getTabs()) {
-            cur_tab->setSettingBase(GSM->getGlobal());
-            cur_tab->reload();
+    {
+        DynamicDependencyRefreshBlocker blocker(m_suppress_dynamic_dependency_refresh);
+        for (SettingPane* cur_pane : m_panes) {
+            for (SettingTab* cur_tab : cur_pane->getTabs()) {
+                cur_tab->setSettingBase(GSM->getGlobal());
+                cur_tab->reload();
+            }
         }
     }
     enableDependRows();
-    refreshDynamicDependencies();
 }
 
 void SettingBar::forwardSettingAboutToChange(QString setting_key, QList<QSharedPointer<SettingsBase>> settings_bases) {
@@ -341,14 +361,16 @@ void SettingBar::forwardModifiedSetting(QString setting_key) {
     modified_keys.append(syncCylindricalSlicingSettings(setting_key));
     m_syncing_radial_settings = false;
 
-    if (modified_keys.size() > 1) {
+    const bool dependencies_refreshed = modified_keys.size() > 1;
+    if (dependencies_refreshed) {
         enableDependRows();
     }
     else {
         refreshDependencyVisibility();
     }
 
-    refreshDynamicDependencies();
+    if (!m_suppress_dynamic_dependency_refresh && !dependencies_refreshed)
+        refreshDynamicDependencies();
 
     for (const QString& modified_key : modified_keys) {
         emit settingModified(modified_key);
@@ -401,13 +423,22 @@ void SettingBar::refreshDynamicDependencies() {
     }
 }
 
+void SettingBar::reloadRowsForUnitChange() {
+    {
+        DynamicDependencyRefreshBlocker blocker(m_suppress_dynamic_dependency_refresh);
+        for (SettingPane* cur_pane : m_panes)
+            cur_pane->reload();
+    }
+
+    refreshDynamicDependencies();
+}
+
 void SettingBar::restoreSettingValue(QString setting_key) {
     m_restoring_settings = true;
     reloadSettingRow(setting_key);
     m_restoring_settings = false;
 
     enableDependRows();
-    refreshDynamicDependencies();
     emit settingModified(setting_key);
 }
 
@@ -432,7 +463,6 @@ void SettingBar::finishPairedGlobalSettingChange(QString first_key, double first
                                                  double second_value) {
     updatePairedGlobalSetting(first_key, first_value, second_key, second_value);
     enableDependRows();
-    refreshDynamicDependencies();
 
     emit settingModified(first_key);
     emit settingModified(second_key);
@@ -555,6 +585,8 @@ void SettingBar::setupEvents() {
     connect(m_tab_widget, &QTabWidget::currentChanged, this, &SettingBar::updateDisplayedLists);
     connect(m_combo_box, QOverload<const QString&>::of(&QComboBox::currentTextChanged), this,
             &SettingBar::updateSettings);
+    connect(PreferencesManager::getInstance().get(), &PreferencesManager::anyUnitChanged, this,
+            &SettingBar::reloadRowsForUnitChange);
     connect(PreferencesManager::getInstance().get(), &PreferencesManager::disabledSettingVisibilityChanged, this,
             &SettingBar::enableDependRows);
 }

--- a/src/widgets/settings/setting_bar.cpp
+++ b/src/widgets/settings/setting_bar.cpp
@@ -291,6 +291,7 @@ void SettingBar::updateSettings(QString text) {
         mostRecentSetting[paneMapping[m_tab_widget->currentIndex()]] = text;
         CSM->setMostRecentSettingHistory(paneMapping[m_tab_widget->currentIndex()], text);
         enableDependRows();
+        refreshDynamicDependencies();
         emit settingsBaseChanged(text);
     }
 }
@@ -322,6 +323,7 @@ void SettingBar::displayNewSetting(QStringList settingCategories, QString settin
         }
     }
     enableDependRows();
+    refreshDynamicDependencies();
 }
 
 void SettingBar::forwardSettingAboutToChange(QString setting_key, QList<QSharedPointer<SettingsBase>> settings_bases) {
@@ -345,6 +347,8 @@ void SettingBar::forwardModifiedSetting(QString setting_key) {
     else {
         refreshDependencyVisibility();
     }
+
+    refreshDynamicDependencies();
 
     for (const QString& modified_key : modified_keys) {
         emit settingModified(modified_key);
@@ -388,12 +392,22 @@ void SettingBar::reloadSettingRow(const QString& setting_key) {
     }
 }
 
+void SettingBar::refreshDynamicDependencies() {
+    for (SettingPane* cur_pane : m_panes) {
+        for (SettingTab* cur_tab : cur_pane->getTabs()) {
+            for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows())
+                cur_row->checkDynamicDependencies();
+        }
+    }
+}
+
 void SettingBar::restoreSettingValue(QString setting_key) {
     m_restoring_settings = true;
     reloadSettingRow(setting_key);
     m_restoring_settings = false;
 
     enableDependRows();
+    refreshDynamicDependencies();
     emit settingModified(setting_key);
 }
 
@@ -418,6 +432,7 @@ void SettingBar::finishPairedGlobalSettingChange(QString first_key, double first
                                                  double second_value) {
     updatePairedGlobalSetting(first_key, first_value, second_key, second_value);
     enableDependRows();
+    refreshDynamicDependencies();
 
     emit settingModified(first_key);
     emit settingModified(second_key);
@@ -558,6 +573,9 @@ void SettingBar::enableDependRows() {
                     DependencyNode root = createNodes(master_json, row, depends);
                     row->setDependencyLogic(root);
                     row->checkDependencies();
+                }
+                else {
+                    row->checkDynamicDependencies();
                 }
             }
         }

--- a/src/widgets/settings/setting_double_spin_box.cpp
+++ b/src/widgets/settings/setting_double_spin_box.cpp
@@ -157,11 +157,16 @@ void SettingDoubleSpinBox::setEnabled(bool enabled) {
 }
 
 void SettingDoubleSpinBox::setNotification(QString msg) {
+    applyNotification(msg, true);
+}
+
+void SettingDoubleSpinBox::applyNotification(QString msg, bool show_tooltip) {
     // apply checkbox stylesheet
     // set pop-up/tooltip
     this->setStyleFromFile(this, m_theme_path + "setting_rows_warning.qss");
     this->setToolTip(msg);
-    QToolTip::showText(this->mapToGlobal(QPoint(0, 0)), msg, nullptr, QRect(), 30000);
+    if (show_tooltip)
+        QToolTip::showText(this->mapToGlobal(QPoint(0, 0)), msg, nullptr, QRect(), 30000);
 }
 
 void SettingDoubleSpinBox::clearNotification() {
@@ -217,7 +222,7 @@ void SettingDoubleSpinBox::checkDynamicDependencies() {
     }
 
     if (!hasConsistentEffectiveDouble()) {
-        setNotification("Multiple Values");
+        applyNotification("Multiple Values", false);
         styleLabel(false);
         emit warnParent(warningCountDelta(true, m_warn));
         return;
@@ -226,7 +231,7 @@ void SettingDoubleSpinBox::checkDynamicDependencies() {
     const QString warning = dynamicDependencyWarning();
     const bool warning_active = !warning.isEmpty();
     if (warning_active) {
-        setNotification(warning);
+        applyNotification(warning, false);
         styleLabel(false);
         m_key_label->setToolTip("<html><body><p><b>" + warning + "</b></p><p>" +
                                 QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) +
@@ -240,39 +245,51 @@ void SettingDoubleSpinBox::checkDynamicDependencies() {
     emit warnParent(warningCountDelta(warning_active, m_warn));
 }
 
-double SettingDoubleSpinBox::effectiveDouble() const {
+int SettingDoubleSpinBox::effectiveSettingsBaseCount() const {
+    return m_settings_bases.isEmpty() ? 1 : m_settings_bases.size();
+}
+
+double SettingDoubleSpinBox::effectiveDouble() const { return effectiveDouble(0); }
+
+double SettingDoubleSpinBox::effectiveDouble(int settings_base_index) const {
     const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
     const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
 
     if (!m_settings_bases.isEmpty())
-        return effectiveValueHelper<double>(m_key, 0, global_value);
+        return effectiveValueHelper<double>(m_key, settings_base_index, global_value);
 
     return global_value;
 }
 
-double SettingDoubleSpinBox::effectiveDouble(const QString& key) const {
+double SettingDoubleSpinBox::effectiveDouble(const QString& key) const { return effectiveDouble(key, 0); }
+
+double SettingDoubleSpinBox::effectiveDouble(const QString& key, int settings_base_index) const {
     const double global_value = m_sb->contains(key) ? m_sb->setting<double>(key) : 0.0;
 
     if (!m_settings_bases.isEmpty())
-        return effectiveValueHelper<double>(key, 0, global_value);
+        return effectiveValueHelper<double>(key, settings_base_index, global_value);
 
     return global_value;
 }
 
-bool SettingDoubleSpinBox::effectiveBool(const QString& key) const {
+bool SettingDoubleSpinBox::effectiveBool(const QString& key) const { return effectiveBool(key, 0); }
+
+bool SettingDoubleSpinBox::effectiveBool(const QString& key, int settings_base_index) const {
     const bool global_value = m_sb->contains(key) ? m_sb->setting<bool>(key) : false;
 
     if (!m_settings_bases.isEmpty())
-        return effectiveValueHelper<bool>(key, 0, global_value);
+        return effectiveValueHelper<bool>(key, settings_base_index, global_value);
 
     return global_value;
 }
 
-int SettingDoubleSpinBox::effectiveInt(const QString& key) const {
+int SettingDoubleSpinBox::effectiveInt(const QString& key) const { return effectiveInt(key, 0); }
+
+int SettingDoubleSpinBox::effectiveInt(const QString& key, int settings_base_index) const {
     const int global_value = m_sb->contains(key) ? m_sb->setting<int>(key) : 0;
 
     if (!m_settings_bases.isEmpty())
-        return effectiveValueHelper<int>(key, 0, global_value);
+        return effectiveValueHelper<int>(key, settings_base_index, global_value);
 
     return global_value;
 }
@@ -294,15 +311,25 @@ bool SettingDoubleSpinBox::hasConsistentEffectiveDouble() const {
 }
 
 QString SettingDoubleSpinBox::dynamicDependencyWarning() const {
+    for (int index = 0, end = effectiveSettingsBaseCount(); index < end; ++index) {
+        const QString warning = dynamicDependencyWarning(index);
+        if (!warning.isEmpty())
+            return warning;
+    }
+
+    return QString();
+}
+
+QString SettingDoubleSpinBox::dynamicDependencyWarning(int settings_base_index) const {
     if (m_sb.isNull())
         return QString();
 
     const QString display = masterString(m_json, Constants::Settings::Master::kDisplay);
     const QString type = masterString(m_json, Constants::Settings::Master::kType);
-    const double value = effectiveDouble();
+    const double value = effectiveDouble(settings_base_index);
 
-    const double min_extruder_speed = effectiveDouble(PRS::MachineSpeed::kMinExtruderSpeed);
-    const double max_extruder_speed = effectiveDouble(PRS::MachineSpeed::kMaxExtruderSpeed);
+    const double min_extruder_speed = effectiveDouble(PRS::MachineSpeed::kMinExtruderSpeed, settings_base_index);
+    const double max_extruder_speed = effectiveDouble(PRS::MachineSpeed::kMaxExtruderSpeed, settings_base_index);
     const bool has_min_extruder_speed = min_extruder_speed > 0;
     const bool has_max_extruder_speed = max_extruder_speed > 0;
     const bool invalid_extruder_range =
@@ -323,14 +350,14 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning() const {
                    formatRpm(max_extruder_speed) + ").";
     }
 
-    const double x_min = effectiveDouble(PRS::Dimensions::kXMin);
-    const double x_max = effectiveDouble(PRS::Dimensions::kXMax);
-    const double y_min = effectiveDouble(PRS::Dimensions::kYMin);
-    const double y_max = effectiveDouble(PRS::Dimensions::kYMax);
-    const double z_min = effectiveDouble(PRS::Dimensions::kZMin);
-    const double z_max = effectiveDouble(PRS::Dimensions::kZMax);
-    const double w_min = effectiveDouble(PRS::Dimensions::kWMin);
-    const double w_max = effectiveDouble(PRS::Dimensions::kWMax);
+    const double x_min = effectiveDouble(PRS::Dimensions::kXMin, settings_base_index);
+    const double x_max = effectiveDouble(PRS::Dimensions::kXMax, settings_base_index);
+    const double y_min = effectiveDouble(PRS::Dimensions::kYMin, settings_base_index);
+    const double y_max = effectiveDouble(PRS::Dimensions::kYMax, settings_base_index);
+    const double z_min = effectiveDouble(PRS::Dimensions::kZMin, settings_base_index);
+    const double z_max = effectiveDouble(PRS::Dimensions::kZMax, settings_base_index);
+    const double w_min = effectiveDouble(PRS::Dimensions::kWMin, settings_base_index);
+    const double w_max = effectiveDouble(PRS::Dimensions::kWMax, settings_base_index);
 
     QString warning = dimensionRangeWarning(m_key, PRS::Dimensions::kXMin, PRS::Dimensions::kXMax, x_min, x_max,
                                             "Minimum X", "Maximum X");
@@ -380,7 +407,7 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning() const {
     };
 
     if (isOneOf(m_key, bead_width_keys)) {
-        const double layer_height = effectiveDouble(PS::Layer::kLayerHeight);
+        const double layer_height = effectiveDouble(PS::Layer::kLayerHeight, settings_base_index);
         if (value <= 0)
             return display + " must be greater than zero (currently " + formatDistance(value) + ").";
 
@@ -390,8 +417,8 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning() const {
     }
 
     if (m_key == PS::Infill::kMinPathLength || m_key == kInfillMaximumPathLength) {
-        const double min_path_length = effectiveDouble(PS::Infill::kMinPathLength);
-        const double max_path_length = effectiveDouble(kInfillMaximumPathLength);
+        const double min_path_length = effectiveDouble(PS::Infill::kMinPathLength, settings_base_index);
+        const double max_path_length = effectiveDouble(kInfillMaximumPathLength, settings_base_index);
         if (min_path_length > 0 && max_path_length > 0 && min_path_length > max_path_length)
             return "Minimum Infill Path Length (" + formatDistance(min_path_length) +
                    ") is greater than Maximum Infill Path Length (" + formatDistance(max_path_length) + ").";
@@ -408,7 +435,7 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning() const {
     };
 
     if (isOneOf(m_key, lift_distance_keys) && value > 0) {
-        const double z_speed = effectiveDouble(PRS::MachineSpeed::kZSpeed);
+        const double z_speed = effectiveDouble(PRS::MachineSpeed::kZSpeed, settings_base_index);
         if (z_speed <= 0)
             return display + " requires Z Speed to be greater than zero.";
 
@@ -417,20 +444,21 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning() const {
                    formatDistance(z_max - z_min) + ").";
     }
 
-    if (m_key == PS::Travel::kMinTravelForLift && value > 0 && effectiveDouble(PS::Travel::kLiftHeight) <= 0)
+    if (m_key == PS::Travel::kMinTravelForLift && value > 0 &&
+        effectiveDouble(PS::Travel::kLiftHeight, settings_base_index) <= 0)
         return display + " is set, but Travel Lift Height is zero.";
 
-    const double fan_min_speed = effectiveDouble(MS::Cooling::kMinSpeed);
-    const double fan_max_speed = effectiveDouble(MS::Cooling::kMaxSpeed);
+    const double fan_min_speed = effectiveDouble(MS::Cooling::kMinSpeed, settings_base_index);
+    const double fan_max_speed = effectiveDouble(MS::Cooling::kMaxSpeed, settings_base_index);
     if ((m_key == MS::Cooling::kMinSpeed || m_key == MS::Cooling::kMaxSpeed) && fan_min_speed > fan_max_speed)
         return "Min Fan Speed (" + formatTypedValue(fan_min_speed, type) + ") is greater than Max Fan Speed (" +
                formatTypedValue(fan_max_speed, type) + ").";
 
-    const bool force_layer_time = effectiveBool(MS::Cooling::kForceMinLayerTime);
+    const bool force_layer_time = effectiveBool(MS::Cooling::kForceMinLayerTime, settings_base_index);
     const bool use_feedrate_layer_time =
-        effectiveInt(MS::Cooling::kForceMinLayerTimeMethod) == kModifyFeedrateLayerTimeMethod;
-    const double min_layer_time = effectiveDouble(MS::Cooling::kMinLayerTime);
-    const double max_layer_time = effectiveDouble(MS::Cooling::kMaxLayerTime);
+        effectiveInt(MS::Cooling::kForceMinLayerTimeMethod, settings_base_index) == kModifyFeedrateLayerTimeMethod;
+    const double min_layer_time = effectiveDouble(MS::Cooling::kMinLayerTime, settings_base_index);
+    const double max_layer_time = effectiveDouble(MS::Cooling::kMaxLayerTime, settings_base_index);
 
     if (force_layer_time && m_key == MS::Cooling::kMinLayerTime) {
         if (value <= 0)

--- a/src/widgets/settings/setting_double_spin_box.cpp
+++ b/src/widgets/settings/setting_double_spin_box.cpp
@@ -9,15 +9,91 @@
 #include <qoverload.h>
 #include <qsharedpointer.h>
 #include <qspinbox.h>
+#include <qstringlist.h>
 #include <qtmetamacros.h>
 #include <qvariant.h>
 
 #include "configs/settings_base.h"
+#include "managers/preferences_manager.h"
 #include "utilities/constants.h"
 #include "utilities/qt_json_conversion.h"
 #include "widgets/settings/setting_row_base.h"
 
 namespace ORNL {
+namespace {
+constexpr int kModifyFeedrateLayerTimeMethod = 1;
+
+const QString kInfillMaximumPathLength = "infill_maximum_path_length";
+
+QString masterString(const fifojson& json, const std::string& key) {
+    return QString::fromStdString(json.at(key).get<std::string>());
+}
+
+bool isOneOf(const QString& key, const QStringList& keys) { return keys.contains(key); }
+
+bool isConfiguredRange(double min_value, double max_value) { return min_value != 0 || max_value != 0; }
+
+bool isValidRange(double min_value, double max_value) {
+    return isConfiguredRange(min_value, max_value) && min_value < max_value;
+}
+
+QString formatRpm(double value) { return QString::number(value, 'g', 6) + " rpm"; }
+
+QString formatDistance(double value) {
+    const Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
+    return QString::number(Distance(value).to(unit), 'g', 6) + " " +
+           PreferencesManager::getInstance()->getDistanceUnitText();
+}
+
+QString formatTime(double value) {
+    const Time unit = PreferencesManager::getInstance()->getTimeUnit();
+    return QString::number(Time(value).to(unit), 'g', 6) + " " + PreferencesManager::getInstance()->getTimeUnitText();
+}
+
+QString formatTypedValue(double value, const QString& type) {
+    if (type == "distance" || type == "location")
+        return formatDistance(value);
+    if (type == "time")
+        return formatTime(value);
+    if (type == "rpm")
+        return formatRpm(value);
+    if (type == "percentage" || type == "percentage100")
+        return QString::number(value, 'g', 6) + "%";
+
+    return QString::number(value, 'g', 6);
+}
+
+QString dimensionRangeWarning(const QString& key, const QString& min_key, const QString& max_key, double min_value,
+                              double max_value, const QString& min_label, const QString& max_label) {
+    if (!isConfiguredRange(min_value, max_value) || min_value < max_value)
+        return QString();
+
+    if (key == min_key || key == max_key) {
+        return min_label + " (" + formatDistance(min_value) + ") must be less than " + max_label + " (" +
+               formatDistance(max_value) + ").";
+    }
+
+    return QString();
+}
+
+QString boundsWarning(const QString& display, double value, double min_value, double max_value, const QString& axis) {
+    if (!isValidRange(min_value, max_value) || (value >= min_value && value <= max_value))
+        return QString();
+
+    return display + " (" + formatDistance(value) + ") is outside the " + axis + " build volume range (" +
+           formatDistance(min_value) + " to " + formatDistance(max_value) + ").";
+}
+
+QString enabledSettingWarning(const QString& display, double value, const QString& required_description,
+                              const QString& type) {
+    if (value > 0)
+        return QString();
+
+    return display + " must be greater than zero " + required_description + " (currently " +
+           formatTypedValue(value, type) + ").";
+}
+} // namespace
+
 SettingDoubleSpinBox::SettingDoubleSpinBox(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                            fifojson json, QGridLayout* layout, int index)
     : SettingRowBase(parent, sb, key, json, layout, index), QDoubleSpinBox() {
@@ -84,6 +160,7 @@ void SettingDoubleSpinBox::setNotification(QString msg) {
     // apply checkbox stylesheet
     // set pop-up/tooltip
     this->setStyleFromFile(this, m_theme_path + "setting_rows_warning.qss");
+    this->setToolTip(msg);
     QToolTip::showText(this->mapToGlobal(QPoint(0, 0)), msg, nullptr, QRect(), 30000);
 }
 
@@ -120,7 +197,8 @@ void SettingDoubleSpinBox::reloadValue() {
 
     this->blockSignals(false);
     emit modified(m_key);
-    emit warnParent(warningCountDelta(!consistent, m_warn));
+
+    checkDynamicDependencies();
 }
 
 void SettingDoubleSpinBox::wheelEvent(QWheelEvent* event) {
@@ -128,5 +206,253 @@ void SettingDoubleSpinBox::wheelEvent(QWheelEvent* event) {
         event->ignore();
     else
         QDoubleSpinBox::wheelEvent(event);
+}
+
+void SettingDoubleSpinBox::checkDynamicDependencies() {
+    if (!m_dependency_enabled) {
+        clearNotification();
+        styleLabel(true);
+        emit warnParent(warningCountDelta(false, m_warn));
+        return;
+    }
+
+    if (!hasConsistentEffectiveDouble()) {
+        setNotification("Multiple Values");
+        styleLabel(false);
+        emit warnParent(warningCountDelta(true, m_warn));
+        return;
+    }
+
+    const QString warning = dynamicDependencyWarning();
+    const bool warning_active = !warning.isEmpty();
+    if (warning_active) {
+        setNotification(warning);
+        styleLabel(false);
+        m_key_label->setToolTip("<html><body><p><b>" + warning + "</b></p><p>" +
+                                QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) +
+                                "</p></body></html>");
+    }
+    else {
+        clearNotification();
+        styleLabel(true);
+    }
+
+    emit warnParent(warningCountDelta(warning_active, m_warn));
+}
+
+double SettingDoubleSpinBox::effectiveDouble() const {
+    const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
+    const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
+
+    if (!m_settings_bases.isEmpty())
+        return effectiveValueHelper<double>(m_key, 0, global_value);
+
+    return global_value;
+}
+
+double SettingDoubleSpinBox::effectiveDouble(const QString& key) const {
+    const double global_value = m_sb->contains(key) ? m_sb->setting<double>(key) : 0.0;
+
+    if (!m_settings_bases.isEmpty())
+        return effectiveValueHelper<double>(key, 0, global_value);
+
+    return global_value;
+}
+
+bool SettingDoubleSpinBox::effectiveBool(const QString& key) const {
+    const bool global_value = m_sb->contains(key) ? m_sb->setting<bool>(key) : false;
+
+    if (!m_settings_bases.isEmpty())
+        return effectiveValueHelper<bool>(key, 0, global_value);
+
+    return global_value;
+}
+
+int SettingDoubleSpinBox::effectiveInt(const QString& key) const {
+    const int global_value = m_sb->contains(key) ? m_sb->setting<int>(key) : 0;
+
+    if (!m_settings_bases.isEmpty())
+        return effectiveValueHelper<int>(key, 0, global_value);
+
+    return global_value;
+}
+
+bool SettingDoubleSpinBox::hasConsistentEffectiveDouble() const {
+    if (m_settings_bases.size() <= 1)
+        return true;
+
+    const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
+    const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
+    const double first_value = effectiveValueHelper<double>(m_key, 0, global_value);
+
+    for (int index = 1, end = m_settings_bases.size(); index < end; ++index) {
+        if (effectiveValueHelper<double>(m_key, index, global_value) != first_value)
+            return false;
+    }
+
+    return true;
+}
+
+QString SettingDoubleSpinBox::dynamicDependencyWarning() const {
+    if (m_sb.isNull())
+        return QString();
+
+    const QString display = masterString(m_json, Constants::Settings::Master::kDisplay);
+    const QString type = masterString(m_json, Constants::Settings::Master::kType);
+    const double value = effectiveDouble();
+
+    const double min_extruder_speed = effectiveDouble(PRS::MachineSpeed::kMinExtruderSpeed);
+    const double max_extruder_speed = effectiveDouble(PRS::MachineSpeed::kMaxExtruderSpeed);
+    const bool has_min_extruder_speed = min_extruder_speed > 0;
+    const bool has_max_extruder_speed = max_extruder_speed > 0;
+    const bool invalid_extruder_range =
+        has_min_extruder_speed && has_max_extruder_speed && min_extruder_speed > max_extruder_speed;
+
+    if (m_key == PRS::MachineSpeed::kMinExtruderSpeed || m_key == PRS::MachineSpeed::kMaxExtruderSpeed) {
+        if (invalid_extruder_range)
+            return "Minimum Extruder Speed (" + formatRpm(min_extruder_speed) +
+                   ") is greater than Maximum Extruder Speed (" + formatRpm(max_extruder_speed) + ").";
+    }
+    else if (type == "rpm" && !invalid_extruder_range) {
+        if (has_min_extruder_speed && value < min_extruder_speed)
+            return display + " (" + formatRpm(value) + ") is below Minimum Extruder Speed (" +
+                   formatRpm(min_extruder_speed) + ").";
+
+        if (has_max_extruder_speed && value > max_extruder_speed)
+            return display + " (" + formatRpm(value) + ") exceeds Maximum Extruder Speed (" +
+                   formatRpm(max_extruder_speed) + ").";
+    }
+
+    const double x_min = effectiveDouble(PRS::Dimensions::kXMin);
+    const double x_max = effectiveDouble(PRS::Dimensions::kXMax);
+    const double y_min = effectiveDouble(PRS::Dimensions::kYMin);
+    const double y_max = effectiveDouble(PRS::Dimensions::kYMax);
+    const double z_min = effectiveDouble(PRS::Dimensions::kZMin);
+    const double z_max = effectiveDouble(PRS::Dimensions::kZMax);
+    const double w_min = effectiveDouble(PRS::Dimensions::kWMin);
+    const double w_max = effectiveDouble(PRS::Dimensions::kWMax);
+
+    QString warning = dimensionRangeWarning(m_key, PRS::Dimensions::kXMin, PRS::Dimensions::kXMax, x_min, x_max,
+                                            "Minimum X", "Maximum X");
+    if (!warning.isEmpty())
+        return warning;
+
+    warning = dimensionRangeWarning(m_key, PRS::Dimensions::kYMin, PRS::Dimensions::kYMax, y_min, y_max, "Minimum Y",
+                                    "Maximum Y");
+    if (!warning.isEmpty())
+        return warning;
+
+    warning = dimensionRangeWarning(m_key, PRS::Dimensions::kZMin, PRS::Dimensions::kZMax, z_min, z_max, "Minimum Z",
+                                    "Maximum Z");
+    if (!warning.isEmpty())
+        return warning;
+
+    warning = dimensionRangeWarning(m_key, PRS::Dimensions::kWMin, PRS::Dimensions::kWMax, w_min, w_max, "Minimum W",
+                                    "Maximum W");
+    if (!warning.isEmpty())
+        return warning;
+
+    if (m_key == PRS::Dimensions::kPurgeX || m_key == PS::Perimeter::kEnableLeadInX)
+        return boundsWarning(display, value, x_min, x_max, "X");
+
+    if (m_key == PRS::Dimensions::kPurgeY || m_key == PS::Perimeter::kEnableLeadInY)
+        return boundsWarning(display, value, y_min, y_max, "Y");
+
+    if (m_key == PRS::Dimensions::kPurgeZ)
+        return boundsWarning(display, value, z_min, z_max, "Z");
+
+    if (m_key == PRS::Dimensions::kDoffingHeight)
+        return boundsWarning(display, value, w_min, w_max, "W");
+
+    if (m_key == PS::Layer::kLayerHeight && value <= 0)
+        return display + " must be greater than zero (currently " + formatDistance(value) + ").";
+
+    const QStringList bead_width_keys {
+        PS::Layer::kBeadWidth,
+        PS::Perimeter::kBeadWidth,
+        PS::Inset::kBeadWidth,
+        PS::Skeleton::kBeadWidth,
+        PS::Skin::kBeadWidth,
+        PS::Infill::kBeadWidth,
+        MS::PlatformAdhesion::kRaftBeadWidth,
+        MS::PlatformAdhesion::kBrimBeadWidth,
+        MS::PlatformAdhesion::kSkirtBeadWidth,
+    };
+
+    if (isOneOf(m_key, bead_width_keys)) {
+        const double layer_height = effectiveDouble(PS::Layer::kLayerHeight);
+        if (value <= 0)
+            return display + " must be greater than zero (currently " + formatDistance(value) + ").";
+
+        if (layer_height > 0 && value < layer_height)
+            return display + " (" + formatDistance(value) + ") is smaller than Layer Height (" +
+                   formatDistance(layer_height) + ").";
+    }
+
+    if (m_key == PS::Infill::kMinPathLength || m_key == kInfillMaximumPathLength) {
+        const double min_path_length = effectiveDouble(PS::Infill::kMinPathLength);
+        const double max_path_length = effectiveDouble(kInfillMaximumPathLength);
+        if (min_path_length > 0 && max_path_length > 0 && min_path_length > max_path_length)
+            return "Minimum Infill Path Length (" + formatDistance(min_path_length) +
+                   ") is greater than Maximum Infill Path Length (" + formatDistance(max_path_length) + ").";
+    }
+
+    const QStringList lift_distance_keys {
+        PS::Travel::kLiftHeight,           PS::Travel::kFinalLiftDistance,
+        MS::SpiralLift::kLiftHeight,       MS::Slowdown::kPerimeterLiftDistance,
+        MS::Slowdown::kInsetLiftDistance,  MS::Slowdown::kSkinLiftDistance,
+        MS::Slowdown::kInfillLiftDistance, MS::Slowdown::kSkeletonLiftDistance,
+        MS::TipWipe::kPerimeterLiftHeight, MS::TipWipe::kInsetLiftHeight,
+        MS::TipWipe::kSkinLiftHeight,      MS::TipWipe::kInfillLiftHeight,
+        MS::TipWipe::kSkeletonLiftHeight,
+    };
+
+    if (isOneOf(m_key, lift_distance_keys) && value > 0) {
+        const double z_speed = effectiveDouble(PRS::MachineSpeed::kZSpeed);
+        if (z_speed <= 0)
+            return display + " requires Z Speed to be greater than zero.";
+
+        if (isValidRange(z_min, z_max) && value > (z_max - z_min))
+            return display + " (" + formatDistance(value) + ") exceeds the Z build volume range (" +
+                   formatDistance(z_max - z_min) + ").";
+    }
+
+    if (m_key == PS::Travel::kMinTravelForLift && value > 0 && effectiveDouble(PS::Travel::kLiftHeight) <= 0)
+        return display + " is set, but Travel Lift Height is zero.";
+
+    const double fan_min_speed = effectiveDouble(MS::Cooling::kMinSpeed);
+    const double fan_max_speed = effectiveDouble(MS::Cooling::kMaxSpeed);
+    if ((m_key == MS::Cooling::kMinSpeed || m_key == MS::Cooling::kMaxSpeed) && fan_min_speed > fan_max_speed)
+        return "Min Fan Speed (" + formatTypedValue(fan_min_speed, type) + ") is greater than Max Fan Speed (" +
+               formatTypedValue(fan_max_speed, type) + ").";
+
+    const bool force_layer_time = effectiveBool(MS::Cooling::kForceMinLayerTime);
+    const bool use_feedrate_layer_time =
+        effectiveInt(MS::Cooling::kForceMinLayerTimeMethod) == kModifyFeedrateLayerTimeMethod;
+    const double min_layer_time = effectiveDouble(MS::Cooling::kMinLayerTime);
+    const double max_layer_time = effectiveDouble(MS::Cooling::kMaxLayerTime);
+
+    if (force_layer_time && m_key == MS::Cooling::kMinLayerTime) {
+        if (value <= 0)
+            return enabledSettingWarning(display, value, "when Force Min / Max Layer Time is enabled", type);
+
+        if (use_feedrate_layer_time && max_layer_time > 0 && value > max_layer_time)
+            return "Minimum Layer Time (" + formatTime(value) + ") is greater than Maximum Layer Time (" +
+                   formatTime(max_layer_time) + ").";
+    }
+
+    if (force_layer_time && use_feedrate_layer_time && m_key == MS::Cooling::kMaxLayerTime) {
+        if (value <= 0)
+            return enabledSettingWarning(display, value, "when Modify Feedrate layer-time control is selected", type);
+
+        if (min_layer_time > 0 && value < min_layer_time)
+            return "Maximum Layer Time (" + formatTime(value) + ") is less than Minimum Layer Time (" +
+                   formatTime(min_layer_time) + ").";
+    }
+
+    if (force_layer_time && use_feedrate_layer_time && m_key == MS::Cooling::kExtruderScaleFactor && value <= 0)
+        return enabledSettingWarning(display, value, "when Modify Feedrate layer-time control is selected", type);
+
+    return QString();
 }
 } // namespace ORNL

--- a/src/widgets/settings/setting_row_base.cpp
+++ b/src/widgets/settings/setting_row_base.cpp
@@ -140,7 +140,10 @@ void SettingRowBase::setBases(QList<QSharedPointer<SettingsBase>> settings_bases
 
 QList<QSharedPointer<SettingsBase>> SettingRowBase::getBases() { return m_settings_bases; }
 
-void SettingRowBase::checkDependencies() { setDependencyEnabled(checkLogic(m_dependency_logic)); }
+void SettingRowBase::checkDependencies() {
+    setDependencyEnabled(checkLogic(m_dependency_logic));
+    checkDynamicDependencies();
+}
 
 void SettingRowBase::hide() {
     m_row_visible = false;


### PR DESCRIPTION
## Summary

Adds warning-only validation for settings values that can become internally inconsistent across printer, material, and profile configuration.

## Changes

- Refreshes dynamic setting warnings when related settings change, profiles switch, or rows reload.
- Warns when speed, extruder RPM, printer dimension, bead geometry, infill path length, lift/travel, fan speed, or minimum layer time values violate related configured limits.
- Reuses the existing warning styling and tab warning counts so invalid values are visible without blocking edits.

## Validation

- `nix develop --command cmake --build build/generic-llvm-ninja`
- `nix develop --command ctest --test-dir build/generic-llvm-ninja --output-on-failure` (no registered tests found)
- `git diff --check`