### PR TITLE
2D Orthographic View

### DIFF
--- a/include/widgets/gcode_widget.h
+++ b/include/widgets/gcode_widget.h
@@ -37,6 +37,10 @@ class GCodeWidget : public QWidget {
     //! \param size
     void resized(QSize size);
 
+    //! \brief signals when the overhead orthographic g-code view is enabled or disabled
+    //! \param status if the view is using orthographic projection
+    void orthographicViewChanged(bool status);
+
   public slots:
     //! \brief Adds the GCode to the view after it has been loaded.
     void addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode);
@@ -103,5 +107,8 @@ class GCodeWidget : public QWidget {
 
     //! \brief Segment / Bead info control
     QSharedPointer<GCodeInfoControl> m_segment_info_control;
+
+    //! \brief Current overhead orthographic projection state.
+    bool m_ortho_enabled = false;
 };
 } // namespace ORNL

--- a/include/widgets/main_toolbar.h
+++ b/include/widgets/main_toolbar.h
@@ -96,6 +96,10 @@ class MainToolbar : public QToolBar {
     //! \param setting_key: the new settings
     void handleModifiedSetting(const QString& setting_key);
 
+    //! \brief updates the 2D g-code button without re-emitting the toggle signal
+    //! \param status if the g-code view is using orthographic projection
+    void setOrthoGcodeChecked(bool status);
+
   private:
     //! \brief sets up the widget
     void setup();

--- a/include/widgets/view_controls_toolbar.h
+++ b/include/widgets/view_controls_toolbar.h
@@ -16,7 +16,7 @@ class ViewControlsToolbar : public QToolBar {
   public:
     //! \brief Constructor
     //! \param parent optional parent widget
-    ViewControlsToolbar(QWidget* parent = nullptr);
+    ViewControlsToolbar(QWidget* parent = nullptr, bool show_orthographic_button = false);
 
   signals:
     //! \brief sets the camera to iso view
@@ -27,6 +27,8 @@ class ViewControlsToolbar : public QToolBar {
     void setSideView();
     //! \brief sets the camera to top view
     void setTopView();
+    //! \brief toggles overhead orthographic g-code projection
+    void setOrthographicView(bool enabled);
 
   public slots:
     //! \brief sets the style of the widget according to current theme
@@ -35,6 +37,12 @@ class ViewControlsToolbar : public QToolBar {
     //! \brief adjusts size and position based on parent redraw
     //! \param new_size the new parent's new size
     void resize(QSize new_size);
+
+    //! \brief enables/ disables the camera orientation buttons
+    void setProjectionControlsEnabled(bool status);
+
+    //! \brief updates the optional orthographic button without emitting its toggle signal
+    void setOrthographicViewChecked(bool status);
 
     void setEnabled(bool status);
 
@@ -48,12 +56,18 @@ class ViewControlsToolbar : public QToolBar {
     //! \brief Constructs a flexible space between buttons
     void makeSpace();
 
+    //! \brief Constructs a separator with surrounding flexible spacing
+    void makeSpacedSeparator();
+
     //! \brief the parent
     QWidget* m_parent;
+
+    bool m_show_orthographic_button;
 
     QToolButton* m_iso_btn;
     QToolButton* m_front_btn;
     QToolButton* m_side_btn;
     QToolButton* m_top_btn;
+    QToolButton* m_ortho_btn;
 };
 } // namespace ORNL

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -613,18 +613,16 @@ void GCodeView::resizeGL(int width, int height) {
     // (Re)Initalize camera projection.
     QMatrix4x4 projection;
 
-    float aspect = (float)width / (float)height;
+    if (width <= 0 || height <= 0) {
+        return;
+    }
 
-    if (aspect >= 1)
-        width *= (aspect);
-    else
-        height *= (1 / aspect);
-
-    int quater_width = width / (std::pow(24, m_state.zoom_factor));
-    int quater_height = height / (std::pow(24, m_state.zoom_factor));
+    const float scale = std::pow(24.0f, m_state.zoom_factor);
+    const float half_width = static_cast<float>(width) / scale;
+    const float half_height = static_cast<float>(height) / scale;
 
     projection.setToIdentity();
-    projection.ortho(-quater_width, quater_width, -quater_height, quater_height, -Constants::OpenGL::kFarPlane,
+    projection.ortho(-half_width, half_width, -half_height, half_height, -Constants::OpenGL::kFarPlane,
                      2 * Constants::OpenGL::kFarPlane);
 
     this->setProjectionMatrix(projection);

--- a/src/widgets/gcode_widget.cpp
+++ b/src/widgets/gcode_widget.cpp
@@ -35,8 +35,16 @@ void GCodeWidget::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) 
 void GCodeWidget::clear() { m_gcode_view->clear(); }
 
 void GCodeWidget::setOrthoView(bool status) {
-    m_view_controls->setEnabled(!status);
+    const bool changed = m_ortho_enabled != status;
+    m_ortho_enabled = status;
+
+    m_view_controls->setProjectionControlsEnabled(!status);
+    m_view_controls->setOrthographicViewChecked(status);
     m_gcode_view->useOrthographic(status);
+
+    if (changed) {
+        emit orthographicViewChanged(status);
+    }
 }
 
 void GCodeWidget::showSegmentInfo(bool show) { m_segment_info_control->setVisible(show); }
@@ -140,7 +148,7 @@ void GCodeWidget::setupSubWidgets() {
     m_gcode_view->hideSegmentType(types, true);
 
     // View Controls
-    m_view_controls = new ViewControlsToolbar(this);
+    m_view_controls = new ViewControlsToolbar(this, true);
     m_view_controls->raise();
 }
 
@@ -164,6 +172,7 @@ void GCodeWidget::setupEvents() {
     connect(m_view_controls, &ViewControlsToolbar::setFrontView, m_gcode_view, &GCodeView::setFrontView);
     connect(m_view_controls, &ViewControlsToolbar::setSideView, m_gcode_view, &GCodeView::setSideView);
     connect(m_view_controls, &ViewControlsToolbar::setTopView, m_gcode_view, &GCodeView::setTopView);
+    connect(m_view_controls, &ViewControlsToolbar::setOrthographicView, this, &GCodeWidget::setOrthoView);
 }
 
 void GCodeWidget::resizeEvent(QResizeEvent* event) {

--- a/src/widgets/main_toolbar.cpp
+++ b/src/widgets/main_toolbar.cpp
@@ -8,6 +8,7 @@
 #include <QInputDialog>
 #include <QLayout>
 #include <QMenu>
+#include <QSignalBlocker>
 #include <qaction.h>
 #include <qfiledevice.h>
 #include <qicon.h>
@@ -515,6 +516,11 @@ void MainToolbar::setLayerSettingsRangeAbility(bool status) {
     }
 
     enableCorrectOptions();
+}
+
+void MainToolbar::setOrthoGcodeChecked(bool status) {
+    const QSignalBlocker blocker(m_2d_gcode_btn);
+    m_2d_gcode_btn->setChecked(status);
 }
 
 void MainToolbar::handleModifiedSetting(const QString& setting_key) {

--- a/src/widgets/view_controls_toolbar.cpp
+++ b/src/widgets/view_controls_toolbar.cpp
@@ -3,6 +3,7 @@
 #include <QFile>
 #include <QGraphicsDropShadowEffect>
 #include <QLayout>
+#include <QSignalBlocker>
 #include <QToolButton>
 #include <qfiledevice.h>
 #include <qicon.h>
@@ -17,7 +18,13 @@
 #include "utilities/constants.h"
 
 namespace ORNL {
-ViewControlsToolbar::ViewControlsToolbar(QWidget* parent) : m_parent(parent), QToolBar(parent) {
+namespace {
+constexpr int kOrthographicButtonWidth = 70;
+} // namespace
+
+ViewControlsToolbar::ViewControlsToolbar(QWidget* parent, bool show_orthographic_button)
+    : QToolBar(parent), m_parent(parent), m_show_orthographic_button(show_orthographic_button), m_iso_btn(nullptr),
+      m_front_btn(nullptr), m_side_btn(nullptr), m_top_btn(nullptr), m_ortho_btn(nullptr) {
     setupWidget();
     setupSubWidgets();
 }
@@ -51,9 +58,7 @@ void ViewControlsToolbar::setupSubWidgets() {
 
     this->makeSpace();
     this->addWidget(m_iso_btn);
-    this->makeSpace();
-    this->addSeparator();
-    this->makeSpace();
+    this->makeSpacedSeparator();
 
     m_front_btn = new QToolButton(this);
     m_front_btn->setIcon(QIcon(":/icons/view_front.png"));
@@ -61,9 +66,7 @@ void ViewControlsToolbar::setupSubWidgets() {
     connect(m_front_btn, &QToolButton::clicked, this, [this]() { emit setFrontView(); });
 
     this->addWidget(m_front_btn);
-    this->makeSpace();
-    this->addSeparator();
-    this->makeSpace();
+    this->makeSpacedSeparator();
 
     m_side_btn = new QToolButton(this);
     m_side_btn->setIcon(QIcon(":/icons/view_left.png"));
@@ -71,9 +74,7 @@ void ViewControlsToolbar::setupSubWidgets() {
     connect(m_side_btn, &QToolButton::clicked, this, [this]() { emit setSideView(); });
 
     this->addWidget(m_side_btn);
-    this->makeSpace();
-    this->addSeparator();
-    this->makeSpace();
+    this->makeSpacedSeparator();
 
     m_top_btn = new QToolButton(this);
     m_top_btn->setIcon(QIcon(":/icons/view_top.png"));
@@ -82,6 +83,22 @@ void ViewControlsToolbar::setupSubWidgets() {
 
     this->addWidget(m_top_btn);
     this->makeSpace();
+
+    if (m_show_orthographic_button) {
+        this->addSeparator();
+        this->makeSpace();
+
+        m_ortho_btn = new QToolButton(this);
+        m_ortho_btn->setIcon(QIcon(":/icons/orthogonal_view.png"));
+        m_ortho_btn->setToolTip("Overhead Orthographic Projection");
+        m_ortho_btn->setCheckable(true);
+        connect(m_ortho_btn, &QToolButton::toggled, this, [this](bool checked) {
+            emit setOrthographicView(checked);
+        });
+
+        this->addWidget(m_ortho_btn);
+        this->makeSpace();
+    }
 }
 
 void ViewControlsToolbar::setupStyle() {
@@ -98,12 +115,19 @@ void ViewControlsToolbar::makeSpace() {
     this->addWidget(spacer);
 }
 
+void ViewControlsToolbar::makeSpacedSeparator() {
+    this->makeSpace();
+    this->addSeparator();
+    this->makeSpace();
+}
+
 void ViewControlsToolbar::resize(QSize new_size) {
     // Update position
     auto parent_size = m_parent->size();
+    const int toolbar_width = Constants::UI::ViewControlsToolbar::kWidth +
+                              (m_show_orthographic_button ? kOrthographicButtonWidth : 0);
 
-    this->move(parent_size.width() - Constants::UI::ViewControlsToolbar::kWidth -
-                   Constants::UI::ViewControlsToolbar::kRightOffset,
+    this->move(parent_size.width() - toolbar_width - Constants::UI::ViewControlsToolbar::kRightOffset,
                parent_size.height() - Constants::UI::ViewControlsToolbar::kHeight -
                    Constants::UI::ViewControlsToolbar::kBottomOffset);
 
@@ -111,14 +135,32 @@ void ViewControlsToolbar::resize(QSize new_size) {
     this->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     this->setMinimumHeight(Constants::UI::ViewControlsToolbar::kHeight);
     this->setMaximumHeight(Constants::UI::ViewControlsToolbar::kHeight);
-    this->setMinimumWidth(Constants::UI::ViewControlsToolbar::kWidth);
-    this->setMaximumWidth(Constants::UI::ViewControlsToolbar::kWidth);
+    this->setMinimumWidth(toolbar_width);
+    this->setMaximumWidth(toolbar_width);
 }
 
-void ViewControlsToolbar::setEnabled(bool status) {
+void ViewControlsToolbar::setProjectionControlsEnabled(bool status) {
     m_iso_btn->setEnabled(status);
     m_front_btn->setEnabled(status);
     m_side_btn->setEnabled(status);
     m_top_btn->setEnabled(status);
+}
+
+void ViewControlsToolbar::setOrthographicViewChecked(bool status) {
+    if (m_ortho_btn == nullptr) {
+        return;
+    }
+
+    const QSignalBlocker blocker(m_ortho_btn);
+    m_ortho_btn->setChecked(status);
+}
+
+void ViewControlsToolbar::setEnabled(bool status) {
+    QToolBar::setEnabled(status);
+    setProjectionControlsEnabled(status);
+
+    if (m_ortho_btn != nullptr) {
+        m_ortho_btn->setEnabled(status);
+    }
 }
 } // namespace ORNL

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -1040,6 +1040,7 @@ void MainWindow::setupEvents() {
     // Toolbar -> GCode Widget
     connect(m_main_toolbar, &MainToolbar::showSegmentInfo, m_gcode_widget, &GCodeWidget::showSegmentInfo);
     connect(m_main_toolbar, &MainToolbar::setOrthoGcode, m_gcode_widget, &GCodeWidget::setOrthoView);
+    connect(m_gcode_widget, &GCodeWidget::orthographicViewChanged, m_main_toolbar, &MainToolbar::setOrthoGcodeChecked);
     connect(m_main_toolbar, &MainToolbar::showGhosts, m_gcode_widget, &GCodeWidget::showGhosts);
     connect(m_main_toolbar, &MainToolbar::showSeams, m_gcode_widget, &GCodeWidget::showSeams);
     connect(m_main_toolbar, &MainToolbar::exportGCode, m_export_window, [this] {


### PR DESCRIPTION
## Summary

- Add an in-view overhead orthographic toggle to the g-code view controls.
- Keep the in-view toggle synchronized with the existing main-toolbar 2D g-code button.
- Fix the orthographic projection extents so top-down 2D views preserve equal X/Y scale.

## Impact

Users can switch the overhead g-code preview into a true orthographic 2D projection from the g-code view itself. Regular shapes should no longer appear stretched by viewport aspect ratio in that mode.

## Validation

- `nix develop --command cmake --build build/generic-llvm-ninja -j2`
- `git diff --check`