### PR TITLE
Fix consecutive point ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,17 @@ if(ORNLSLICER_BUILD_TESTS)
     )
     target_link_libraries(${PROJECT_NAME}_mesh_repair_tests PRIVATE ${PROJECT_NAME}_obj)
     add_test(NAME mesh_repair_tests COMMAND ${PROJECT_NAME}_mesh_repair_tests)
+
+    add_executable(${PROJECT_NAME}_point_order_optimizer_tests tests/point_order_optimizer_tests.cpp)
+    target_include_directories(
+        ${PROJECT_NAME}_point_order_optimizer_tests
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+            ${ORNLSLICER_INCLUDE_DIRS}
+    )
+    target_link_libraries(${PROJECT_NAME}_point_order_optimizer_tests PRIVATE ${PROJECT_NAME}_obj)
+    add_test(NAME point_order_optimizer_tests COMMAND ${PROJECT_NAME}_point_order_optimizer_tests)
 endif()
 
 function(CreateSettingsTarget)

--- a/include/optimizers/point_order_optimizer.h
+++ b/include/optimizers/point_order_optimizer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <qtypes.h>
 
 #include "geometry/point.h"
@@ -44,7 +46,8 @@ class PointOrderOptimizer {
                                            PointOrderOptimization pointOptimization, bool min_dist_enabled,
                                            Distance min_dist_threshold, Distance consecutive_dist_threshold,
                                            bool local_randomness_enable, Distance randomness_radius,
-                                           bool allow_segment_breaking = false);
+                                           bool allow_segment_breaking = false,
+                                           const std::optional<Point>& consecutive_reference = std::nullopt);
 
     //! \brief Constructor
     //! \param current_location: The current location
@@ -91,12 +94,21 @@ class PointOrderOptimizer {
     //! \return The index of the point to link to
     static int linkToRandom(const Polyline& polyline);
 
-    //! \brief Links to the next consecutive point in the polyline based on the layer number
+    //! \brief Links to the next consecutive point in the polyline based on the previous layer's start point
     //! \param polyline: The polyline to link to
     //! \param layer_number: The layer number of the current polyline
     //! \param minDist: The minimum distance the consecutive point must be from the previous layer's start point
+    //! \param previous_start: Previous layer start point, when available
+    //! \return Point selection details for rotating and optionally splitting the polyline
+    static PointOrderSelection linkToConsecutive(const Polyline& polyline, uint layer_number, Distance minDist,
+                                                 const std::optional<Point>& previous_start);
+
+    //! \brief Legacy consecutive point selection based only on layer number
+    //! \param polyline: The polyline to link to
+    //! \param layer_number: The layer number of the current polyline
+    //! \param minDist: The minimum distance to walk along the polyline
     //! \return The index of the point to link to
-    static int linkToConsecutive(const Polyline& polyline, uint layer_number, Distance minDist);
+    static int linkToConsecutiveByIndex(const Polyline& polyline, uint layer_number, Distance minDist);
 
     //! \brief Computes the perturbation of the point after the current optimization scheme is run
     //! \param polyline: The polyline to select candidates for perturbation

--- a/include/optimizers/polyline_order_optimizer.h
+++ b/include/optimizers/polyline_order_optimizer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <qcontainerfwd.h>
 #include <qsharedpointer.h>
 #include <qtypes.h>
@@ -63,6 +65,9 @@ class PolylineOrderOptimizer {
     void setPointParameters(PointOrderOptimization pointOptimization, bool minDistanceEnable,
                             Distance minDistanceThreshold, Distance consecutiveThreshold, bool randomnessEnable,
                             Distance randomnessRadius, bool enableSegmentBreaking);
+
+    //! \brief Sets the previous layer's physical start point for consecutive point ordering.
+    void setConsecutiveReferencePoint(const std::optional<Point>& point);
 
     //! \brief Gets remaining Polylines
     //! \return current Polylines remaining
@@ -215,6 +220,9 @@ class PolylineOrderOptimizer {
 
     //! \brief Override location to use for linking instead of current location (Polyline and point optimizer)
     Point m_override_location, m_point_override_location;
+
+    //! \brief Previous layer's physical start point for consecutive point ordering.
+    std::optional<Point> m_consecutive_reference_point;
 
     //! \brief Current region type for Polyline. Determines which version of link is called
     RegionType m_current_region_type;

--- a/include/step/layer/island/island_base.h
+++ b/include/step/layer/island/island_base.h
@@ -99,6 +99,10 @@ class IslandBase {
     void fitCircularArcs(const QSharedPointer<SettingsBase>& global_sb);
 
   protected:
+    //! \brief Prepares a region for optimization with layer metadata and previous-layer seam context.
+    void prepareRegionForOptimization(const QSharedPointer<RegionBase>& region, int layerNumber,
+                                      QVector<QSharedPointer<RegionBase>>& previousRegions);
+
     //! \brief Geometry of island.
     PolygonList m_geometry;
 

--- a/include/step/layer/regions/region_base.h
+++ b/include/step/layer/regions/region_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <QObject>
 #include <qcontainerfwd.h>
 #include <qtypes.h>
@@ -12,6 +14,7 @@
 #include "geometry/polygon_list.h"
 #include "geometry/settings_polygon.h"
 #include "units/unit.h"
+#include "utilities/enums.h"
 
 namespace ORNL {
 class PathOrderOptimizer;
@@ -27,12 +30,14 @@ class RegionBase {
     //! \param index: index for region order
     //! \param settings_polygons: a vector of settings polygons to apply
     RegionBase(const QSharedPointer<SettingsBase>& sb, const int index,
-               const QVector<SettingsPolygon>& settings_polygons, PolygonList uncut_geometry = PolygonList());
+               const QVector<SettingsPolygon>& settings_polygons, PolygonList uncut_geometry = PolygonList(),
+               RegionType region_type = RegionType::kUnknown);
 
     //! \brief Constructor
     //! \param sb: the settings
     //! \param settings_polygons: a vector of settings polygons to apply
-    RegionBase(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons);
+    RegionBase(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons,
+               RegionType region_type = RegionType::kUnknown);
 
     //! \brief Destructor
     virtual ~RegionBase() = default;
@@ -54,6 +59,15 @@ class RegionBase {
     //! \brief Get the paths generated from this region.
     //! \return Reference to region paths
     QVector<Path>& getPaths();
+
+    //! \brief Returns the first material-depositing start point in the region, if one exists.
+    std::optional<Point> getFirstPrintingStartPoint();
+
+    //! \brief Sets the prior layer's start point for consecutive point ordering.
+    void setPreviousLayerStartPoint(const std::optional<Point>& point);
+
+    //! \brief Gets the prior layer's start point for consecutive point ordering.
+    std::optional<Point> getPreviousLayerStartPoint() const;
 
     //! \brief Reverse path ordering in this region.
     void reversePaths();
@@ -87,6 +101,15 @@ class RegionBase {
     //! \brief return index that represents region order
     //! \return region order index
     int getIndex();
+
+    //! \brief Returns the concrete region type.
+    RegionType getRegionType() const;
+
+    //! \brief Records the layer number used for the last optimization pass.
+    void setOptimizedLayerNumber(int layer_number);
+
+    //! \brief Returns the layer number used for the last optimization pass.
+    int getOptimizedLayerNumber() const;
 
     //! \brief returns the material number of a region
     //! \return material number
@@ -146,6 +169,15 @@ class RegionBase {
 
     //! \brief Index for order
     int m_index;
+
+    //! \brief Concrete type for matching regions across layers.
+    RegionType m_region_type;
+
+    //! \brief Layer number used for the last optimization pass.
+    int m_optimized_layer_number = -1;
+
+    //! \brief Previous layer's physical start point for consecutive point ordering.
+    std::optional<Point> m_previous_layer_start_point;
 
     //! \brief Whether last region was spiralized
     bool m_was_last_region_spiral;

--- a/src/optimizers/point_order_optimizer.cpp
+++ b/src/optimizers/point_order_optimizer.cpp
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <cfloat>
+#include <cmath>
 #include <limits>
+#include <optional>
 
 #include <QRandomGenerator>
 #include <qcontainerfwd.h>
@@ -15,13 +17,51 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
+namespace {
+constexpr double kDistanceTolerance = 1.0e-6;
+
+Distance planarDistance(const Point& lhs, const Point& rhs) {
+    return Distance(std::hypot(static_cast<double>(lhs.x() - rhs.x()), static_cast<double>(lhs.y() - rhs.y())));
+}
+
+std::optional<Point> pointAtPlanarDistance(const Point& start, const Point& end, const Point& reference,
+                                           Distance distance) {
+    const double dx = static_cast<double>(end.x() - start.x());
+    const double dy = static_cast<double>(end.y() - start.y());
+    const double a = (dx * dx) + (dy * dy);
+    if (a <= kDistanceTolerance)
+        return std::nullopt;
+
+    const double fx = static_cast<double>(start.x() - reference.x());
+    const double fy = static_cast<double>(start.y() - reference.y());
+    const double b = 2.0 * ((fx * dx) + (fy * dy));
+    const double c = (fx * fx) + (fy * fy) - (distance() * distance());
+    const double discriminant = (b * b) - (4.0 * a * c);
+    if (discriminant < -kDistanceTolerance)
+        return std::nullopt;
+
+    const double root = std::sqrt(std::max(0.0, discriminant));
+    double candidates[2] = {(-b - root) / (2.0 * a), (-b + root) / (2.0 * a)};
+    std::sort(candidates, candidates + 2);
+
+    for (double t : candidates) {
+        if (t < -kDistanceTolerance || t > 1.0 + kDistanceTolerance)
+            continue;
+
+        t = std::clamp(t, 0.0, 1.0);
+        return Point(start.x() + (dx * t), start.y() + (dy * t), start.z() + ((end.z() - start.z()) * t));
+    }
+
+    return std::nullopt;
+}
+} // namespace
 
 PointOrderOptimizer::PointOrderSelection
 PointOrderOptimizer::linkToPoint(const Point& current_location, const Polyline& polyline, uint layer_number,
                                  PointOrderOptimization pointOptimization, bool min_dist_enabled,
                                  Distance min_dist_threshold, Distance consecutive_dist_threshold,
                                  bool local_randomness_enable, Distance randomness_radius,
-                                 bool allow_segment_breaking) {
+                                 bool allow_segment_breaking, const std::optional<Point>& consecutive_reference) {
     PointOrderSelection result;
 
     bool use_segment_breaking = allow_segment_breaking && polyline.size() > 1 && !min_dist_enabled &&
@@ -47,7 +87,7 @@ PointOrderOptimizer::linkToPoint(const Point& current_location, const Polyline& 
             result = selectionFromIndex(linkToRandom(polyline));
             break;
         case PointOrderOptimization::kConsecutive:
-            result = selectionFromIndex(linkToConsecutive(polyline, layer_number, consecutive_dist_threshold));
+            result = linkToConsecutive(polyline, layer_number, consecutive_dist_threshold, consecutive_reference);
             break;
         case PointOrderOptimization::kCustomPoint:
             result = selectionFromIndex(findShortestOrLongestDistance(polyline, current_location, false, Distance(0)));
@@ -61,8 +101,10 @@ PointOrderOptimizer::linkToPoint(const Point& current_location, const Polyline& 
             break;
     }
 
-    if (local_randomness_enable)
-        result = selectionFromIndex(computePerturbation(polyline, polyline[result.rotation_index], randomness_radius));
+    if (local_randomness_enable && !polyline.isEmpty()) {
+        const Point random_origin = result.insert_split_point ? result.split_point : polyline[result.rotation_index];
+        result = selectionFromIndex(computePerturbation(polyline, random_origin, randomness_radius));
+    }
 
     return result;
 }
@@ -201,12 +243,76 @@ int PointOrderOptimizer::linkToRandom(const Polyline& polyline) {
     return QRandomGenerator::global()->bounded(polyline.size());
 }
 
-int PointOrderOptimizer::linkToConsecutive(const Polyline& polyline, uint layer_number, Distance minDist) {
-    int startIndex = layer_number - 2;
+PointOrderOptimizer::PointOrderSelection
+PointOrderOptimizer::linkToConsecutive(const Polyline& polyline, uint layer_number, Distance minDist,
+                                       const std::optional<Point>& previous_start) {
+    if (polyline.isEmpty())
+        return PointOrderSelection();
+
+    if (polyline.size() == 1)
+        return selectionFromIndex(0);
+
+    if (!previous_start.has_value() || minDist <= 0)
+        return selectionFromIndex(linkToConsecutiveByIndex(polyline, layer_number, minDist));
+
+    Point reference(previous_start->x(), previous_start->y(), polyline.front().z());
+    PointOrderSelection nearest_selection = findClosestPointOnClosedLoop(polyline, reference);
+
+    Point segment_start;
+    int segment_end_index;
+    if (nearest_selection.insert_split_point) {
+        segment_start = nearest_selection.split_point;
+        segment_end_index = nearest_selection.insertion_index;
+    }
+    else {
+        const int start_index = nearest_selection.rotation_index % polyline.size();
+        segment_start = polyline[start_index];
+        segment_end_index = (start_index + 1) % polyline.size();
+    }
+
+    if (planarDistance(segment_start, reference) >= minDist)
+        return nearest_selection;
+
+    Distance farthest_distance = Distance(-1.0);
+    int farthest_index = 0;
+
+    for (int segment_count = 0; segment_count < polyline.size(); ++segment_count) {
+        const Point& segment_end = polyline[segment_end_index];
+        const Distance end_distance = planarDistance(segment_end, reference);
+
+        if (end_distance > farthest_distance) {
+            farthest_distance = end_distance;
+            farthest_index = segment_end_index;
+        }
+
+        if (end_distance >= minDist) {
+            std::optional<Point> split_point = pointAtPlanarDistance(segment_start, segment_end, reference, minDist);
+            if (split_point.has_value() && *split_point != segment_start && *split_point != segment_end) {
+                PointOrderSelection selection;
+                selection.rotation_index = segment_end_index;
+                selection.insert_split_point = true;
+                selection.split_point = *split_point;
+                selection.insertion_index = segment_end_index;
+                return selection;
+            }
+
+            return selectionFromIndex(segment_end_index);
+        }
+
+        segment_start = segment_end;
+        segment_end_index = (segment_end_index + 1) % polyline.size();
+    }
+
+    return selectionFromIndex(farthest_index);
+}
+
+int PointOrderOptimizer::linkToConsecutiveByIndex(const Polyline& polyline, uint layer_number, Distance minDist) {
+    if (polyline.isEmpty())
+        return 0;
+
+    int startIndex = (static_cast<int>(layer_number) - 2) % polyline.size();
     if (startIndex < 0)
         startIndex += polyline.size();
-    else
-        startIndex %= polyline.size();
 
     int previousIndex = startIndex;
 

--- a/src/optimizers/point_order_optimizer.cpp
+++ b/src/optimizers/point_order_optimizer.cpp
@@ -103,7 +103,9 @@ PointOrderOptimizer::linkToPoint(const Point& current_location, const Polyline& 
 
     if (local_randomness_enable && !polyline.isEmpty()) {
         const Point random_origin = result.insert_split_point ? result.split_point : polyline[result.rotation_index];
-        result = selectionFromIndex(computePerturbation(polyline, random_origin, randomness_radius));
+        const int randomized_index = computePerturbation(polyline, random_origin, randomness_radius);
+        if (randomized_index >= 0)
+            result = selectionFromIndex(randomized_index);
     }
 
     return result;
@@ -338,6 +340,9 @@ int PointOrderOptimizer::computePerturbation(const Polyline& polyline, const Poi
         if (polyline[i].distance(current_start) < radius)
             candidates.push_back(i);
     }
+
+    if (candidates.isEmpty())
+        return -1;
 
     return candidates[QRandomGenerator::global()->bounded(candidates.size())];
 }

--- a/src/optimizers/polyline_order_optimizer.cpp
+++ b/src/optimizers/polyline_order_optimizer.cpp
@@ -70,6 +70,10 @@ void PolylineOrderOptimizer::setPointParameters(PointOrderOptimization pointOpti
     m_segment_breaking_enable = enableSegmentBreaking;
 }
 
+void PolylineOrderOptimizer::setConsecutiveReferencePoint(const std::optional<Point>& point) {
+    m_consecutive_reference_point = point;
+}
+
 void PolylineOrderOptimizer::setStartOverride(Point pt) {
     m_override_location = pt;
     m_override_used = true;
@@ -262,7 +266,8 @@ Polyline PolylineOrderOptimizer::linkNextSkeletonPolyline() {
         auto pointSelection =
             PointOrderOptimizer::linkToPoint(queryPoint, new_polyline, m_layer_num, m_point_optimization,
                                              m_min_point_distance_enable, m_min_point_distance, m_consecutive_threshold,
-                                             m_randomness_enable, m_randomness_radius, m_segment_breaking_enable);
+                                             m_randomness_enable, m_randomness_radius, m_segment_breaking_enable,
+                                             m_consecutive_reference_point);
 
         applyPointOrderSelection(new_polyline, pointSelection);
 
@@ -455,7 +460,8 @@ Polyline PolylineOrderOptimizer::linkTo() {
 
     auto pointSelection = PointOrderOptimizer::linkToPoint(
         queryPoint, nextPolyline, m_layer_num, m_point_optimization, m_min_point_distance_enable, m_min_point_distance,
-        m_consecutive_threshold, m_randomness_enable, m_randomness_radius, m_segment_breaking_enable);
+        m_consecutive_threshold, m_randomness_enable, m_randomness_radius, m_segment_breaking_enable,
+        m_consecutive_reference_point);
 
     applyPointOrderSelection(nextPolyline, pointSelection);
 
@@ -594,18 +600,20 @@ Polyline PolylineOrderOptimizer::linkSpiralPolyline2D(bool last_spiral, Distance
     m_polylines.removeAt(polylineIndex);
     auto pointSelection = PointOrderOptimizer::linkToPoint(m_current_location, newPolyline, m_layer_num,
                                                            PointOrderOptimization::kNextClosest, false, 0, 0, false, 0,
-                                                           m_segment_breaking_enable);
+                                                           m_segment_breaking_enable, m_consecutive_reference_point);
 
     // Define which point to start layer one - all other layers must use next closest
     if (m_layer_num == 0) {
         if (usesCustomPointLocation(pointOrder)) {
             Point startOverride = m_point_override_location;
             pointSelection = PointOrderOptimizer::linkToPoint(startOverride, newPolyline, m_layer_num, pointOrder,
-                                                              false, 0, 0, false, 0, m_segment_breaking_enable);
+                                                              false, 0, 0, false, 0, m_segment_breaking_enable,
+                                                              m_consecutive_reference_point);
         }
         else {
             pointSelection = PointOrderOptimizer::linkToPoint(m_current_location, newPolyline, m_layer_num, pointOrder,
-                                                              false, 0, 0, false, 0, m_segment_breaking_enable);
+                                                              false, 0, 0, false, 0, m_segment_breaking_enable,
+                                                              m_consecutive_reference_point);
         }
     }
 

--- a/src/step/layer/island/brim_island.cpp
+++ b/src/step/layer/island/brim_island.cpp
@@ -25,6 +25,7 @@ void BrimIsland::optimize(int layerNumber, Point& currentLocation,
                           QVector<QSharedPointer<RegionBase>>& previousRegions) {
     bool unused = true;
     for (QSharedPointer<RegionBase> r : m_regions) {
+        prepareRegionForOptimization(r, layerNumber, previousRegions);
         r->optimize(layerNumber, currentLocation, unused);
     }
 }

--- a/src/step/layer/island/island_base.cpp
+++ b/src/step/layer/island/island_base.cpp
@@ -1,6 +1,7 @@
 #include "step/layer/island/island_base.h"
 
 #include <limits>
+#include <optional>
 #include <utility>
 
 #include <qcontainerfwd.h>
@@ -238,6 +239,27 @@ bool IslandBase::getAnyValidPaths() {
 }
 
 QVector<SettingsPolygon> IslandBase::getSettingsPolygons() { return m_settings_polygons; }
+
+void IslandBase::prepareRegionForOptimization(const QSharedPointer<RegionBase>& region, int layerNumber,
+                                              QVector<QSharedPointer<RegionBase>>& previousRegions) {
+    std::optional<Point> previous_start;
+
+    for (int i = previousRegions.size() - 1; i >= 0; --i) {
+        const QSharedPointer<RegionBase>& previous_region = previousRegions[i];
+        if (previous_region->getRegionType() != region->getRegionType())
+            continue;
+
+        if (previous_region->getOptimizedLayerNumber() >= layerNumber)
+            continue;
+
+        previous_start = previous_region->getFirstPrintingStartPoint();
+        if (previous_start.has_value())
+            break;
+    }
+
+    region->setOptimizedLayerNumber(layerNumber);
+    region->setPreviousLayerStartPoint(previous_start);
+}
 
 void IslandBase::calculateMultiMaterialTransitions(QVector<QSharedPointer<RegionBase>>& previousRegions) {
     if (previousRegions.size() > 1) {

--- a/src/step/layer/island/laser_scan_island.cpp
+++ b/src/step/layer/island/laser_scan_island.cpp
@@ -26,6 +26,7 @@ void LaserScanIsland::optimize(int layerNumber, Point& currentLocation,
                                QVector<QSharedPointer<RegionBase>>& previousRegions) {
     bool unused = true;
     for (QSharedPointer<RegionBase> r : m_regions) {
+        prepareRegionForOptimization(r, layerNumber, previousRegions);
         r->optimize(layerNumber, currentLocation, unused);
     }
 }

--- a/src/step/layer/island/polymer_island.cpp
+++ b/src/step/layer/island/polymer_island.cpp
@@ -76,6 +76,7 @@ void PolymerIsland::optimize(int layerNumber, Point& currentLocation,
             wasLastSpiral = previousRegions.last()->getSb()->setting<bool>(PS::SpecialModes::kEnableSpiralize);
 
         r->setLastSpiral(wasLastSpiral);
+        prepareRegionForOptimization(r, layerNumber, previousRegions);
 
         r->optimize(layerNumber, currentLocation, shouldNextPathBeCCW);
 

--- a/src/step/layer/island/raft_island.cpp
+++ b/src/step/layer/island/raft_island.cpp
@@ -25,6 +25,7 @@ void RaftIsland::optimize(int layerNumber, Point& currentLocation,
                           QVector<QSharedPointer<RegionBase>>& previousRegions) {
     bool unused = true;
     for (QSharedPointer<RegionBase> r : m_regions) {
+        prepareRegionForOptimization(r, layerNumber, previousRegions);
         r->optimize(layerNumber, currentLocation, unused);
     }
 }

--- a/src/step/layer/island/skirt_island.cpp
+++ b/src/step/layer/island/skirt_island.cpp
@@ -25,6 +25,7 @@ void SkirtIsland::optimize(int layerNumber, Point& currentLocation,
                            QVector<QSharedPointer<RegionBase>>& previousRegions) {
     bool unused = true;
     for (QSharedPointer<RegionBase> r : m_regions) {
+        prepareRegionForOptimization(r, layerNumber, previousRegions);
         r->optimize(layerNumber, currentLocation, unused);
     }
 }

--- a/src/step/layer/island/skirt_island.cpp
+++ b/src/step/layer/island/skirt_island.cpp
@@ -27,6 +27,9 @@ void SkirtIsland::optimize(int layerNumber, Point& currentLocation,
     for (QSharedPointer<RegionBase> r : m_regions) {
         prepareRegionForOptimization(r, layerNumber, previousRegions);
         r->optimize(layerNumber, currentLocation, unused);
+
+        if (r->getPaths().size() > 0)
+            previousRegions.push_back(r);
     }
 }
 } // namespace ORNL

--- a/src/step/layer/island/support_island.cpp
+++ b/src/step/layer/island/support_island.cpp
@@ -28,6 +28,7 @@ void SupportIsland::optimize(int layerNumber, Point& currentLocation,
                              QVector<QSharedPointer<RegionBase>>& previousRegions) {
     bool unused = true;
     for (QSharedPointer<RegionBase> r : m_regions) {
+        prepareRegionForOptimization(r, layerNumber, previousRegions);
         r->optimize(layerNumber, currentLocation, unused);
 
         if (r->getPaths().size() > 0)

--- a/src/step/layer/island/thermal_scan_island.cpp
+++ b/src/step/layer/island/thermal_scan_island.cpp
@@ -26,6 +26,7 @@ void ThermalScanIsland::optimize(int layerNumber, Point& currentLocation,
                                  QVector<QSharedPointer<RegionBase>>& previousRegions) {
     bool unused = true;
     for (QSharedPointer<RegionBase> r : m_regions) {
+        prepareRegionForOptimization(r, layerNumber, previousRegions);
         r->optimize(layerNumber, currentLocation, unused);
     }
 }

--- a/src/step/layer/regions/brim.cpp
+++ b/src/step/layer/regions/brim.cpp
@@ -26,7 +26,7 @@
 
 namespace ORNL {
 Brim::Brim(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, settings_polygons) {
+    : RegionBase(sb, settings_polygons, RegionType::kBrim) {
     // NOP
 }
 
@@ -100,6 +100,7 @@ void Brim::optimize(int layerNumber, Point& current_location, bool& shouldNextPa
                            getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
                            getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
                            getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+    poo.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
 
     m_paths.clear();
 

--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -24,7 +24,7 @@
 namespace ORNL {
 Infill::Infill(const QSharedPointer<SettingsBase>& sb, const int index,
                const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, index, settings_polygons) {
+    : RegionBase(sb, index, settings_polygons, PolygonList(), RegionType::kInfill) {
     // NOP
 }
 
@@ -179,6 +179,7 @@ void Infill::optimize(int layerNumber, Point& current_location, bool& shouldNext
                            getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
                            getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
                            getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+    poo.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
 
     for (QVector<Polyline> lines : m_computed_geometry) {
         poo.setGeometryToEvaluate(

--- a/src/step/layer/regions/inset.cpp
+++ b/src/step/layer/regions/inset.cpp
@@ -318,7 +318,7 @@ bool pointOnClosedPolylineXY(const Point& point, const Polyline& line, double to
 } // namespace
 
 Inset::Inset(const QSharedPointer<SettingsBase>& sb, const int index, const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, index, settings_polygons) {
+    : RegionBase(sb, index, settings_polygons, PolygonList(), RegionType::kInset) {
     // NOP
 }
 
@@ -444,6 +444,7 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
                                      getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
                                      getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
                                      getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+        optimizer.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
     };
 
     PolylineOrderOptimizer poo(current_location, layerNumber);

--- a/src/step/layer/regions/laser_scan.cpp
+++ b/src/step/layer/regions/laser_scan.cpp
@@ -19,7 +19,7 @@
 
 namespace ORNL {
 LaserScan::LaserScan(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, settings_polygons) {
+    : RegionBase(sb, settings_polygons, RegionType::kLaserScan) {
     // NOP
 }
 

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -345,7 +345,7 @@ bool pointOnClosedPolylineXY(const Point& point, const Polyline& line, double to
 
 Perimeter::Perimeter(const QSharedPointer<SettingsBase>& sb, const int index,
                      const QVector<SettingsPolygon>& settings_polygons, PolygonList uncut_geometry)
-    : RegionBase(sb, index, settings_polygons, uncut_geometry) {}
+    : RegionBase(sb, index, settings_polygons, uncut_geometry, RegionType::kPerimeter) {}
 
 QString Perimeter::writeGCode(QSharedPointer<WriterBase> writer) {
     QString gcode;
@@ -513,6 +513,7 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                                      getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
                                      getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
                                      getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+        optimizer.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
     };
 
     PolylineOrderOptimizer poo(current_location, layerNumber);

--- a/src/step/layer/regions/raft.cpp
+++ b/src/step/layer/regions/raft.cpp
@@ -22,7 +22,7 @@
 
 namespace ORNL {
 Raft::Raft(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, settings_polygons) {
+    : RegionBase(sb, settings_polygons, RegionType::kRaft) {
     // NOP
 }
 
@@ -79,6 +79,7 @@ void Raft::optimize(int layerNumber, Point& current_location, bool& shouldNextPa
                            getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
                            getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
                            getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+    poo.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
 
     poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kInfill,
                               static_cast<PathOrderOptimization>(m_sb->setting<int>(PS::Optimizations::kPathOrder)));

--- a/src/step/layer/regions/region_base.cpp
+++ b/src/step/layer/regions/region_base.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 
 #include <qcontainerfwd.h>
 #include <qlist.h>
@@ -21,6 +22,7 @@
 #include "units/unit.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
+#include "utilities/mathutils.h"
 
 namespace ORNL {
 namespace {
@@ -54,20 +56,54 @@ bool planarArcFittingAllowed(const QSharedPointer<SettingsBase>& global_sb) {
            std::abs(global_sb->setting<float>(PS::Slicing::kSlicePlaneNormalY)) <= kVectorTolerance &&
            std::abs(global_sb->setting<float>(PS::Slicing::kSlicePlaneNormalZ) - 1.0f) <= kVectorTolerance;
 }
+
+Point flattenIntoOptimizationFrame(const Point& point, const Plane& slicing_plane, const Point& optimization_shift) {
+    const QVector3D normal = slicing_plane.normal();
+    if (normal.isNull())
+        return point;
+
+    const QQuaternion rotation = MathUtils::CreateQuaternion(normal, QVector3D(0, 0, 1));
+    const QVector3D shifted = (point - optimization_shift).toQVector3D();
+    return Point::fromQVector3D(rotation.rotatedVector(shifted)) + optimization_shift;
+}
 } // namespace
 
 RegionBase::RegionBase(const QSharedPointer<SettingsBase>& sb, const int index,
-                       const QVector<SettingsPolygon>& settings_polygons, PolygonList uncut_geometry)
-    : m_sb(sb), m_index(index), m_settings_polygons(settings_polygons), m_uncut_geometry(uncut_geometry) {
+                       const QVector<SettingsPolygon>& settings_polygons, PolygonList uncut_geometry,
+                       RegionType region_type)
+    : m_sb(sb), m_settings_polygons(settings_polygons), m_index(index), m_region_type(region_type),
+      m_uncut_geometry(uncut_geometry) {
     // NOP
 }
 
-RegionBase::RegionBase(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons)
-    : m_sb(sb), m_settings_polygons(settings_polygons) {
+RegionBase::RegionBase(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons,
+                       RegionType region_type)
+    : m_sb(sb), m_settings_polygons(settings_polygons), m_region_type(region_type) {
     // NOP
 }
 
 QVector<Path>& RegionBase::getPaths() { return m_paths; }
+
+std::optional<Point> RegionBase::getFirstPrintingStartPoint() {
+    for (Path& path : m_paths) {
+        for (const QSharedPointer<SegmentBase>& segment : path.getSegments()) {
+            if (segment->isPrintingSegment())
+                return segment->start();
+        }
+    }
+
+    return std::nullopt;
+}
+
+void RegionBase::setPreviousLayerStartPoint(const std::optional<Point>& point) {
+    if (point.has_value())
+        m_previous_layer_start_point = flattenIntoOptimizationFrame(*point, m_optimization_slicing_plane,
+                                                                    m_optimization_shift);
+    else
+        m_previous_layer_start_point = std::nullopt;
+}
+
+std::optional<Point> RegionBase::getPreviousLayerStartPoint() const { return m_previous_layer_start_point; }
 
 void RegionBase::appendPath(const Path& path) { m_paths.append(path); }
 
@@ -113,6 +149,12 @@ void RegionBase::setGeometry(const PolygonList& geometry) { m_geometry = geometr
 void RegionBase::reversePaths() { std::reverse(m_paths.begin(), m_paths.end()); }
 
 int RegionBase::getIndex() { return m_index; }
+
+RegionType RegionBase::getRegionType() const { return m_region_type; }
+
+void RegionBase::setOptimizedLayerNumber(int layer_number) { m_optimized_layer_number = layer_number; }
+
+int RegionBase::getOptimizedLayerNumber() const { return m_optimized_layer_number; }
 
 int RegionBase::getMaterialNumber() { return m_material_number; }
 

--- a/src/step/layer/regions/skeleton.cpp
+++ b/src/step/layer/regions/skeleton.cpp
@@ -63,7 +63,7 @@ template <> struct boost::polygon::segment_traits<ORNL::Polyline> {
 namespace ORNL {
 Skeleton::Skeleton(const QSharedPointer<SettingsBase>& sb, const int index,
                    const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, index, settings_polygons) {}
+    : RegionBase(sb, index, settings_polygons, PolygonList(), RegionType::kSkeleton) {}
 
 QString Skeleton::writeGCode(QSharedPointer<WriterBase> writer) {
     QString gcode;
@@ -898,6 +898,7 @@ void Skeleton::optimize(int layerNumber, Point& current_location, bool& shouldNe
                            getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
                            getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
                            getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+    poo.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
 
     poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kSkeleton,
                               static_cast<PathOrderOptimization>(m_sb->setting<int>(PS::Optimizations::kPathOrder)));

--- a/src/step/layer/regions/skin.cpp
+++ b/src/step/layer/regions/skin.cpp
@@ -70,7 +70,7 @@ PolygonList futurePerimeterSupport(const PolygonList& current_geometry, const Po
 } // namespace
 
 Skin::Skin(const QSharedPointer<SettingsBase>& sb, const int index, const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, index, settings_polygons) {
+    : RegionBase(sb, index, settings_polygons, PolygonList(), RegionType::kSkin) {
     // NOP
 }
 
@@ -272,6 +272,7 @@ void Skin::optimize(int layerNumber, Point& current_location, bool& shouldNextPa
                            getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
                            getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
                            getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+    poo.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
 
     m_paths.clear();
     bool supportsG3 = m_sb->setting<bool>(PRS::MachineSetup::kSupportG3);

--- a/src/step/layer/regions/skirt.cpp
+++ b/src/step/layer/regions/skirt.cpp
@@ -25,7 +25,7 @@
 
 namespace ORNL {
 Skirt::Skirt(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, settings_polygons) {
+    : RegionBase(sb, settings_polygons, RegionType::kSkirt) {
     // NOP
 }
 
@@ -105,6 +105,7 @@ void Skirt::optimize(int layerNumber, Point& current_location, bool& shouldNextP
                            getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
                            getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
                            getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+    poo.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
 
     m_paths.clear();
 

--- a/src/step/layer/regions/support.cpp
+++ b/src/step/layer/regions/support.cpp
@@ -24,7 +24,7 @@
 
 namespace ORNL {
 Support::Support(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, settings_polygons) {
+    : RegionBase(sb, settings_polygons, RegionType::kSupport) {
     // NOP
 }
 
@@ -158,6 +158,7 @@ void Support::optimize(int layerNumber, Point& current_location, bool& shouldNex
                            getSb()->setting<bool>(PS::Optimizations::kLocalRandomnessEnable),
                            getSb()->setting<Distance>(PS::Optimizations::kLocalRandomnessRadius),
                            getSb()->setting<bool>(PS::Optimizations::kEnablePointOrderSegmentBreaking));
+    poo.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
 
     m_paths.clear();
 

--- a/src/step/layer/regions/thermal_scan.cpp
+++ b/src/step/layer/regions/thermal_scan.cpp
@@ -18,7 +18,7 @@
 
 namespace ORNL {
 ThermalScan::ThermalScan(const QSharedPointer<SettingsBase>& sb, const QVector<SettingsPolygon>& settings_polygons)
-    : RegionBase(sb, settings_polygons) {
+    : RegionBase(sb, settings_polygons, RegionType::kThermalScan) {
     // NOP
 }
 

--- a/tests/point_order_optimizer_tests.cpp
+++ b/tests/point_order_optimizer_tests.cpp
@@ -1,0 +1,68 @@
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+
+#include "geometry/point.h"
+#include "geometry/polyline.h"
+#include "optimizers/point_order_optimizer.h"
+#include "units/unit.h"
+#include "utilities/enums.h"
+
+namespace {
+bool expect(bool condition, const std::string& message) {
+    if (condition)
+        return true;
+
+    std::cerr << message << '\n';
+    return false;
+}
+
+bool closeTo(double lhs, double rhs) { return std::abs(lhs - rhs) <= 1.0e-5; }
+
+ORNL::Polyline squareLoop() {
+    return ORNL::Polyline {ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(10.0f, 0.0f, 0.0f),
+                           ORNL::Point(10.0f, 10.0f, 0.0f), ORNL::Point(0.0f, 10.0f, 0.0f)};
+}
+} // namespace
+
+int main() {
+    bool passed = true;
+    const ORNL::Polyline polyline = squareLoop();
+
+    const auto physical_selection = ORNL::PointOrderOptimizer::linkToPoint(
+        ORNL::Point(999.0f, 999.0f, 0.0f), polyline, 4, ORNL::PointOrderOptimization::kConsecutive, false,
+        ORNL::Distance(0.0), ORNL::Distance(5.0), false, ORNL::Distance(0.0), false,
+        std::optional<ORNL::Point>(ORNL::Point(0.0f, 0.0f, 20.0f)));
+
+    passed &= expect(physical_selection.insert_split_point,
+                     "Expected consecutive physical selection to split at the requested XY distance.");
+    passed &= expect(physical_selection.insertion_index == 1,
+                     "Expected consecutive split to be inserted before the second square vertex.");
+    passed &= expect(closeTo(physical_selection.split_point.x(), 5.0) &&
+                         closeTo(physical_selection.split_point.y(), 0.0),
+                     "Expected consecutive split point at (5, 0).");
+
+    const auto middle_reference_selection = ORNL::PointOrderOptimizer::linkToPoint(
+        ORNL::Point(999.0f, 999.0f, 0.0f), polyline, 4, ORNL::PointOrderOptimization::kConsecutive, false,
+        ORNL::Distance(0.0), ORNL::Distance(5.0), false, ORNL::Distance(0.0), false,
+        std::optional<ORNL::Point>(ORNL::Point(2.0f, 0.0f, 20.0f)));
+
+    passed &= expect(middle_reference_selection.insert_split_point,
+                     "Expected consecutive physical selection to split from a mid-edge prior start.");
+    passed &= expect(closeTo(middle_reference_selection.split_point.x(), 7.0) &&
+                         closeTo(middle_reference_selection.split_point.y(), 0.0),
+                     "Expected mid-edge consecutive split point at (7, 0).");
+
+    const auto legacy_selection = ORNL::PointOrderOptimizer::linkToPoint(
+        ORNL::Point(999.0f, 999.0f, 0.0f), polyline, 4, ORNL::PointOrderOptimization::kConsecutive, false,
+        ORNL::Distance(0.0), ORNL::Distance(5.0), false, ORNL::Distance(0.0), false);
+
+    passed &= expect(!legacy_selection.insert_split_point,
+                     "Expected legacy consecutive selection without a prior start to use an existing vertex.");
+    passed &= expect(legacy_selection.rotation_index == 3,
+                     "Expected legacy consecutive fallback to preserve layer-index selection.");
+
+    return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/point_order_optimizer_tests.cpp
+++ b/tests/point_order_optimizer_tests.cpp
@@ -44,6 +44,17 @@ int main() {
                          closeTo(physical_selection.split_point.y(), 0.0),
                      "Expected consecutive split point at (5, 0).");
 
+    const auto randomized_split_selection = ORNL::PointOrderOptimizer::linkToPoint(
+        ORNL::Point(999.0f, 999.0f, 0.0f), polyline, 4, ORNL::PointOrderOptimization::kConsecutive, false,
+        ORNL::Distance(0.0), ORNL::Distance(5.0), true, ORNL::Distance(4.0), false,
+        std::optional<ORNL::Point>(ORNL::Point(0.0f, 0.0f, 20.0f)));
+
+    passed &= expect(randomized_split_selection.insert_split_point,
+                     "Expected local randomness with no candidates to preserve the split selection.");
+    passed &= expect(closeTo(randomized_split_selection.split_point.x(), 5.0) &&
+                         closeTo(randomized_split_selection.split_point.y(), 0.0),
+                     "Expected preserved randomized split point at (5, 0).");
+
     const auto middle_reference_selection = ORNL::PointOrderOptimizer::linkToPoint(
         ORNL::Point(999.0f, 999.0f, 0.0f), polyline, 4, ORNL::PointOrderOptimization::kConsecutive, false,
         ORNL::Distance(0.0), ORNL::Distance(5.0), false, ORNL::Distance(0.0), false,


### PR DESCRIPTION
## Summary
- Fix consecutive point ordering to use the previous layer's actual physical start point instead of only the layer-derived vertex index.
- Allow closed contours to split at the exact XY threshold distance when the target falls along a segment.
- Add a focused point-order optimizer regression test and register it with CTest.

## Root Cause
The consecutive start/stop optimizer selected the next seam from `layer_number - 2` and walked along the current polyline. That made the configured threshold depend on contour index position, so similar layers could still start too close together in XY space.

## Validation
- `ctest --test-dir build/generic-llvm-ninja -C Debug -R 'mesh_repair_tests|point_order_optimizer_tests' --output-on-failure`

Fixes #10