### PR TITLE
docs(wiki): link SLUG archive from legacy Home

### DIFF
--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -10,6 +10,7 @@ The canonical documentation entry point is the [Documentation Index](../README.m
 - [Relevant Papers](Relevant-Papers.md)
 - [Citation and Copyright Information](Citation-and-Copyright-Information.md)
 - [License and Library Licenses](License-and-Library-Licenses.md)
+- [SLUG Archive](SLUG.md)
 
 ## Developers
 


### PR DESCRIPTION
## Summary

- Add missing [SLUG Archive](docs/wiki/SLUG.md) entry on `docs/wiki/Home.md`
- `docs/README.md` already indexes this page under migrated wiki content; the legacy wiki home did not

## Motivation

After #214/#215, the free-file markdown/image link scan is clean. Residual inventory found one discoverability gap: `SLUG.md` is reachable from the docs index but omitted from the wiki Home listing users see first when browsing legacy content.

## Verification

- Target `docs/wiki/SLUG.md` exists (local PDFs under `docs/wiki/SLUG-2023/` referenced from that page)
- Docs-only, single-line addition

## AI disclosure

Assisted by an AI coding tool (Hermes/Sera); human-reviewed before open.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes campaign=construction-am pilot=1 -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 72h  
**Claim:** `sera` · pilot-1 construction-am