### PR TITLE
Add Layer Time Estimate to G-Code

### DIFF
--- a/include/gcode/parsers/common_parser.h
+++ b/include/gcode/parsers/common_parser.h
@@ -559,6 +559,9 @@ class CommonParser : public ParserBase {
     // List of all calculated times/volumes for layers as well as total distance
     QList<Time> m_layer_times;
 
+    //! \brief Additional layer time inserted by dwell-based minimum layer time enforcement.
+    QList<Time> m_layer_dwell_adjustments;
+
     //! \brief layer "G1 F" lines feedrate modifier
     QList<double> m_layer_FR_modifiers;
 

--- a/include/threading/abs_slicing_thread.h
+++ b/include/threading/abs_slicing_thread.h
@@ -98,6 +98,9 @@ class AbstractSlicingThread : public QObject {
     //! \param base: WriterBase to do the appropriate gcode writing
     void writeGCodeShutdown();
 
+    //! \brief Adds estimated layer-time comments to the generated G-Code when enabled.
+    void writeLayerTimeComments();
+
     //! \brief Returns max steps among all sliced parts
     int getMaxSteps();
 

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -267,6 +267,7 @@ class Constants {
             static const QString kEnableWaitForUser;
             static const QString kEnableBoundingBox;
             static const QString kEnableSettingsFooter;
+            static const QString kLayerTimeComments;
             static const QString kStartCode;
             static const QString kLayerCodeChange;
             static const QString kEndCode;

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -870,6 +870,19 @@
       "symbol":"kSettingsFooter",
       "local":false
   },
+  "enable_layer_time_comments": {
+      "display":"Layer Time Comments",
+      "type":"boolean",
+      "tooltip":"If selected, each layer marker in the G-Code includes the estimated layer time in seconds.",
+      "depends":"",
+      "options":"",
+      "default":false,
+      "minor":"G-Code",
+      "major":"Printer",
+      "namespace":"Printer::GCode",
+      "symbol":"kLayerTimeComments",
+      "local":false
+  },
   "start_code": {
       "display":"Start Code",
       "type":"multiline_text",

--- a/resources/settings/006_printer_g_code.yaml
+++ b/resources/settings/006_printer_g_code.yaml
@@ -61,6 +61,18 @@ settings:
     namespace: "Printer::GCode"
     symbol: "kSettingsFooter"
     local: false
+  - name: "enable_layer_time_comments"
+    display: "Layer Time Comments"
+    type: "boolean"
+    tooltip: "If selected, each layer marker in the G-Code includes the estimated layer time in seconds."
+    depends: {}
+    options: []
+    default: false
+    minor: "G-Code"
+    major: "Printer"
+    namespace: "Printer::GCode"
+    symbol: "kLayerTimeComments"
+    local: false
   - name: "start_code"
     display: "Start Code"
     type: "multiline_text"

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -634,6 +634,7 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
     m_layer_start_lines.push_back(1);
 
     m_layer_times.push_back(Time());
+    m_layer_dwell_adjustments.push_back(Time());
     m_layer_FR_modifiers.push_back(1.0);
     m_layer_G1F_times.push_back(Time());
     m_layer_volumes.push_back(Volume());
@@ -786,6 +787,7 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
 
                 // add empty slots to arrays for this layer
                 m_layer_times.push_back(Time());
+                m_layer_dwell_adjustments.push_back(Time());
                 m_layer_FR_modifiers.push_back(1.0);
                 m_layer_G1F_times.push_back(Time());
                 m_layer_volumes.push_back(Volume());
@@ -902,12 +904,17 @@ void CommonParser::reset() {
     m_command_modal_feedrates.clear();
     m_explicit_modal_feedrates.clear();
     m_command_G1F_times.clear();
+    m_layer_dwell_adjustments.clear();
 }
 
 QList<Time> CommonParser::getLayerTimes() { return m_layer_times; }
 
 QList<Time> CommonParser::getAdjustedLayerTimes() {
     QList<Time> adjusted_layer_times = m_layer_times;
+    for (int layer = 0; layer < adjusted_layer_times.size() && layer < m_layer_dwell_adjustments.size(); ++layer) {
+        adjusted_layer_times[layer] += m_layer_dwell_adjustments[layer];
+    }
+
     const bool has_adjusted_feedrates = std::any_of(m_layer_FR_modifiers.cbegin(), m_layer_FR_modifiers.cend(),
                                                     [](double modifier) { return modifier > 0 && modifier != 1.0; });
     if (!has_adjusted_feedrates)
@@ -2048,6 +2055,9 @@ void CommonParser::M5Handler(QVector<QString> params) {
 void CommonParser::AddDwell(double dwellTime) {
     int insertIndex = m_current_line - 1 + m_insertions;
     QSharedPointer<SettingsBase> sb = GSM->getGlobal();
+    if (m_current_layer >= 0 && m_current_layer < m_layer_dwell_adjustments.size()) {
+        m_layer_dwell_adjustments[m_current_layer] += Time(dwellTime);
+    }
 
     if (sb->setting<bool>(MS::Purge::kEnablePurgeDwell)) {
         QString rv;

--- a/src/threading/abs_slicing_thread.cpp
+++ b/src/threading/abs_slicing_thread.cpp
@@ -407,18 +407,29 @@ void AbstractSlicingThread::writeLayerTimeComments() {
                                                   "\\s*BEGINNING\\s+LAYER\\s*:\\s*(\\d+)\\b",
                                               QRegularExpression::CaseInsensitiveOption);
 
-        int layer_time_index = 1;
         QStringList annotated_lines = text.split('\n');
-        for (int line_index = 0; line_index < annotated_lines.size() && layer_time_index < adjusted_layer_times.size();
-             ++line_index) {
+        int layer_marker_count = 0;
+        for (const QString& line : annotated_lines) {
+            if (layer_marker.match(line).hasMatch()) {
+                ++layer_marker_count;
+            }
+        }
+
+        const int layer_time_offset = adjusted_layer_times.size() > layer_marker_count ? 1 : 0;
+        for (int line_index = 0; line_index < annotated_lines.size(); ++line_index) {
             const QRegularExpressionMatch match = layer_marker.match(annotated_lines[line_index]);
             if (!match.hasMatch()) {
                 continue;
             }
 
+            bool converted = false;
+            const int layer_time_index = match.captured(1).toInt(&converted) - 1 + layer_time_offset;
+            if (!converted || layer_time_index < 0 || layer_time_index >= adjusted_layer_times.size()) {
+                continue;
+            }
+
             annotated_lines.insert(line_index + 1, layerTimeComment(meta, adjusted_layer_times[layer_time_index]));
             ++line_index;
-            ++layer_time_index;
         }
 
         if (!m_temp_gcode_output_file.resize(0) || !m_temp_gcode_output_file.seek(0)) {

--- a/src/threading/abs_slicing_thread.cpp
+++ b/src/threading/abs_slicing_thread.cpp
@@ -2,19 +2,35 @@
 
 #include <algorithm>
 #include <climits>
+#include <exception>
 #include <limits>
+#include <memory>
 
 #include <QApplication>
+#include <QStringBuilder>
+#include <QTextStream>
 #include <qdebug.h>
 #include <qfiledevice.h>
 #include <qfileinfo.h>
 #include <qhashfunctions.h>
 #include <qobject.h>
+#include <qregularexpression.h>
 #include <qsharedpointer.h>
 #include <qtmetamacros.h>
 #include <qtypes.h>
 
 #include "gcode/gcode_meta.h"
+#include "gcode/parsers/adamantine_parser.h"
+#include "gcode/parsers/aerobasic_parser.h"
+#include "gcode/parsers/arc_specialties_parser.h"
+#include "gcode/parsers/beam_parser.h"
+#include "gcode/parsers/cincinnati_parser.h"
+#include "gcode/parsers/common_parser.h"
+#include "gcode/parsers/marlin_parser.h"
+#include "gcode/parsers/mazak_parser.h"
+#include "gcode/parsers/mvp_parser.h"
+#include "gcode/parsers/siemens_parser.h"
+#include "gcode/parsers/tormach_parser.h"
 #include "gcode/writers/adamantine_writer.h"
 #include "gcode/writers/aerobasic_writer.h"
 #include "gcode/writers/aml3d_writer.h"
@@ -50,6 +66,116 @@
 #include "utilities/enums.h"
 
 namespace ORNL {
+namespace {
+GcodeMeta metaForSyntax(GcodeSyntax syntax) {
+    switch (syntax) {
+        case GcodeSyntax::kAML3D:
+            return GcodeMetaList::AML3DMeta;
+        case GcodeSyntax::kBeam:
+            return GcodeMetaList::BeamMeta;
+        case GcodeSyntax::kCincinnati:
+        case GcodeSyntax::kThermwood:
+            return GcodeMetaList::CincinnatiMeta;
+        case GcodeSyntax::kDmgDmu:
+            return GcodeMetaList::DmgDmuAndBeamMeta;
+        case GcodeSyntax::kGudel:
+            return GcodeMetaList::GudelMeta;
+        case GcodeSyntax::kHaasInch:
+            return GcodeMetaList::HaasInchMeta;
+        case GcodeSyntax::kHaasMetric:
+        case GcodeSyntax::kHaasMetricNoComments:
+        case GcodeSyntax::kOkuma:
+            return GcodeMetaList::HaasMetricMeta;
+        case GcodeSyntax::kHurco:
+            return GcodeMetaList::HurcoMeta;
+        case GcodeSyntax::kIngersoll:
+            return GcodeMetaList::IngersollMeta;
+        case GcodeSyntax::kKraussMaffei:
+            return GcodeMetaList::KraussMaffeiMeta;
+        case GcodeSyntax::kJuggerBot:
+        case GcodeSyntax::kMach4:
+        case GcodeSyntax::kMarlin:
+            return GcodeMetaList::MarlinMeta;
+        case GcodeSyntax::kRepRap:
+            return GcodeMetaList::RepRapMeta;
+        case GcodeSyntax::kMazak:
+            return GcodeMetaList::MazakMeta;
+        case GcodeSyntax::kMeld:
+            return GcodeMetaList::MeldMeta;
+        case GcodeSyntax::kMeltio:
+            return GcodeMetaList::MeltioMeta;
+        case GcodeSyntax::kMVP:
+            return GcodeMetaList::MVPMeta;
+        case GcodeSyntax::kORNLMetric:
+            return GcodeMetaList::ORNLMetricMeta;
+        case GcodeSyntax::kORNL:
+            return GcodeMetaList::ORNLMeta;
+        case GcodeSyntax::kArcSpecialties:
+            return GcodeMetaList::ArcSpecialtiesMeta;
+        case GcodeSyntax::kRomiFanuc:
+            return GcodeMetaList::RomiFanucMeta;
+        case GcodeSyntax::kSandia:
+            return GcodeMetaList::SandiaMeta;
+        case GcodeSyntax::kSiemens:
+            return GcodeMetaList::SiemensMeta;
+        case GcodeSyntax::kTormach:
+            return GcodeMetaList::TormachMeta;
+        case GcodeSyntax::kWolf:
+            return GcodeMetaList::WolfMeta;
+        case GcodeSyntax::kAeroBasic:
+            return GcodeMetaList::AeroBasicMeta;
+        case GcodeSyntax::kAdamantine:
+            return GcodeMetaList::AdamantineMeta;
+        default:
+            return GcodeMetaList::MarlinMeta;
+    }
+}
+
+std::unique_ptr<CommonParser> makeLayerTimeParser(GcodeSyntax syntax, QStringList& original_lines,
+                                                  QStringList& upper_lines) {
+    constexpr bool kAllowLayerAlter = true;
+    const GcodeMeta meta = metaForSyntax(syntax);
+
+    switch (syntax) {
+        case GcodeSyntax::kAML3D:
+            return std::make_unique<CincinnatiParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kBeam:
+            return std::make_unique<BeamParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kCincinnati:
+        case GcodeSyntax::kThermwood:
+            return std::make_unique<CincinnatiParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kKraussMaffei:
+        case GcodeSyntax::kJuggerBot:
+        case GcodeSyntax::kMach4:
+        case GcodeSyntax::kMarlin:
+        case GcodeSyntax::kRepRap:
+            return std::make_unique<MarlinParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kMazak:
+            return std::make_unique<MazakParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kMVP:
+            return std::make_unique<MVPParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kArcSpecialties:
+            return std::make_unique<ArcSpecialtiesParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kSiemens:
+            return std::make_unique<SiemensParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kTormach:
+            return std::make_unique<TormachParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kAeroBasic:
+            return std::make_unique<AeroBasicParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        case GcodeSyntax::kAdamantine:
+            return std::make_unique<AdamantineParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+        default:
+            return std::make_unique<CommonParser>(meta, kAllowLayerAlter, original_lines, upper_lines);
+    }
+}
+
+QString layerTimeComment(const GcodeMeta& meta, Time layer_time) {
+    return meta.m_comment_starting_delimiter %
+           QString("ORNL_SLICER_LAYER_TIME_ESTIMATE=%1").arg(layer_time.to(s), 0, 'f', 3) %
+           meta.m_comment_ending_delimiter;
+}
+} // namespace
+
 AbstractSlicingThread::AbstractSlicingThread(QString outputLocation, bool skipGcode)
     : QObject(), m_min(0), m_max(INT_MAX), m_should_cancel(false) {
     m_skip_gcode = skipGcode;
@@ -234,10 +360,78 @@ void AbstractSlicingThread::writeGCodeSetup() {
 }
 
 void AbstractSlicingThread::writeGCodeShutdown() {
-    QTextStream stream(&m_temp_gcode_output_file);
-    stream << m_base->writeShutdown();
-    if (m_syntax != GcodeSyntax::kMVP)
-        stream << m_base->writeSettingsFooter();
+    {
+        QTextStream stream(&m_temp_gcode_output_file);
+        stream << m_base->writeShutdown();
+        if (m_syntax != GcodeSyntax::kMVP)
+            stream << m_base->writeSettingsFooter();
+        stream.flush();
+    }
+    writeLayerTimeComments();
     m_temp_gcode_output_file.close();
+}
+
+void AbstractSlicingThread::writeLayerTimeComments() {
+    if (!GSM->getGlobal()->setting<bool>(PRS::GCode::kLayerTimeComments)) {
+        return;
+    }
+
+    const QString file_name = m_temp_gcode_output_file.fileName();
+    if (!m_temp_gcode_output_file.isOpen() || !m_temp_gcode_output_file.flush() || !m_temp_gcode_output_file.seek(0)) {
+        qWarning() << "Unable to read generated G-Code for layer time comments:" << file_name;
+        return;
+    }
+
+    QString text;
+    {
+        QTextStream in(&m_temp_gcode_output_file);
+        text = in.readAll();
+    }
+
+    try {
+        QStringList original_lines = text.split('\n');
+        QStringList upper_lines = text.toUpper().split('\n');
+
+        std::unique_ptr<CommonParser> parser = makeLayerTimeParser(m_syntax, original_lines, upper_lines);
+        parser->parseHeader();
+        parser->parseFooter();
+        parser->parseLines();
+
+        const QList<Time> adjusted_layer_times = parser->getAdjustedLayerTimes();
+        if (adjusted_layer_times.isEmpty()) {
+            return;
+        }
+
+        const GcodeMeta meta = metaForSyntax(m_syntax);
+        const QRegularExpression layer_marker("^\\s*" + QRegularExpression::escape(meta.m_comment_starting_delimiter) +
+                                                  "\\s*BEGINNING\\s+LAYER\\s*:\\s*(\\d+)\\b",
+                                              QRegularExpression::CaseInsensitiveOption);
+
+        int layer_time_index = 1;
+        QStringList annotated_lines = text.split('\n');
+        for (int line_index = 0; line_index < annotated_lines.size() && layer_time_index < adjusted_layer_times.size();
+             ++line_index) {
+            const QRegularExpressionMatch match = layer_marker.match(annotated_lines[line_index]);
+            if (!match.hasMatch()) {
+                continue;
+            }
+
+            annotated_lines.insert(line_index + 1, layerTimeComment(meta, adjusted_layer_times[layer_time_index]));
+            ++line_index;
+            ++layer_time_index;
+        }
+
+        if (!m_temp_gcode_output_file.resize(0) || !m_temp_gcode_output_file.seek(0)) {
+            qWarning() << "Unable to write generated G-Code layer time comments:" << file_name;
+            return;
+        }
+
+        QTextStream out(&m_temp_gcode_output_file);
+        out << annotated_lines.join('\n');
+        out.flush();
+    } catch (const std::exception& exception) {
+        qWarning() << "Unable to add generated G-Code layer time comments:" << exception.what();
+        return;
+    }
 }
 } // namespace ORNL

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -318,6 +318,7 @@ const QString Constants::PrinterSettings::GCode::kEnableMaterialLoad = "enable_m
 const QString Constants::PrinterSettings::GCode::kEnableWaitForUser = "enable_wait_for_user";
 const QString Constants::PrinterSettings::GCode::kEnableBoundingBox = "enable_bounding_box";
 const QString Constants::PrinterSettings::GCode::kEnableSettingsFooter = "enable_settings_footer";
+const QString Constants::PrinterSettings::GCode::kLayerTimeComments = "enable_layer_time_comments";
 const QString Constants::PrinterSettings::GCode::kStartCode = "start_code";
 const QString Constants::PrinterSettings::GCode::kLayerCodeChange = "layer_change_code";
 const QString Constants::PrinterSettings::GCode::kEndCode = "end_code";


### PR DESCRIPTION
## Summary
- add a Printer Settings -> G-Code checkbox for layer time comments
- annotate each generated `BEGINNING LAYER` marker with an adjusted layer time estimate
- reuse the existing G-code parser layer-time calculation so the emitted value matches adjusted layer-time behavior

Closes #64

## Validation
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer -j2`
- `git diff --check`