### PR TITLE
Arc Visualization Color Preference & Fix Model Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ project(
     HOMEPAGE_URL "https://github.com/ORNLSlicer/ORNLSlicer"
 )
 
+include(CTest)
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -223,7 +225,7 @@ if(WIN32)
     target_link_libraries(${PROJECT_NAME}_cli ${PROJECT_NAME}_obj)
 endif()
 
-option(ORNLSLICER_BUILD_TESTS "Build ORNLSlicer test executables" ON)
+option(ORNLSLICER_BUILD_TESTS "Build ORNLSlicer test executables" ${BUILD_TESTING})
 if(ORNLSLICER_BUILD_TESTS)
     enable_testing()
     add_executable(${PROJECT_NAME}_mesh_repair_tests tests/mesh_repair_tests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ set(ORNLSLICER_LIBRARY_DIRS ${RESULT_LIBRARY_DIRS})
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS "src/**.cpp")
 file(GLOB_RECURSE HEADERS CONFIGURE_DEPENDS "include/**.h")
 file(GLOB_RECURSE RESOURCES CONFIGURE_DEPENDS "resources/**.qrc")
+list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp")
 
 add_library(${PROJECT_NAME}_obj OBJECT)
 target_include_directories(
@@ -208,6 +209,8 @@ if(ORNLSLICER_ENABLE_UNITY_BUILD)
 endif()
 
 add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE src/main.cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated/include)
 target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_obj)
 
 if(WIN32)
@@ -215,7 +218,24 @@ if(WIN32)
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-mwindows")
 
     add_executable(${PROJECT_NAME}_cli)
+    target_sources(${PROJECT_NAME}_cli PRIVATE src/main.cpp)
+    target_include_directories(${PROJECT_NAME}_cli PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated/include)
     target_link_libraries(${PROJECT_NAME}_cli ${PROJECT_NAME}_obj)
+endif()
+
+option(ORNLSLICER_BUILD_TESTS "Build ORNLSlicer test executables" ON)
+if(ORNLSLICER_BUILD_TESTS)
+    enable_testing()
+    add_executable(${PROJECT_NAME}_mesh_repair_tests tests/mesh_repair_tests.cpp)
+    target_include_directories(
+        ${PROJECT_NAME}_mesh_repair_tests
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+            ${ORNLSLICER_INCLUDE_DIRS}
+    )
+    target_link_libraries(${PROJECT_NAME}_mesh_repair_tests PRIVATE ${PROJECT_NAME}_obj)
+    add_test(NAME mesh_repair_tests COMMAND ${PROJECT_NAME}_mesh_repair_tests)
 endif()
 
 function(CreateSettingsTarget)

--- a/include/geometry/mesh/closed_mesh.h
+++ b/include/geometry/mesh/closed_mesh.h
@@ -4,6 +4,7 @@
 
 #include <CGAL/Modifier_base.h>
 #include <CGAL/Polyhedron_incremental_builder_3.h>
+#include <QString>
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qsharedpointer.h>
@@ -26,6 +27,16 @@ namespace ORNL {
 //! \brief A class that represents a closed 3D volume
 class ClosedMesh : public MeshBase {
   public:
+    enum class RepairResult {
+        kSuccess,
+        kSkippedLargeBoundary,
+        kSkippedNonManifoldBoundary,
+        kFailedHoleFilling,
+        kFailedSelfIntersectionCheck,
+        kFailedSelfIntersectionRepair,
+        kRepairLeftOpen
+    };
+
     //! \brief Default constructor
     ClosedMesh();
 
@@ -155,11 +166,19 @@ class ClosedMesh : public MeshBase {
 
     //! \brief Attempts to clean a supplied polyhedron for closed-mesh import.
     //! \param polyhedron Candidate polyhedron to clean in place.
-    //! \return True if the cleaned polyhedron should replace the import candidate; false if callers should keep the
-    //! original mesh.
+    //! \return Repair result indicating whether the cleaned polyhedron should replace the import candidate or why
+    //! callers should keep the original mesh.
     //! \note Repair operations are expected to run on a caller-owned copy so failed repairs do not partially replace
     //! the original import geometry.
+    static RepairResult CleanPolyhedronWithStatus(MeshTypes::Polyhedron& polyhedron);
+
+    //! \brief Attempts to clean a supplied polyhedron for closed-mesh import.
+    //! \return True if the cleaned polyhedron should replace the import candidate; false if callers should keep the
+    //! original mesh.
     static bool CleanPolyhedron(MeshTypes::Polyhedron& polyhedron);
+
+    //! \brief Returns a user-facing description of a repair result.
+    static QString RepairResultDescription(RepairResult result);
 
     MeshTypes::SurfaceMesh extractUpwardFaces() override;
 

--- a/include/managers/preferences_manager.h
+++ b/include/managers/preferences_manager.h
@@ -477,6 +477,9 @@ class PreferencesManager : public QObject {
     //! \brief bool to determine if a save is necessary
     int m_dirty;
 
+    //! \brief Version of one-time visualization color migrations applied to this preferences file.
+    int m_visualization_color_migration_version;
+
     //! Std construct to make it easier to write out to json for hidden settings
     //! Construct limited to this class.  All input/output converted to Qt structures.
     std::unordered_map<std::string, std::list<std::string>> m_hidden_settings;

--- a/include/threading/gcode_loader.h
+++ b/include/threading/gcode_loader.h
@@ -107,6 +107,11 @@ class GCodeLoader : public QThread {
     //! \return color based on command type and comment keywords
     QColor determineSegmentColor(int command_id, const QString& comment);
 
+    //! \brief Checks whether a comment contains a path modifier with color precedence.
+    //! \param comment: Comment to parse
+    //! \return True when modifier coloring should not be overridden by region-specific arc colors.
+    bool containsColorPriorityModifier(const QString& comment) const;
+
     //! \brief determine display type based on comment keywords
     //! \param comment: Comment to parse
     //! \return semantic display type used for visibility and selection behavior

--- a/include/threading/gcode_loader.h
+++ b/include/threading/gcode_loader.h
@@ -101,6 +101,12 @@ class GCodeLoader : public QThread {
     //! \return color based on comment keywords
     QColor determineFontColor(const QString& comment);
 
+    //! \brief determine visualization color based on motion command and comment keywords
+    //! \param command_id: Parsed G-code motion command ID.
+    //! \param comment: Comment to parse
+    //! \return color based on command type and comment keywords
+    QColor determineSegmentColor(int command_id, const QString& comment);
+
     //! \brief determine display type based on comment keywords
     //! \param comment: Comment to parse
     //! \return semantic display type used for visibility and selection behavior

--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -768,10 +768,12 @@ enum class VisualizationColors {
     kInfill,
     kInitialStartup,
     kInset,
+    kInsetArc,
     kLaserScan,
     kLeadIn,
     kFlyingStart,
     kPerimeter,
+    kPerimeterArc,
     kPrestart,
     kRaft,
     kRadial,
@@ -806,6 +808,8 @@ inline QString VisualizationColorsName(VisualizationColors color) {
             return "InitialStartup";
         case VisualizationColors::kInset:
             return "Inset";
+        case VisualizationColors::kInsetArc:
+            return "InsetArc";
         case VisualizationColors::kLaserScan:
             return "LaserScan";
         case VisualizationColors::kLeadIn:
@@ -814,6 +818,8 @@ inline QString VisualizationColorsName(VisualizationColors color) {
             return "FlyingStart";
         case VisualizationColors::kPerimeter:
             return "Perimeter";
+        case VisualizationColors::kPerimeterArc:
+            return "PerimeterArc";
         case VisualizationColors::kPrestart:
             return "Prestart";
         case VisualizationColors::kRaft:
@@ -876,6 +882,8 @@ inline constexpr const QColor VisualizationColorsDefaults(VisualizationColors co
             return QColor(135, 222, 205, 255);
         case VisualizationColors::kInset:
             return QColor(0, 204, 255, 255);
+        case VisualizationColors::kInsetArc:
+            return QColor(102, 224, 255, 255);
         case VisualizationColors::kLaserScan:
             return QColor(90, 255, 90, 255);
         case VisualizationColors::kLeadIn:
@@ -884,6 +892,8 @@ inline constexpr const QColor VisualizationColorsDefaults(VisualizationColors co
             return QColor(120, 150, 250);
         case VisualizationColors::kPerimeter:
             return QColor(0, 0, 255, 255);
+        case VisualizationColors::kPerimeterArc:
+            return QColor(0, 85, 255, 255);
         case VisualizationColors::kPrestart:
             return QColor(204, 0, 255, 255);
         case VisualizationColors::kRaft:

--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -883,7 +883,7 @@ inline constexpr const QColor VisualizationColorsDefaults(VisualizationColors co
         case VisualizationColors::kInset:
             return QColor(0, 204, 255, 255);
         case VisualizationColors::kInsetArc:
-            return QColor(102, 224, 255, 255);
+            return QColor(0, 184, 255, 255);
         case VisualizationColors::kLaserScan:
             return QColor(90, 255, 90, 255);
         case VisualizationColors::kLeadIn:
@@ -893,7 +893,7 @@ inline constexpr const QColor VisualizationColorsDefaults(VisualizationColors co
         case VisualizationColors::kPerimeter:
             return QColor(0, 0, 255, 255);
         case VisualizationColors::kPerimeterArc:
-            return QColor(0, 85, 255, 255);
+            return QColor(32, 64, 255, 255);
         case VisualizationColors::kPrestart:
             return QColor(204, 0, 255, 255);
         case VisualizationColors::kRaft:

--- a/src/geometry/mesh/closed_mesh.cpp
+++ b/src/geometry/mesh/closed_mesh.cpp
@@ -22,6 +22,7 @@
 #include <CGAL/Polygon_mesh_processing/measure.h>
 #include <CGAL/Polygon_mesh_processing/repair.h>
 #include <CGAL/Polygon_mesh_processing/repair_degeneracies.h>
+#include <CGAL/Polygon_mesh_processing/self_intersections.h>
 #include <CGAL/Polygon_mesh_processing/transform.h>
 #include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
 #include <CGAL/Polygon_mesh_slicer.h>
@@ -74,24 +75,19 @@ std::size_t countBorderHalfedges(MeshTypes::Polyhedron& polyhedron) {
     return count;
 }
 
-bool shouldAttemptHoleFilling(MeshTypes::Polyhedron& polyhedron, std::size_t border_halfedges) {
+ClosedMesh::RepairResult holeFillingPreflightResult(MeshTypes::Polyhedron& polyhedron, std::size_t border_halfedges) {
     if (border_halfedges > kMaxBoundaryHalfedgesForHoleFilling) {
-        qWarning() << "Skipping hole filling because the mesh has" << border_halfedges
-                   << "boundary halfedges; continuing with the unrepaired mesh.";
-        return false;
+        return ClosedMesh::RepairResult::kSkippedLargeBoundary;
     }
 
-    const std::size_t max_boundary_halfedges =
-        std::max(kMaxSmallModelBoundaryHalfedgesForHoleFilling,
-                 polyhedron.size_of_facets() / kMaxBoundaryHalfedgeToFacetRatio);
+    const std::size_t max_boundary_halfedges = std::max(kMaxSmallModelBoundaryHalfedgesForHoleFilling,
+                                                        polyhedron.size_of_facets() / kMaxBoundaryHalfedgeToFacetRatio);
 
     if (border_halfedges > max_boundary_halfedges) {
-        qWarning() << "Skipping hole filling because the mesh boundary is too large for safe automatic repair; "
-                      "continuing with the unrepaired mesh.";
-        return false;
+        return ClosedMesh::RepairResult::kSkippedLargeBoundary;
     }
 
-    return true;
+    return ClosedMesh::RepairResult::kSuccess;
 }
 
 std::optional<PolyhedronHalfedgeDescriptor> firstBorderHalfedge(MeshTypes::Polyhedron& polyhedron) {
@@ -116,43 +112,39 @@ bool fillBorderHole(MeshTypes::Polyhedron& polyhedron, PolyhedronHalfedgeDescrip
     return !patch_facets.empty();
 }
 
-bool fillBorderHoles(MeshTypes::Polyhedron& polyhedron) {
+ClosedMesh::RepairResult fillBorderHoles(MeshTypes::Polyhedron& polyhedron) {
     const std::size_t border_halfedges = countBorderHalfedges(polyhedron);
-    if (!shouldAttemptHoleFilling(polyhedron, border_halfedges)) {
-        return false;
-    }
+    ClosedMesh::RepairResult preflight_result = holeFillingPreflightResult(polyhedron, border_halfedges);
+    if (preflight_result != ClosedMesh::RepairResult::kSuccess)
+        return preflight_result;
 
     std::size_t remaining_attempts = border_halfedges;
 
     while (!polyhedron.is_closed()) {
         if (remaining_attempts == 0) {
-            qWarning() << "CGAL hole filling exceeded the available boundary halfedges; continuing with the unrepaired mesh.";
-            return false;
+            return ClosedMesh::RepairResult::kFailedHoleFilling;
         }
 
         std::optional<PolyhedronHalfedgeDescriptor> border_halfedge = firstBorderHalfedge(polyhedron);
         if (!border_halfedge.has_value()) {
-            qWarning() << "CGAL hole filling found no border halfedge on an open mesh; continuing with the unrepaired mesh.";
-            return false;
+            return ClosedMesh::RepairResult::kFailedHoleFilling;
         }
 
         --remaining_attempts;
 
         try {
-            if (!fillBorderHole(polyhedron, *border_halfedge)) {
-                qWarning() << "CGAL hole filling failed; continuing with the unrepaired mesh.";
-                return false;
-            }
+            if (!fillBorderHole(polyhedron, *border_halfedge))
+                return ClosedMesh::RepairResult::kFailedHoleFilling;
         } catch (const CGAL::Failure_exception& error) {
-            qWarning() << "CGAL hole filling failed; continuing with the unrepaired mesh:" << error.what();
-            return false;
+            qWarning() << "CGAL hole filling failed:" << error.what();
+            return ClosedMesh::RepairResult::kFailedHoleFilling;
         } catch (const std::exception& error) {
-            qWarning() << "Hole filling failed; continuing with the unrepaired mesh:" << error.what();
-            return false;
+            qWarning() << "Hole filling failed:" << error.what();
+            return ClosedMesh::RepairResult::kFailedHoleFilling;
         }
     }
 
-    return true;
+    return ClosedMesh::RepairResult::kSuccess;
 }
 } // namespace
 
@@ -520,7 +512,7 @@ ClosedMesh::FacesAndVerticesFromPolyhedron(MeshTypes::Polyhedron& mesh) {
     return std::pair<QVector<MeshVertex>, QVector<MeshFace>>(mesh_vertices, mesh_faces);
 }
 
-bool ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
+ClosedMesh::RepairResult ClosedMesh::CleanPolyhedronWithStatus(MeshTypes::Polyhedron& polyhedron) {
     CGAL::Polygon_mesh_processing::remove_degenerate_faces(polyhedron);
     CGAL::Polygon_mesh_processing::remove_isolated_vertices(polyhedron);
     CGAL::Polygon_mesh_processing::remove_connected_components_of_negligible_size(polyhedron);
@@ -531,41 +523,75 @@ bool ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
         CGAL::Polygon_mesh_processing::non_manifold_vertices(polyhedron, std::back_inserter(non_manifold_vertices));
 
         if (!non_manifold_vertices.empty()) {
-            qWarning() << "Skipping hole filling because the mesh has non-manifold boundary vertices.";
-            return false;
+            return RepairResult::kSkippedNonManifoldBoundary;
         }
 
-        if (!fillBorderHoles(polyhedron))
-            return false;
+        RepairResult hole_filling_result = fillBorderHoles(polyhedron);
+        if (hole_filling_result != RepairResult::kSuccess)
+            return hole_filling_result;
     }
 
-    if (!polyhedron.is_closed()) {
-        qWarning() << "CGAL mesh repair left the mesh open; continuing with the unrepaired mesh.";
-        return false;
+    if (!polyhedron.is_closed())
+        return RepairResult::kRepairLeftOpen;
+
+    try {
+        if (!CGAL::Polygon_mesh_processing::does_self_intersect(
+                polyhedron, CGAL::parameters::vertex_point_map(get(CGAL::vertex_point, polyhedron))
+                                .geom_traits(MeshTypes::Kernel()))) {
+            return RepairResult::kSuccess;
+        }
+    } catch (const CGAL::Failure_exception& error) {
+        qWarning() << "CGAL self-intersection check failed:" << error.what();
+        return RepairResult::kFailedSelfIntersectionCheck;
+    } catch (const std::exception& error) {
+        qWarning() << "Self-intersection check failed:" << error.what();
+        return RepairResult::kFailedSelfIntersectionCheck;
     }
 
     MeshTypes::Polyhedron self_intersection_repair = polyhedron;
     try {
         if (!CGAL::Polygon_mesh_processing::experimental::autorefine_and_remove_self_intersections(
                 self_intersection_repair)) {
-            qWarning() << "CGAL could not repair all self-intersections; continuing with the unrepaired mesh.";
-            return false;
+            return RepairResult::kFailedSelfIntersectionRepair;
         }
     } catch (const CGAL::Failure_exception& error) {
-        qWarning() << "CGAL self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
-        return false;
+        qWarning() << "CGAL self-intersection repair failed:" << error.what();
+        return RepairResult::kFailedSelfIntersectionRepair;
     } catch (const std::exception& error) {
-        qWarning() << "Self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
-        return false;
+        qWarning() << "Self-intersection repair failed:" << error.what();
+        return RepairResult::kFailedSelfIntersectionRepair;
     }
     polyhedron = self_intersection_repair;
 
-    if (!polyhedron.is_closed()) {
-        qWarning() << "CGAL self-intersection repair left the mesh open; continuing with the unrepaired mesh.";
-        return false;
+    if (!polyhedron.is_closed())
+        return RepairResult::kRepairLeftOpen;
+
+    return RepairResult::kSuccess;
+}
+
+bool ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
+    return CleanPolyhedronWithStatus(polyhedron) == RepairResult::kSuccess;
+}
+
+QString ClosedMesh::RepairResultDescription(RepairResult result) {
+    switch (result) {
+        case RepairResult::kSuccess:
+            return "model repair completed successfully.";
+        case RepairResult::kSkippedLargeBoundary:
+            return "model has too much open boundary for safe automatic repair.";
+        case RepairResult::kSkippedNonManifoldBoundary:
+            return "model has non-manifold boundary vertices.";
+        case RepairResult::kFailedHoleFilling:
+            return "CGAL hole filling failed.";
+        case RepairResult::kFailedSelfIntersectionCheck:
+            return "CGAL self-intersection check failed.";
+        case RepairResult::kFailedSelfIntersectionRepair:
+            return "CGAL self-intersection repair failed.";
+        case RepairResult::kRepairLeftOpen:
+            return "model repair left the mesh open.";
     }
 
-    return true;
+    return "model repair did not complete.";
 }
 
 void ClosedMesh::convert() {

--- a/src/geometry/mesh/closed_mesh.cpp
+++ b/src/geometry/mesh/closed_mesh.cpp
@@ -5,6 +5,7 @@
 #include <exception>
 #include <iterator>
 #include <list>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -54,6 +55,64 @@
 #include "utilities/enums.h"
 
 namespace ORNL {
+namespace {
+using PolyhedronFaceDescriptor = boost::graph_traits<MeshTypes::Polyhedron>::face_descriptor;
+using PolyhedronHalfedgeDescriptor = boost::graph_traits<MeshTypes::Polyhedron>::halfedge_descriptor;
+using PolyhedronVertexDescriptor = boost::graph_traits<MeshTypes::Polyhedron>::vertex_descriptor;
+
+std::optional<PolyhedronHalfedgeDescriptor> firstBorderHalfedge(MeshTypes::Polyhedron& polyhedron) {
+    for (PolyhedronHalfedgeDescriptor h : halfedges(polyhedron)) {
+        if (CGAL::is_border(h, polyhedron))
+            return h;
+    }
+
+    return std::nullopt;
+}
+
+bool fillBorderHole(MeshTypes::Polyhedron& polyhedron, PolyhedronHalfedgeDescriptor border_halfedge) {
+    std::vector<PolyhedronFaceDescriptor> patch_facets;
+    std::vector<PolyhedronVertexDescriptor> patch_vertices;
+
+    return std::get<0>(CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole(
+        polyhedron, border_halfedge, std::back_inserter(patch_facets), std::back_inserter(patch_vertices),
+        CGAL::parameters::vertex_point_map(get(CGAL::vertex_point, polyhedron)).geom_traits(MeshTypes::Kernel())));
+}
+
+bool fillBorderHoles(MeshTypes::Polyhedron& polyhedron) {
+    std::size_t remaining_attempts = polyhedron.size_of_halfedges();
+
+    while (!polyhedron.is_closed()) {
+        if (remaining_attempts == 0) {
+            qWarning() << "CGAL hole filling exceeded the available boundary halfedges; continuing with the unrepaired mesh.";
+            return false;
+        }
+
+        std::optional<PolyhedronHalfedgeDescriptor> border_halfedge = firstBorderHalfedge(polyhedron);
+        if (!border_halfedge.has_value()) {
+            qWarning() << "CGAL hole filling found no border halfedge on an open mesh; continuing with the unrepaired mesh.";
+            return false;
+        }
+
+        --remaining_attempts;
+
+        try {
+            if (!fillBorderHole(polyhedron, *border_halfedge)) {
+                qWarning() << "CGAL hole filling failed; continuing with the unrepaired mesh.";
+                return false;
+            }
+        } catch (const CGAL::Failure_exception& error) {
+            qWarning() << "CGAL hole filling failed; continuing with the unrepaired mesh:" << error.what();
+            return false;
+        } catch (const std::exception& error) {
+            qWarning() << "Hole filling failed; continuing with the unrepaired mesh:" << error.what();
+            return false;
+        }
+    }
+
+    return true;
+}
+} // namespace
+
 ClosedMesh::ClosedMesh() : MeshBase() { m_is_closed = true; }
 
 ClosedMesh::ClosedMesh(const QVector<MeshVertex>& vertices, const QVector<MeshFace>& faces)
@@ -441,8 +500,7 @@ bool ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
 
     // If the mesh is not closed, fill holes.
     if (!polyhedron.is_closed()) {
-        typedef boost::graph_traits<MeshTypes::Polyhedron>::halfedge_descriptor halfedge_descriptor;
-        std::vector<halfedge_descriptor> non_manifold_vertices;
+        std::vector<PolyhedronHalfedgeDescriptor> non_manifold_vertices;
         CGAL::Polygon_mesh_processing::non_manifold_vertices(polyhedron, std::back_inserter(non_manifold_vertices));
 
         if (!non_manifold_vertices.empty()) {
@@ -450,20 +508,8 @@ bool ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
             return false;
         }
 
-        for (boost::graph_traits<MeshTypes::Polyhedron>::halfedge_descriptor h : halfedges(polyhedron)) {
-            if (CGAL::is_border(h, polyhedron)) {
-                std::vector<boost::graph_traits<MeshTypes::Polyhedron>::face_descriptor> patch_facets;
-                std::vector<boost::graph_traits<MeshTypes::Polyhedron>::vertex_descriptor> patch_vertices;
-                const bool success = std::get<0>(CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole(
-                    polyhedron, h, std::back_inserter(patch_facets), std::back_inserter(patch_vertices),
-                    CGAL::parameters::vertex_point_map(get(CGAL::vertex_point, polyhedron))
-                        .geom_traits(MeshTypes::Kernel())));
-                if (!success) {
-                    qWarning() << "CGAL hole filling failed; continuing with the unrepaired mesh.";
-                    return false;
-                }
-            }
-        }
+        if (!fillBorderHoles(polyhedron))
+            return false;
     }
 
     if (!polyhedron.is_closed()) {

--- a/src/geometry/mesh/closed_mesh.cpp
+++ b/src/geometry/mesh/closed_mesh.cpp
@@ -1,5 +1,6 @@
 #include "geometry/mesh/closed_mesh.h"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <exception>
@@ -58,7 +59,40 @@ namespace ORNL {
 namespace {
 using PolyhedronFaceDescriptor = boost::graph_traits<MeshTypes::Polyhedron>::face_descriptor;
 using PolyhedronHalfedgeDescriptor = boost::graph_traits<MeshTypes::Polyhedron>::halfedge_descriptor;
-using PolyhedronVertexDescriptor = boost::graph_traits<MeshTypes::Polyhedron>::vertex_descriptor;
+
+constexpr std::size_t kMaxSmallModelBoundaryHalfedgesForHoleFilling = 32;
+constexpr std::size_t kMaxBoundaryHalfedgesForHoleFilling = 512;
+constexpr std::size_t kMaxBoundaryHalfedgeToFacetRatio = 8;
+
+std::size_t countBorderHalfedges(MeshTypes::Polyhedron& polyhedron) {
+    std::size_t count = 0;
+    for (PolyhedronHalfedgeDescriptor h : halfedges(polyhedron)) {
+        if (CGAL::is_border(h, polyhedron))
+            ++count;
+    }
+
+    return count;
+}
+
+bool shouldAttemptHoleFilling(MeshTypes::Polyhedron& polyhedron, std::size_t border_halfedges) {
+    if (border_halfedges > kMaxBoundaryHalfedgesForHoleFilling) {
+        qWarning() << "Skipping hole filling because the mesh has" << border_halfedges
+                   << "boundary halfedges; continuing with the unrepaired mesh.";
+        return false;
+    }
+
+    const std::size_t max_boundary_halfedges =
+        std::max(kMaxSmallModelBoundaryHalfedgesForHoleFilling,
+                 polyhedron.size_of_facets() / kMaxBoundaryHalfedgeToFacetRatio);
+
+    if (border_halfedges > max_boundary_halfedges) {
+        qWarning() << "Skipping hole filling because the mesh boundary is too large for safe automatic repair; "
+                      "continuing with the unrepaired mesh.";
+        return false;
+    }
+
+    return true;
+}
 
 std::optional<PolyhedronHalfedgeDescriptor> firstBorderHalfedge(MeshTypes::Polyhedron& polyhedron) {
     for (PolyhedronHalfedgeDescriptor h : halfedges(polyhedron)) {
@@ -71,15 +105,24 @@ std::optional<PolyhedronHalfedgeDescriptor> firstBorderHalfedge(MeshTypes::Polyh
 
 bool fillBorderHole(MeshTypes::Polyhedron& polyhedron, PolyhedronHalfedgeDescriptor border_halfedge) {
     std::vector<PolyhedronFaceDescriptor> patch_facets;
-    std::vector<PolyhedronVertexDescriptor> patch_vertices;
 
-    return std::get<0>(CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole(
-        polyhedron, border_halfedge, std::back_inserter(patch_facets), std::back_inserter(patch_vertices),
-        CGAL::parameters::vertex_point_map(get(CGAL::vertex_point, polyhedron)).geom_traits(MeshTypes::Kernel())));
+    CGAL::Polygon_mesh_processing::triangulate_hole(
+        polyhedron, border_halfedge,
+        CGAL::parameters::face_output_iterator(std::back_inserter(patch_facets))
+            .vertex_point_map(get(CGAL::vertex_point, polyhedron))
+            .geom_traits(MeshTypes::Kernel())
+            .do_not_use_cubic_algorithm(true));
+
+    return !patch_facets.empty();
 }
 
 bool fillBorderHoles(MeshTypes::Polyhedron& polyhedron) {
-    std::size_t remaining_attempts = polyhedron.size_of_halfedges();
+    const std::size_t border_halfedges = countBorderHalfedges(polyhedron);
+    if (!shouldAttemptHoleFilling(polyhedron, border_halfedges)) {
+        return false;
+    }
+
+    std::size_t remaining_attempts = border_halfedges;
 
     while (!polyhedron.is_closed()) {
         if (remaining_attempts == 0) {
@@ -482,22 +525,6 @@ bool ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
     CGAL::Polygon_mesh_processing::remove_isolated_vertices(polyhedron);
     CGAL::Polygon_mesh_processing::remove_connected_components_of_negligible_size(polyhedron);
 
-    MeshTypes::Polyhedron self_intersection_repair = polyhedron;
-    try {
-        if (!CGAL::Polygon_mesh_processing::experimental::autorefine_and_remove_self_intersections(
-                self_intersection_repair)) {
-            qWarning() << "CGAL could not repair all self-intersections; continuing with the unrepaired mesh.";
-            return false;
-        }
-    } catch (const CGAL::Failure_exception& error) {
-        qWarning() << "CGAL self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
-        return false;
-    } catch (const std::exception& error) {
-        qWarning() << "Self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
-        return false;
-    }
-    polyhedron = self_intersection_repair;
-
     // If the mesh is not closed, fill holes.
     if (!polyhedron.is_closed()) {
         std::vector<PolyhedronHalfedgeDescriptor> non_manifold_vertices;
@@ -514,6 +541,27 @@ bool ClosedMesh::CleanPolyhedron(MeshTypes::Polyhedron& polyhedron) {
 
     if (!polyhedron.is_closed()) {
         qWarning() << "CGAL mesh repair left the mesh open; continuing with the unrepaired mesh.";
+        return false;
+    }
+
+    MeshTypes::Polyhedron self_intersection_repair = polyhedron;
+    try {
+        if (!CGAL::Polygon_mesh_processing::experimental::autorefine_and_remove_self_intersections(
+                self_intersection_repair)) {
+            qWarning() << "CGAL could not repair all self-intersections; continuing with the unrepaired mesh.";
+            return false;
+        }
+    } catch (const CGAL::Failure_exception& error) {
+        qWarning() << "CGAL self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
+        return false;
+    } catch (const std::exception& error) {
+        qWarning() << "Self-intersection repair failed; continuing with the unrepaired mesh:" << error.what();
+        return false;
+    }
+    polyhedron = self_intersection_repair;
+
+    if (!polyhedron.is_closed()) {
+        qWarning() << "CGAL self-intersection repair left the mesh open; continuing with the unrepaired mesh.";
         return false;
     }
 

--- a/src/managers/preferences_manager.cpp
+++ b/src/managers/preferences_manager.cpp
@@ -30,6 +30,9 @@
 
 namespace ORNL {
 namespace {
+constexpr int kVisualizationColorMigrationVersion = 1;
+constexpr const char* kVisualizationColorMigrationVersionKey = "visualization_color_migration_version";
+
 /*!
  * \brief Resolve a persisted visualization color name to its enum value.
  * \param name Persisted visualization color name.
@@ -130,7 +133,8 @@ PreferencesManager::PreferencesManager()
       m_warn_unsaved_project_on_close_preference(true), m_themeName(ThemeName::kLightMode),
       m_theme(static_cast<int>(m_themeName)), m_rotation_unit(RotationUnit::kPitchRollYaw), m_dirty(false),
       m_is_maximized(false), m_window_size(-1, -1), m_window_pos(-1, -1), m_use_implicit_transforms(false),
-      m_always_drop_parts(false), m_layer_lag(100), m_segment_lag(10) {
+      m_always_drop_parts(false), m_layer_lag(100), m_segment_lag(10),
+      m_visualization_color_migration_version(kVisualizationColorMigrationVersion) {
     m_hidden_settings["Printer"] = std::list<std::string>();
     m_hidden_settings["Material"] = std::list<std::string>();
     m_hidden_settings["Profile"] = std::list<std::string>();
@@ -192,7 +196,9 @@ std::map<std::string, std::string> PreferencesManager::getVisualizationHexColors
 void PreferencesManager::setDefaultVisualizationColors(
     const std::unordered_map<std::string, std::string>& visualizationColorsHex) {
     std::unordered_map<std::string, std::string> migratedVisualizationColorsHex = visualizationColorsHex;
-    if (migrateVisualizationColorDefaults(migratedVisualizationColorsHex)) {
+    if (m_visualization_color_migration_version < kVisualizationColorMigrationVersion) {
+        migrateVisualizationColorDefaults(migratedVisualizationColorsHex);
+        m_visualization_color_migration_version = kVisualizationColorMigrationVersion;
         m_dirty = true;
     }
 
@@ -290,6 +296,8 @@ void PreferencesManager::importPreferences(QString filepath) {
         if (j.contains("warn_unsaved_project_on_close"))
             setWarnUnsavedProjectOnClosePreference(j["warn_unsaved_project_on_close"]);
 
+        m_visualization_color_migration_version = j.value(kVisualizationColorMigrationVersionKey, 0);
+
         std::unordered_map<std::string, std::string> visualizationColorsHex;
         if (j.find("visualization_colors") != j.end())
             visualizationColorsHex = j.at("visualization_colors").get<std::unordered_map<std::string, std::string>>();
@@ -348,6 +356,7 @@ fifojson PreferencesManager::json() {
     j["use_implicit_transforms"] = m_use_implicit_transforms;
     j["always_drop_parts"] = m_always_drop_parts;
     j["visualization_colors"] = getVisualizationHexColors();
+    j[kVisualizationColorMigrationVersionKey] = m_visualization_color_migration_version;
     j["layer_lag"] = m_layer_lag;
     j["segment_lag"] = m_segment_lag;
 

--- a/src/managers/preferences_manager.cpp
+++ b/src/managers/preferences_manager.cpp
@@ -70,6 +70,44 @@ QColor parseVisualizationColor(const std::string& colorText, bool& valid) {
 
     return color;
 }
+
+bool visualizationColorMatches(const std::string& colorText, const QColor& expectedColor) {
+    bool validColor;
+    QColor parsedColor = parseVisualizationColor(colorText, validColor);
+    return validColor && parsedColor == expectedColor;
+}
+
+bool replaceStaleVisualizationColor(std::unordered_map<std::string, std::string>& visualizationColorsHex,
+                                    VisualizationColors color, const std::vector<QColor>& staleColors) {
+    const std::string name = VisualizationColorsName(color).toStdString();
+    auto colorIt = visualizationColorsHex.find(name);
+    if (colorIt == visualizationColorsHex.end()) {
+        return false;
+    }
+
+    for (const QColor& staleColor : staleColors) {
+        if (visualizationColorMatches(colorIt->second, staleColor)) {
+            colorIt->second = VisualizationColorsDefaults(color).name().toStdString();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool migrateVisualizationColorDefaults(std::unordered_map<std::string, std::string>& visualizationColorsHex) {
+    bool migrated = false;
+
+    // Carry forward revised arc defaults for users who ran pre-release builds with these stale values persisted.
+    migrated |= replaceStaleVisualizationColor(
+        visualizationColorsHex, VisualizationColors::kInsetArc,
+        {QColor(255, 179, 0, 255), QColor(102, 224, 255, 255)});
+    migrated |= replaceStaleVisualizationColor(
+        visualizationColorsHex, VisualizationColors::kPerimeterArc,
+        {QColor(255, 0, 204, 255), QColor(0, 85, 255, 255)});
+
+    return migrated;
+}
 } // namespace
 
 QSharedPointer<PreferencesManager> PreferencesManager::m_singleton = QSharedPointer<PreferencesManager>();
@@ -153,6 +191,11 @@ std::map<std::string, std::string> PreferencesManager::getVisualizationHexColors
 
 void PreferencesManager::setDefaultVisualizationColors(
     const std::unordered_map<std::string, std::string>& visualizationColorsHex) {
+    std::unordered_map<std::string, std::string> migratedVisualizationColorsHex = visualizationColorsHex;
+    if (migrateVisualizationColorDefaults(migratedVisualizationColorsHex)) {
+        m_dirty = true;
+    }
+
     m_visualization_qcolors.clear();
     int visualizationColorsLength = (int)VisualizationColors::Length;
     for (int i = 0; i < visualizationColorsLength; ++i) {
@@ -161,7 +204,7 @@ void PreferencesManager::setDefaultVisualizationColors(
             VisualizationColorsDefaults(colorEnum);
     }
 
-    for (const auto& color : visualizationColorsHex) {
+    for (const auto& color : migratedVisualizationColorsHex) {
         VisualizationColors colorEnum;
         if (!visualizationColorFromName(color.first, colorEnum)) {
             continue;

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -380,7 +380,7 @@ void GCodeLoader::run() {
                         line_color = fontColors[command.getComment()].foreground().color();
                     }
                     else if (!command.getComment().isEmpty()) {
-                        line_color = determineFontColor(command.getComment());
+                        line_color = determineSegmentColor(command.getCommandID(), command.getComment());
                         QTextCharFormat format;
                         format.setForeground(line_color);
                         fontColors.insert(m_original_lines[command.getLineNumber()], format);
@@ -721,6 +721,27 @@ QColor GCodeLoader::determineFontColor(const QString& comment) {
     }
 
     return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kUnknown);
+}
+
+QColor GCodeLoader::determineSegmentColor(int command_id, const QString& comment) {
+    QColor color = determineFontColor(comment);
+    if (command_id != 2 && command_id != 3) {
+        return color;
+    }
+
+    if (m_modifier_colors.contains(color)) {
+        return color;
+    }
+
+    if (m_perimeter.indexIn(comment) != -1) {
+        return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kPerimeterArc);
+    }
+
+    if (m_inset.indexIn(comment) != -1) {
+        return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kInsetArc);
+    }
+
+    return color;
 }
 
 SegmentDisplayType GCodeLoader::determineSegmentDisplayType(const QString& comment) {

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -729,7 +729,7 @@ QColor GCodeLoader::determineSegmentColor(int command_id, const QString& comment
         return color;
     }
 
-    if (m_modifier_colors.contains(color)) {
+    if (containsColorPriorityModifier(comment)) {
         return color;
     }
 
@@ -742,6 +742,16 @@ QColor GCodeLoader::determineSegmentColor(int command_id, const QString& comment
     }
 
     return color;
+}
+
+bool GCodeLoader::containsColorPriorityModifier(const QString& comment) const {
+    return m_prestart.indexIn(comment) != -1 || m_initial_startup.indexIn(comment) != -1 ||
+           m_slowdown.indexIn(comment) != -1 || m_forward_tipwipe.indexIn(comment) != -1 ||
+           m_reverse_tipwipe.indexIn(comment) != -1 || m_angled_tipwipe.indexIn(comment) != -1 ||
+           m_coasting.indexIn(comment) != -1 || m_spirallift.indexIn(comment) != -1 ||
+           m_rampingup.indexIn(comment) != -1 || m_rampingdown.indexIn(comment) != -1 ||
+           m_leadin.indexIn(comment) != -1 ||
+           comment.contains(Constants::PathModifierStrings::kPerimeterTipWipe);
 }
 
 SegmentDisplayType GCodeLoader::determineSegmentDisplayType(const QString& comment) {

--- a/src/threading/mesh_loader.cpp
+++ b/src/threading/mesh_loader.cpp
@@ -167,8 +167,25 @@ QSharedPointer<MeshBase> buildMeshFromStepSurfaceMesh(MeshTypes::SurfaceMesh& su
         MeshTypes::Polyhedron polyhedron;
         CGAL::copy_face_graph(surface_mesh, polyhedron);
 
-        if (GSM->getGlobal()->setting<bool>(PS::SpecialModes::kEnableFixModel))
-            ClosedMesh::CleanPolyhedron(polyhedron);
+        if (GSM->getGlobal()->setting<bool>(PS::SpecialModes::kEnableFixModel)) {
+            MeshTypes::Polyhedron repaired_polyhedron = polyhedron;
+            try {
+                ClosedMesh::RepairResult repair_result = ClosedMesh::CleanPolyhedronWithStatus(repaired_polyhedron);
+                if (repair_result == ClosedMesh::RepairResult::kSuccess) {
+                    polyhedron = repaired_polyhedron;
+                }
+                else {
+                    qWarning() << "Model repair did not complete for" << file_info.fileName() << "-"
+                               << ClosedMesh::RepairResultDescription(repair_result) << "Importing unrepaired mesh.";
+                }
+            } catch (const CGAL::Failure_exception& error) {
+                qWarning() << "CGAL model repair failed for" << file_info.fileName()
+                           << "- importing unrepaired mesh:" << error.what();
+            } catch (const std::exception& error) {
+                qWarning() << "Model repair failed for" << file_info.fileName()
+                           << "- importing unrepaired mesh:" << error.what();
+            }
+        }
 
         if (polyhedron.is_closed())
             mesh = QSharedPointer<ClosedMesh>::create(polyhedron, file_info.baseName(), file_info.fileName());
@@ -320,12 +337,15 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
                 if (!builder.wasError() && GSM->getGlobal()->setting<bool>(PS::SpecialModes::kEnableFixModel)) {
                     MeshTypes::Polyhedron repaired_polyhedron = polyhedron;
                     try {
-                        if (ClosedMesh::CleanPolyhedron(repaired_polyhedron)) {
+                        ClosedMesh::RepairResult repair_result =
+                            ClosedMesh::CleanPolyhedronWithStatus(repaired_polyhedron);
+                        if (repair_result == ClosedMesh::RepairResult::kSuccess) {
                             polyhedron = repaired_polyhedron;
                         }
                         else {
-                            qWarning() << "Model repair did not complete for" << file_info.fileName()
-                                       << "- importing unrepaired mesh.";
+                            qWarning() << "Model repair did not complete for" << file_info.fileName() << "-"
+                                       << ClosedMesh::RepairResultDescription(repair_result)
+                                       << "Importing unrepaired mesh.";
                         }
                     } catch (const CGAL::Failure_exception& error) {
                         qWarning() << "CGAL model repair failed for" << file_info.fileName()

--- a/tests/mesh_repair_tests.cpp
+++ b/tests/mesh_repair_tests.cpp
@@ -1,0 +1,137 @@
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <CGAL/Modifier_base.h>
+#include <CGAL/Polyhedron_incremental_builder_3.h>
+
+#include "geometry/mesh/advanced/mesh_types.h"
+#include "geometry/mesh/closed_mesh.h"
+
+namespace {
+struct Triangle {
+    int a;
+    int b;
+    int c;
+};
+
+template <class HDS> class PolyhedronBuilder : public CGAL::Modifier_base<HDS> {
+  public:
+    PolyhedronBuilder(const std::vector<ORNL::MeshTypes::Point_3>& points, const std::vector<Triangle>& triangles)
+        : m_points(points), m_triangles(triangles) {}
+
+    void operator()(HDS& hds) {
+        CGAL::Polyhedron_incremental_builder_3<HDS> builder(hds, true);
+        builder.begin_surface(m_points.size(), m_triangles.size());
+
+        for (const ORNL::MeshTypes::Point_3& point : m_points)
+            builder.add_vertex(point);
+
+        for (const Triangle& triangle : m_triangles) {
+            builder.begin_facet();
+            builder.add_vertex_to_facet(triangle.a);
+            builder.add_vertex_to_facet(triangle.b);
+            builder.add_vertex_to_facet(triangle.c);
+            builder.end_facet();
+
+            if (builder.error()) {
+                m_error = true;
+                builder.rollback();
+                return;
+            }
+        }
+
+        if (builder.error()) {
+            m_error = true;
+            builder.rollback();
+            return;
+        }
+
+        builder.end_surface();
+    }
+
+    bool wasError() const { return m_error; }
+
+  private:
+    const std::vector<ORNL::MeshTypes::Point_3>& m_points;
+    const std::vector<Triangle>& m_triangles;
+    bool m_error = false;
+};
+
+ORNL::MeshTypes::Polyhedron buildPolyhedron(const std::vector<ORNL::MeshTypes::Point_3>& points,
+                                            const std::vector<Triangle>& triangles) {
+    ORNL::MeshTypes::Polyhedron polyhedron;
+    PolyhedronBuilder<ORNL::MeshTypes::HalfedgeDescriptor> builder(points, triangles);
+    polyhedron.delegate(builder);
+
+    if (builder.wasError()) {
+        std::cerr << "Failed to build test polyhedron\n";
+        std::exit(EXIT_FAILURE);
+    }
+
+    return polyhedron;
+}
+
+ORNL::MeshTypes::Polyhedron buildLargeBoundaryOpenStrip() {
+    constexpr int strip_segments = 18;
+
+    std::vector<ORNL::MeshTypes::Point_3> points;
+    points.reserve((strip_segments + 1) * 2);
+    for (int x = 0; x <= strip_segments; ++x) {
+        points.emplace_back(x, 0, 0);
+        points.emplace_back(x, 1, 0);
+    }
+
+    std::vector<Triangle> triangles;
+    triangles.reserve(strip_segments * 2);
+    for (int x = 0; x < strip_segments; ++x) {
+        const int lower_left = x * 2;
+        const int upper_left = lower_left + 1;
+        const int lower_right = lower_left + 2;
+        const int upper_right = lower_left + 3;
+
+        triangles.push_back({lower_left, lower_right, upper_right});
+        triangles.push_back({lower_left, upper_right, upper_left});
+    }
+
+    return buildPolyhedron(points, triangles);
+}
+
+ORNL::MeshTypes::Polyhedron buildClosedTetrahedron() {
+    const std::vector<ORNL::MeshTypes::Point_3> points = {
+        ORNL::MeshTypes::Point_3(0, 0, 0), ORNL::MeshTypes::Point_3(1, 0, 0), ORNL::MeshTypes::Point_3(0, 1, 0),
+        ORNL::MeshTypes::Point_3(0, 0, 1)};
+
+    const std::vector<Triangle> triangles = {{0, 2, 1}, {0, 1, 3}, {1, 2, 3}, {2, 0, 3}};
+
+    return buildPolyhedron(points, triangles);
+}
+
+bool expect(bool condition, const std::string& message) {
+    if (condition)
+        return true;
+
+    std::cerr << message << '\n';
+    return false;
+}
+} // namespace
+
+int main() {
+    bool passed = true;
+
+    ORNL::MeshTypes::Polyhedron open_strip = buildLargeBoundaryOpenStrip();
+    ORNL::ClosedMesh::RepairResult open_result = ORNL::ClosedMesh::CleanPolyhedronWithStatus(open_strip);
+    passed &= expect(open_result == ORNL::ClosedMesh::RepairResult::kSkippedLargeBoundary,
+                     "Expected large-boundary open strip repair to be skipped.");
+    passed &= expect(!open_strip.is_closed(), "Expected skipped open strip to remain open.");
+
+    ORNL::MeshTypes::Polyhedron tetrahedron = buildClosedTetrahedron();
+    passed &= expect(tetrahedron.is_closed(), "Expected tetrahedron test fixture to start closed.");
+    ORNL::ClosedMesh::RepairResult closed_result = ORNL::ClosedMesh::CleanPolyhedronWithStatus(tetrahedron);
+    passed &= expect(closed_result == ORNL::ClosedMesh::RepairResult::kSuccess,
+                     "Expected closed tetrahedron repair to succeed.");
+    passed &= expect(tetrahedron.is_closed(), "Expected closed tetrahedron to remain closed after repair.");
+
+    return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
- Adds separate visualization color preferences for perimeter arcs and inset arcs.
- Applies those colors when loaded G-code commands are G2/G3 arc moves in perimeter or inset regions.
- Keeps modifier colors, such as tip wipe and slow down, taking precedence over arc-specific colors.

## Why
Issue #15 notes that arcs are hard to distinguish from neighboring linear segments in the G-code preview. The new preferences make arc geometry easier to identify without replacing the existing region-color scheme.

## User Impact
Users can customize `PerimeterArc` and `InsetArc` in the existing Visualization Colors preferences. The defaults stay close to the existing perimeter and inset blues while remaining visually distinct.

## Validation
- `nix develop --command cmake --build --preset debug-generic-llvm-ninja`

Closes #15