### PR TITLE
Fix for Infill Links that Overlap with Contours

### DIFF
--- a/include/optimizers/polyline_order_optimizer.h
+++ b/include/optimizers/polyline_order_optimizer.h
@@ -51,13 +51,13 @@ class PolylineOrderOptimizer {
     /// @param minDistance: minimum distance of resulting polyline
     /// @param minTravelDistance: minimum distance for travel to be used instead of link
     /// @param enable_partitioned_linking: whether to enable partitioned linking of line infill
-    /// @param avoid_link_overlap: whether infill print-link footprints must stay inside link_overlap_geometry
-    /// @param link_footprint_width: bead footprint width to use when checking infill print-link footprints
+    /// @param avoid_link_overlap: whether infill print-link cores must stay inside link_overlap_geometry
+    /// @param link_core_width: overlap-adjusted bead core width to use when checking infill print links
     /// @param link_overlap_geometry: overlap-expanded geometry that linked infill print-segment cores must remain
     /// inside
     void setInfillParameters(InfillPatterns infillPattern, PolygonList border_geometry, Distance minInfillPathDistance,
                              Distance minTravelDistance, bool enable_partitioned_linking = false,
-                             bool avoid_link_overlap = false, Distance link_footprint_width = 0,
+                             bool avoid_link_overlap = false, Distance link_core_width = 0,
                              PolygonList link_overlap_geometry = PolygonList());
 
     void setPointParameters(PointOrderOptimization pointOptimization, bool minDistanceEnable,
@@ -134,7 +134,7 @@ class PolylineOrderOptimizer {
     bool linkIntersects(Point link_start, Point link_end, QVector<Polyline> infill_geometry,
                         PolygonList border_geometry);
 
-    //! \brief Determines whether the overlap-adjusted footprint of an infill link exits the allowed geometry
+    //! \brief Determines whether the overlap-adjusted core of an infill link exits the allowed geometry
     //! \param link_start: Start of link
     //! \param link_end: End of link
     //! \return whether the printed link would overlap contour space beyond the allowed overlap
@@ -236,11 +236,11 @@ class PolylineOrderOptimizer {
     /// linking between partitions
     bool m_enable_partitioned_linking = false;
 
-    /// @brief Whether linked infill print segments should be rejected when their bead footprint overlaps contours
+    /// @brief Whether linked infill print segments should be rejected when their bead core overlaps contours
     bool m_avoid_link_overlap = false;
 
-    /// @brief Bead footprint width used to test linked infill print-segment footprints
-    Distance m_link_footprint_width = 0;
+    /// @brief Overlap-adjusted bead core width used to test linked infill print segments
+    Distance m_link_core_width = 0;
 
     /// @brief Overlap-expanded geometry that linked infill print-segment cores must remain inside
     PolygonList m_link_overlap_geometry;

--- a/include/optimizers/polyline_order_optimizer.h
+++ b/include/optimizers/polyline_order_optimizer.h
@@ -52,12 +52,12 @@ class PolylineOrderOptimizer {
     /// @param minTravelDistance: minimum distance for travel to be used instead of link
     /// @param enable_partitioned_linking: whether to enable partitioned linking of line infill
     /// @param avoid_link_overlap: whether infill print-link footprints must stay inside link_overlap_geometry
-    /// @param link_overlap_width: overlap-adjusted bead core width to use when checking infill print-link footprints
+    /// @param link_footprint_width: bead footprint width to use when checking infill print-link footprints
     /// @param link_overlap_geometry: overlap-expanded geometry that linked infill print-segment cores must remain
     /// inside
     void setInfillParameters(InfillPatterns infillPattern, PolygonList border_geometry, Distance minInfillPathDistance,
                              Distance minTravelDistance, bool enable_partitioned_linking = false,
-                             bool avoid_link_overlap = false, Distance link_overlap_width = 0,
+                             bool avoid_link_overlap = false, Distance link_footprint_width = 0,
                              PolygonList link_overlap_geometry = PolygonList());
 
     void setPointParameters(PointOrderOptimization pointOptimization, bool minDistanceEnable,
@@ -239,8 +239,8 @@ class PolylineOrderOptimizer {
     /// @brief Whether linked infill print segments should be rejected when their bead footprint overlaps contours
     bool m_avoid_link_overlap = false;
 
-    /// @brief Overlap-adjusted bead core width used to test linked infill print-segment footprints
-    Distance m_link_overlap_width = 0;
+    /// @brief Bead footprint width used to test linked infill print-segment footprints
+    Distance m_link_footprint_width = 0;
 
     /// @brief Overlap-expanded geometry that linked infill print-segment cores must remain inside
     PolygonList m_link_overlap_geometry;

--- a/include/optimizers/polyline_order_optimizer.h
+++ b/include/optimizers/polyline_order_optimizer.h
@@ -51,8 +51,14 @@ class PolylineOrderOptimizer {
     /// @param minDistance: minimum distance of resulting polyline
     /// @param minTravelDistance: minimum distance for travel to be used instead of link
     /// @param enable_partitioned_linking: whether to enable partitioned linking of line infill
+    /// @param avoid_link_overlap: whether infill print-link footprints must stay inside link_overlap_geometry
+    /// @param link_overlap_width: overlap-adjusted bead core width to use when checking infill print-link footprints
+    /// @param link_overlap_geometry: overlap-expanded geometry that linked infill print-segment cores must remain
+    /// inside
     void setInfillParameters(InfillPatterns infillPattern, PolygonList border_geometry, Distance minInfillPathDistance,
-                             Distance minTravelDistance, bool enable_partitioned_linking = false);
+                             Distance minTravelDistance, bool enable_partitioned_linking = false,
+                             bool avoid_link_overlap = false, Distance link_overlap_width = 0,
+                             PolygonList link_overlap_geometry = PolygonList());
 
     void setPointParameters(PointOrderOptimization pointOptimization, bool minDistanceEnable,
                             Distance minDistanceThreshold, Distance consecutiveThreshold, bool randomnessEnable,
@@ -127,6 +133,12 @@ class PolylineOrderOptimizer {
     //! \return whether or not intersection occurs
     bool linkIntersects(Point link_start, Point link_end, QVector<Polyline> infill_geometry,
                         PolygonList border_geometry);
+
+    //! \brief Determines whether the overlap-adjusted footprint of an infill link exits the allowed geometry
+    //! \param link_start: Start of link
+    //! \param link_end: End of link
+    //! \return whether the printed link would overlap contour space beyond the allowed overlap
+    bool linkOverlapsContour(Point link_start, Point link_end) const;
 
     //! \brief Finds the index and end of the the closest Polyline to m_current_location
     //! \param polylines: vector of polylines to test for closeness
@@ -223,6 +235,15 @@ class PolylineOrderOptimizer {
     /// @brief Whether to enable partitioned linking of line infill, which links lines in the same partition before
     /// linking between partitions
     bool m_enable_partitioned_linking = false;
+
+    /// @brief Whether linked infill print segments should be rejected when their bead footprint overlaps contours
+    bool m_avoid_link_overlap = false;
+
+    /// @brief Overlap-adjusted bead core width used to test linked infill print-segment footprints
+    Distance m_link_overlap_width = 0;
+
+    /// @brief Overlap-expanded geometry that linked infill print-segment cores must remain inside
+    PolygonList m_link_overlap_geometry;
 
     /// @brief Selection state used to alternate the two exterior edges when ordering open lines outside-in
     int m_open_path_selection_count = 0;

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -712,6 +712,7 @@ class Constants {
             static const QString kManualLineSpacing;
             static const QString kPattern;
             static const QString kLinesPartitionedLinking;
+            static const QString kAvoidLinkOverlap;
             static const QString kBasedOnPrinter;
             static const QString kAngle;
             static const QString kAngleRotation;

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -4822,6 +4822,19 @@
       "symbol":"kInfillLinesPartitionedLinking",
       "local":true
   },
+  "infill_avoid_link_overlap": {
+      "display":"Avoid Infill Link Contour Overlap",
+      "type":"boolean",
+      "tooltip":"If enabled, infill linking segments whose bead core would exceed the configured infill overlap are replaced by travel moves.",
+      "depends":{"AND":[{"slicing_mode":0},{"infill":true}]},
+      "options":"",
+      "default":false,
+      "minor":"Infill",
+      "major":"Profile",
+      "namespace":"Profile::Infill",
+      "symbol":"kAvoidInfillLinkOverlap",
+      "local":true
+  },
   "infill_based_on_printer": {
       "display":"Infill Based on Printer Area",
       "type":"boolean",

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -4825,7 +4825,7 @@
   "infill_avoid_link_overlap": {
       "display":"Avoid Infill Link Contour Overlap",
       "type":"boolean",
-      "tooltip":"If enabled, infill linking segments whose bead core would exceed the configured infill overlap are replaced by travel moves.",
+      "tooltip":"If enabled, infill linking segments whose bead footprint would exceed the configured infill overlap are replaced by travel moves.",
       "depends":{"AND":[{"slicing_mode":0},{"infill":true}]},
       "options":"",
       "default":false,

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -4825,7 +4825,7 @@
   "infill_avoid_link_overlap": {
       "display":"Avoid Infill Link Contour Overlap",
       "type":"boolean",
-      "tooltip":"If enabled, infill linking segments whose bead footprint would exceed the configured infill overlap are replaced by travel moves.",
+      "tooltip":"If enabled, infill linking segments whose bead core would exceed the configured infill overlap are replaced by travel moves.",
       "depends":{"AND":[{"slicing_mode":0},{"infill":true}]},
       "options":"",
       "default":false,

--- a/resources/settings/025_profile_infill.yaml
+++ b/resources/settings/025_profile_infill.yaml
@@ -80,6 +80,18 @@ settings:
     namespace: "Profile::Infill"
     symbol: "kInfillLinesPartitionedLinking"
     local: true
+  - name: "infill_avoid_link_overlap"
+    display: "Avoid Infill Link Contour Overlap"
+    type: "boolean"
+    tooltip: "If enabled, infill linking segments whose bead core would exceed the configured infill overlap are replaced by travel moves."
+    depends: {"AND":[{"slicing_mode":0},{"infill":true}]}
+    options: []
+    default: false
+    minor: "Infill"
+    major: "Profile"
+    namespace: "Profile::Infill"
+    symbol: "kAvoidInfillLinkOverlap"
+    local: true
   - name: "infill_based_on_printer"
     display: "Infill Based on Printer Area"
     type: "boolean"

--- a/resources/settings/025_profile_infill.yaml
+++ b/resources/settings/025_profile_infill.yaml
@@ -83,7 +83,7 @@ settings:
   - name: "infill_avoid_link_overlap"
     display: "Avoid Infill Link Contour Overlap"
     type: "boolean"
-    tooltip: "If enabled, infill linking segments whose bead core would exceed the configured infill overlap are replaced by travel moves."
+    tooltip: "If enabled, infill linking segments whose bead footprint would exceed the configured infill overlap are replaced by travel moves."
     depends: {"AND":[{"slicing_mode":0},{"infill":true}]}
     options: []
     default: false

--- a/resources/settings/025_profile_infill.yaml
+++ b/resources/settings/025_profile_infill.yaml
@@ -83,7 +83,7 @@ settings:
   - name: "infill_avoid_link_overlap"
     display: "Avoid Infill Link Contour Overlap"
     type: "boolean"
-    tooltip: "If enabled, infill linking segments whose bead footprint would exceed the configured infill overlap are replaced by travel moves."
+    tooltip: "If enabled, infill linking segments whose bead core would exceed the configured infill overlap are replaced by travel moves."
     depends: {"AND":[{"slicing_mode":0},{"infill":true}]}
     options: []
     default: false

--- a/src/optimizers/polyline_order_optimizer.cpp
+++ b/src/optimizers/polyline_order_optimizer.cpp
@@ -38,14 +38,14 @@ void PolylineOrderOptimizer::setGeometryToEvaluate(QVector<Polyline> polylines, 
 void PolylineOrderOptimizer::setInfillParameters(InfillPatterns infillPattern, PolygonList border_geometry,
                                                  Distance minInfillPathDistance, Distance minTravelDistance,
                                                  bool enable_partitioned_linking, bool avoid_link_overlap,
-                                                 Distance link_overlap_width, PolygonList link_overlap_geometry) {
+                                                 Distance link_footprint_width, PolygonList link_overlap_geometry) {
     m_pattern = infillPattern;
     m_border_geometry = border_geometry;
     m_min_distance = minInfillPathDistance;
     m_min_travel_distance = minTravelDistance;
     m_enable_partitioned_linking = enable_partitioned_linking && m_pattern == InfillPatterns::kLines;
     m_avoid_link_overlap = avoid_link_overlap;
-    m_link_overlap_width = link_overlap_width;
+    m_link_footprint_width = link_footprint_width;
     m_link_overlap_geometry = link_overlap_geometry;
 }
 
@@ -304,13 +304,13 @@ bool PolylineOrderOptimizer::linkIntersects(Point link_start, Point link_end, QV
 }
 
 bool PolylineOrderOptimizer::linkOverlapsContour(Point link_start, Point link_end) const {
-    if (!m_avoid_link_overlap || m_link_overlap_width <= 0 || m_link_overlap_geometry.isEmpty() ||
+    if (!m_avoid_link_overlap || m_link_footprint_width <= 0 || m_link_overlap_geometry.isEmpty() ||
         link_start == link_end) {
         return false;
     }
 
     PolygonList link_footprint;
-    link_footprint += Polyline({link_start, link_end}).makeReal(m_link_overlap_width);
+    link_footprint += Polyline({link_start, link_end}).makeReal(m_link_footprint_width);
 
     return !(link_footprint - m_link_overlap_geometry).isEmpty();
 }

--- a/src/optimizers/polyline_order_optimizer.cpp
+++ b/src/optimizers/polyline_order_optimizer.cpp
@@ -18,6 +18,10 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
+namespace {
+const Distance kLinkOverlapContainmentTolerance = 1 * micron;
+} // namespace
+
 PolylineOrderOptimizer::PolylineOrderOptimizer(Point& start, uint layer_number)
     : m_current_location(start), m_layer_number(layer_number), m_override_used(false) {
     m_layer_num = layer_number;
@@ -46,7 +50,11 @@ void PolylineOrderOptimizer::setInfillParameters(InfillPatterns infillPattern, P
     m_enable_partitioned_linking = enable_partitioned_linking && m_pattern == InfillPatterns::kLines;
     m_avoid_link_overlap = avoid_link_overlap;
     m_link_footprint_width = link_footprint_width;
-    m_link_overlap_geometry = link_overlap_geometry;
+    // Links generated from offset geometry can legally touch the allowed boundary; relax by one internal unit so
+    // Clipper slivers from exact boundary contact do not turn safe links into travels.
+    m_link_overlap_geometry = m_avoid_link_overlap && !link_overlap_geometry.isEmpty()
+                                  ? link_overlap_geometry.offset(kLinkOverlapContainmentTolerance)
+                                  : link_overlap_geometry;
 }
 
 void PolylineOrderOptimizer::setPointParameters(PointOrderOptimization pointOptimization, bool minDistanceEnable,

--- a/src/optimizers/polyline_order_optimizer.cpp
+++ b/src/optimizers/polyline_order_optimizer.cpp
@@ -37,12 +37,16 @@ void PolylineOrderOptimizer::setGeometryToEvaluate(QVector<Polyline> polylines, 
 
 void PolylineOrderOptimizer::setInfillParameters(InfillPatterns infillPattern, PolygonList border_geometry,
                                                  Distance minInfillPathDistance, Distance minTravelDistance,
-                                                 bool enable_partitioned_linking) {
+                                                 bool enable_partitioned_linking, bool avoid_link_overlap,
+                                                 Distance link_overlap_width, PolygonList link_overlap_geometry) {
     m_pattern = infillPattern;
     m_border_geometry = border_geometry;
     m_min_distance = minInfillPathDistance;
     m_min_travel_distance = minTravelDistance;
     m_enable_partitioned_linking = enable_partitioned_linking && m_pattern == InfillPatterns::kLines;
+    m_avoid_link_overlap = avoid_link_overlap;
+    m_link_overlap_width = link_overlap_width;
+    m_link_overlap_geometry = link_overlap_geometry;
 }
 
 void PolylineOrderOptimizer::setPointParameters(PointOrderOptimization pointOptimization, bool minDistanceEnable,
@@ -173,7 +177,8 @@ Polyline PolylineOrderOptimizer::linkNextInfillLines(QVector<Polyline>& polyline
                 // or currently constructed polylines AND must be shorter than travel distance. Otherwise, a travel must
                 // be used.
                 if (link_distance < m_min_travel_distance &&
-                    !(linkIntersects(link_start, link_end, empty_polylines, m_border_geometry) ||
+                    !(linkOverlapsContour(link_start, link_end) ||
+                      linkIntersects(link_start, link_end, empty_polylines, m_border_geometry) ||
                       linkIntersects(link_start, link_end, m_polylines, empty_polygon_list) ||
                       linkIntersects(link_start, link_end, polylines, empty_polygon_list) ||
                       linkIntersects(link_start, link_end, QVector<Polyline> {new_polyline}, empty_polygon_list))) {
@@ -296,6 +301,18 @@ bool PolylineOrderOptimizer::linkIntersects(Point link_start, Point link_end, QV
     }
 
     return false;
+}
+
+bool PolylineOrderOptimizer::linkOverlapsContour(Point link_start, Point link_end) const {
+    if (!m_avoid_link_overlap || m_link_overlap_width <= 0 || m_link_overlap_geometry.isEmpty() ||
+        link_start == link_end) {
+        return false;
+    }
+
+    PolygonList link_footprint;
+    link_footprint += Polyline({link_start, link_end}).makeReal(m_link_overlap_width);
+
+    return !(link_footprint - m_link_overlap_geometry).isEmpty();
 }
 
 QPair<int, bool> PolylineOrderOptimizer::closestOpenPolyline(QVector<Polyline> polylines, Point currentLocation) {

--- a/src/optimizers/polyline_order_optimizer.cpp
+++ b/src/optimizers/polyline_order_optimizer.cpp
@@ -42,14 +42,14 @@ void PolylineOrderOptimizer::setGeometryToEvaluate(QVector<Polyline> polylines, 
 void PolylineOrderOptimizer::setInfillParameters(InfillPatterns infillPattern, PolygonList border_geometry,
                                                  Distance minInfillPathDistance, Distance minTravelDistance,
                                                  bool enable_partitioned_linking, bool avoid_link_overlap,
-                                                 Distance link_footprint_width, PolygonList link_overlap_geometry) {
+                                                 Distance link_core_width, PolygonList link_overlap_geometry) {
     m_pattern = infillPattern;
     m_border_geometry = border_geometry;
     m_min_distance = minInfillPathDistance;
     m_min_travel_distance = minTravelDistance;
     m_enable_partitioned_linking = enable_partitioned_linking && m_pattern == InfillPatterns::kLines;
     m_avoid_link_overlap = avoid_link_overlap;
-    m_link_footprint_width = link_footprint_width;
+    m_link_core_width = link_core_width;
     // Links generated from offset geometry can legally touch the allowed boundary; relax by one internal unit so
     // Clipper slivers from exact boundary contact do not turn safe links into travels.
     m_link_overlap_geometry = m_avoid_link_overlap && !link_overlap_geometry.isEmpty()
@@ -312,15 +312,15 @@ bool PolylineOrderOptimizer::linkIntersects(Point link_start, Point link_end, QV
 }
 
 bool PolylineOrderOptimizer::linkOverlapsContour(Point link_start, Point link_end) const {
-    if (!m_avoid_link_overlap || m_link_footprint_width <= 0 || m_link_overlap_geometry.isEmpty() ||
+    if (!m_avoid_link_overlap || m_link_core_width <= 0 || m_link_overlap_geometry.isEmpty() ||
         link_start == link_end) {
         return false;
     }
 
-    PolygonList link_footprint;
-    link_footprint += Polyline({link_start, link_end}).makeReal(m_link_footprint_width);
+    PolygonList link_core;
+    link_core += Polyline({link_start, link_end}).makeReal(m_link_core_width);
 
-    return !(link_footprint - m_link_overlap_geometry).isEmpty();
+    return !(link_core - m_link_overlap_geometry).isEmpty();
 }
 
 QPair<int, bool> PolylineOrderOptimizer::closestOpenPolyline(QVector<Polyline> polylines, Point currentLocation) {

--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -165,12 +165,11 @@ void Infill::optimize(int layerNumber, Point& current_location, bool& shouldNext
         poo.setStartPointOverride(startOverride);
     }
     const Distance bead_width = getSb()->setting<Distance>(PS::Infill::kBeadWidth);
-    const Distance link_overlap_width = bead_width - 2 * getSb()->setting<Distance>(PS::Infill::kOverlap);
     poo.setInfillParameters(static_cast<InfillPatterns>(m_sb->setting<int>(PS::Infill::kPattern)), m_geometry_copy,
                             getSb()->setting<Distance>(PS::Infill::kMinPathLength),
                             getSb()->setting<Distance>(PS::Travel::kInfillMinLength),
                             getSb()->setting<bool>(PS::Infill::kLinesPartitionedLinking),
-                            getSb()->setting<bool>(PS::Infill::kAvoidLinkOverlap), link_overlap_width, m_geometry_copy);
+                            getSb()->setting<bool>(PS::Infill::kAvoidLinkOverlap), bead_width, m_geometry_copy);
 
     poo.setPointParameters(pointOrderOptimization, getSb()->setting<bool>(PS::Optimizations::kMinDistanceEnabled),
                            getSb()->setting<Distance>(PS::Optimizations::kMinDistanceThreshold),

--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -47,8 +47,9 @@ void Infill::compute(uint layer_num) {
 
     m_paths.clear();
 
-    // keep around unaltered m_geometry for later connections for travels
-    m_geometry_copy = m_geometry.offset(m_sb->setting<Distance>(PS::Infill::kOverlap));
+    // Keep around the overlapped geometry for later connections/travels.
+    const Distance overlap = m_sb->setting<Distance>(PS::Infill::kOverlap);
+    m_geometry_copy = m_geometry.offset(overlap);
 
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kInfillNum));
 
@@ -163,10 +164,13 @@ void Infill::optimize(int layerNumber, Point& current_location, bool& shouldNext
 
         poo.setStartPointOverride(startOverride);
     }
+    const Distance bead_width = getSb()->setting<Distance>(PS::Infill::kBeadWidth);
+    const Distance link_overlap_width = bead_width - 2 * getSb()->setting<Distance>(PS::Infill::kOverlap);
     poo.setInfillParameters(static_cast<InfillPatterns>(m_sb->setting<int>(PS::Infill::kPattern)), m_geometry_copy,
                             getSb()->setting<Distance>(PS::Infill::kMinPathLength),
                             getSb()->setting<Distance>(PS::Travel::kInfillMinLength),
-                            getSb()->setting<bool>(PS::Infill::kLinesPartitionedLinking));
+                            getSb()->setting<bool>(PS::Infill::kLinesPartitionedLinking),
+                            getSb()->setting<bool>(PS::Infill::kAvoidLinkOverlap), link_overlap_width, m_geometry_copy);
 
     poo.setPointParameters(pointOrderOptimization, getSb()->setting<bool>(PS::Optimizations::kMinDistanceEnabled),
                            getSb()->setting<Distance>(PS::Optimizations::kMinDistanceThreshold),

--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -165,11 +165,13 @@ void Infill::optimize(int layerNumber, Point& current_location, bool& shouldNext
         poo.setStartPointOverride(startOverride);
     }
     const Distance bead_width = getSb()->setting<Distance>(PS::Infill::kBeadWidth);
+    const Distance overlap = getSb()->setting<Distance>(PS::Infill::kOverlap);
+    const Distance link_core_width = bead_width - 2 * overlap;
     poo.setInfillParameters(static_cast<InfillPatterns>(m_sb->setting<int>(PS::Infill::kPattern)), m_geometry_copy,
                             getSb()->setting<Distance>(PS::Infill::kMinPathLength),
                             getSb()->setting<Distance>(PS::Travel::kInfillMinLength),
                             getSb()->setting<bool>(PS::Infill::kLinesPartitionedLinking),
-                            getSb()->setting<bool>(PS::Infill::kAvoidLinkOverlap), bead_width, m_geometry_copy);
+                            getSb()->setting<bool>(PS::Infill::kAvoidLinkOverlap), link_core_width, m_geometry_copy);
 
     poo.setPointParameters(pointOrderOptimization, getSb()->setting<bool>(PS::Optimizations::kMinDistanceEnabled),
                            getSb()->setting<Distance>(PS::Optimizations::kMinDistanceThreshold),

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -657,6 +657,7 @@ const QString Constants::ProfileSettings::Infill::kDensity = "infill_density";
 const QString Constants::ProfileSettings::Infill::kManualLineSpacing = "infill_manual_spacing";
 const QString Constants::ProfileSettings::Infill::kPattern = "infill_pattern";
 const QString Constants::ProfileSettings::Infill::kLinesPartitionedLinking = "infill_lines_partitioned_linking";
+const QString Constants::ProfileSettings::Infill::kAvoidLinkOverlap = "infill_avoid_link_overlap";
 const QString Constants::ProfileSettings::Infill::kBasedOnPrinter = "infill_based_on_printer";
 const QString Constants::ProfileSettings::Infill::kAngle = "infill_angle";
 const QString Constants::ProfileSettings::Infill::kAngleRotation = "infill_angle_rotation";


### PR DESCRIPTION
## Summary

Adds a default-off infill setting, `infill_avoid_link_overlap`, that prevents printed infill linking segments from intruding beyond the configured contour overlap allowance.

## Root Cause

Short infill linking moves were being treated like normal infill extrusion links based primarily on centerline intersection checks. For some geometries, the link centerline could pass the existing checks while the printed bead footprint still overlapped contour space.

## Changes

- Adds the `Avoid Infill Link Contour Overlap` profile setting, defaulting to `false` to preserve existing behavior.
- Passes overlap-aware link-check parameters from `Infill` into `PolylineOrderOptimizer`.
- Rejects candidate infill links when an overlap-adjusted bead core footprint exits the overlap-expanded infill geometry, causing those unsafe links to remain travel moves.
- Regenerates `resources/configs/master.conf` from the settings YAML.

## Validation

- `nix develop -c cmake --build build/generic-llvm-ninja --config Debug`
- `git diff --check`
- Headless sliced the provided infill-overlap sample with the setting enabled and confirmed legal links are preserved while contour-overlapping links are converted to travels.