### PR TITLE
Fix installer slicing crash after compute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CMAKE_AUTOUIC OFF)
 set(CMAKE_AUTORCC ON)
 
 include(build_info)
+set(ORNLSLICER_PACKAGE_TYPE "local" CACHE STRING "Package/distribution type reported in runtime diagnostics.")
 FetchBuildInfo()
 set(ORNLSLICER_BUILD_VERSION "${RESULT_VAR}")
 configure_file(
@@ -249,6 +250,31 @@ if(ORNLSLICER_BUILD_TESTS)
     )
     target_link_libraries(${PROJECT_NAME}_point_order_optimizer_tests PRIVATE ${PROJECT_NAME}_obj)
     add_test(NAME point_order_optimizer_tests COMMAND ${PROJECT_NAME}_point_order_optimizer_tests)
+
+    add_executable(${PROJECT_NAME}_optimizer_empty_input_tests tests/optimizer_empty_input_tests.cpp)
+    target_include_directories(
+        ${PROJECT_NAME}_optimizer_empty_input_tests
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+            ${ORNLSLICER_INCLUDE_DIRS}
+    )
+    target_link_libraries(${PROJECT_NAME}_optimizer_empty_input_tests PRIVATE ${PROJECT_NAME}_obj)
+    add_test(NAME optimizer_empty_input_tests COMMAND ${PROJECT_NAME}_optimizer_empty_input_tests)
+
+    set(ORNLSLICER_NEW_IMPACT_PROJECT "/home/rhc/develop/new-impact.s2p" CACHE FILEPATH
+        "Optional local project used for the new-impact planar slicing regression test.")
+    if(EXISTS "${ORNLSLICER_NEW_IMPACT_PROJECT}")
+        add_test(
+            NAME new_impact_project_regression
+            COMMAND
+                ${CMAKE_COMMAND}
+                -DORNLSLICER_EXECUTABLE=$<TARGET_FILE:${PROJECT_NAME}>
+                -DPROJECT_FILE=${ORNLSLICER_NEW_IMPACT_PROJECT}
+                -DOUTPUT_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/Testing/new-impact-regression/new-impact
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_project_slice_regression.cmake
+        )
+    endif()
 endif()
 
 function(CreateSettingsTarget)

--- a/cmake/build_info.cmake
+++ b/cmake/build_info.cmake
@@ -1,8 +1,25 @@
 include_guard(DIRECTORY)
 
+include(git)
 include(version)
 
 function(FetchBuildInfo)
     FetchVersion()
-    set(RESULT_VAR "${RESULT_VAR}" PARENT_SCOPE)
+    set(BUILD_INFO_VERSION "${RESULT_VAR}")
+
+    FetchRevHash()
+    set(BUILD_INFO_GIT_REVISION "${RESULT_VAR}")
+
+    if(CMAKE_CONFIGURATION_TYPES)
+        set(BUILD_INFO_CONFIGURATION "multi-config")
+    elseif(CMAKE_BUILD_TYPE)
+        set(BUILD_INFO_CONFIGURATION "${CMAKE_BUILD_TYPE}")
+    else()
+        set(BUILD_INFO_CONFIGURATION "unspecified")
+    endif()
+
+    set(RESULT_VAR "${BUILD_INFO_VERSION}" PARENT_SCOPE)
+    set(ORNLSLICER_BUILD_GIT_REVISION "${BUILD_INFO_GIT_REVISION}" PARENT_SCOPE)
+    set(ORNLSLICER_BUILD_CONFIGURATION "${BUILD_INFO_CONFIGURATION}" PARENT_SCOPE)
+    set(ORNLSLICER_PACKAGE_TYPE "${ORNLSLICER_PACKAGE_TYPE}" PARENT_SCOPE)
 endfunction()

--- a/cmake/build_info.h.in
+++ b/cmake/build_info.h.in
@@ -2,4 +2,7 @@
 
 namespace ORNL::BuildInfo {
 inline constexpr const char* Version = "@ORNLSLICER_BUILD_VERSION@";
+inline constexpr const char* GitRevision = "@ORNLSLICER_BUILD_GIT_REVISION@";
+inline constexpr const char* BuildConfiguration = "@ORNLSLICER_BUILD_CONFIGURATION@";
+inline constexpr const char* PackageType = "@ORNLSLICER_PACKAGE_TYPE@";
 }

--- a/include/threading/step_thread.h
+++ b/include/threading/step_thread.h
@@ -24,6 +24,9 @@ class StepThread : public QObject {
     //! \brief Set the step for operation.
     void setStep(const QSharedPointer<Step>& value);
 
+    //! \brief Stops the internal worker thread after any active step callback has returned.
+    void stop();
+
   public slots:
     //! \brief Perfom the computation for the step in this thread.
     void doStep();

--- a/include/utilities/runtime_diagnostics.h
+++ b/include/utilities/runtime_diagnostics.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <QString>
+
+namespace ORNL::Diagnostics {
+QString runtimeSummary(const QString& mode);
+void logLine(const QString& message);
+void logRuntimeSummary(const QString& mode);
+} // namespace ORNL::Diagnostics

--- a/src/console/command_line_processor.cpp
+++ b/src/console/command_line_processor.cpp
@@ -15,6 +15,7 @@
 #include "ornlslicer/build_info.h"
 #include "units/unit.h"
 #include "utilities/constants.h"
+#include "utilities/runtime_diagnostics.h"
 
 namespace ORNL {
 namespace {
@@ -113,7 +114,7 @@ void CommandLineConverter::setupCommandLineParser(QCommandLineParser& parser) {
 
 bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSharedPointer<SettingsBase> options) {
     if (parser.isSet(Constants::ConsoleOptionStrings::kVersion)) {
-        qInfo() << QString::fromUtf8(ORNL::BuildInfo::Version);
+        Diagnostics::logRuntimeSummary(QStringLiteral("cli-version"));
         return false;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,8 +27,10 @@
 #include "part/part.h"
 #include "threading/mesh_loader.h"
 #include "units/unit.h"
+#include "utilities/constants.h"
 #include "utilities/enums.h"
 #include "utilities/qt_json_conversion.h"
+#include "utilities/runtime_diagnostics.h"
 #include "windows/main_window.h"
 
 int main(int argc, char* argv[]) {
@@ -80,6 +82,7 @@ int main(int argc, char* argv[]) {
         bool setupResult = clc.convertOptions(parser, options);
 
         if (setupResult) {
+            ORNL::Diagnostics::logRuntimeSummary(QStringLiteral("cli"));
             ORNL::MainControl* control = new ORNL::MainControl(options);
             QObject::connect(control, &ORNL::MainControl::finished, &ca, &QCoreApplication::quit, Qt::QueuedConnection);
 
@@ -89,7 +92,7 @@ int main(int argc, char* argv[]) {
             delete control;
             return ret;
         }
-        return 1;
+        return parser.isSet(ORNL::Constants::ConsoleOptionStrings::kVersion) ? 0 : 1;
     }
     else {
         QApplication a(argc, argv);
@@ -99,6 +102,7 @@ int main(int argc, char* argv[]) {
         QApplication::setOrganizationName("ornl");
         QApplication::setApplicationVersion(QString::fromUtf8(ORNL::BuildInfo::Version));
         QApplication::setApplicationDisplayName(QString("ORNLSlicer-") + QString::fromUtf8(ORNL::BuildInfo::Version));
+        ORNL::Diagnostics::logRuntimeSummary(QStringLiteral("gui"));
 
         Q_INIT_RESOURCE(icons);
         Q_INIT_RESOURCE(shaders);

--- a/src/managers/session_manager.cpp
+++ b/src/managers/session_manager.cpp
@@ -37,6 +37,7 @@
 #include "utilities/constants.h"
 #include "utilities/enums.h"
 #include "utilities/qt_json_conversion.h"
+#include "utilities/runtime_diagnostics.h"
 #include "widgets/part_widget/model/part_meta_item.h"
 
 namespace ORNL {
@@ -550,6 +551,7 @@ bool SessionManager::doSlice() {
 
 bool SessionManager::sliceComplete() {
 
+    Diagnostics::logLine(QString("SessionManager slice complete: %1").arg(tempGcodeFile));
     emit forwardSliceComplete(tempGcodeFile, true);
     return true;
 }

--- a/src/optimizers/island_order_optimizer.cpp
+++ b/src/optimizers/island_order_optimizer.cpp
@@ -61,6 +61,9 @@ int IslandBaseOrderOptimizer::getLastIslandBaseVisited() { return m_last_island_
 int IslandBaseOrderOptimizer::getFirstIndexSelected() { return m_first_index; }
 
 int IslandBaseOrderOptimizer::computeNextIndex() {
+    if (m_island_list.isEmpty())
+        return -1;
+
     //! \note No need to optimize if we only have a single island
     if (m_island_list.size() < 2)
         return 0;
@@ -103,6 +106,9 @@ int IslandBaseOrderOptimizer::computeNextIndex() {
             break;
     }
 
+    if (index < 0 || index >= m_island_list.size())
+        return -1;
+
     m_island_list.removeAt(index);
 
     return index;
@@ -112,9 +118,15 @@ QList<QUuid> IslandBaseOrderOptimizer::computePartOrder() {
     QList<QUuid> result;
 
     while (m_part_island_list.size() > 0) {
+        if (m_island_list.isEmpty())
+            break;
+
         // make a copy of the island list to get reference to island from result of computeNext()
         QList<QSharedPointer<IslandBase>> islandSave = m_island_list;
         int index = computeNextIndex();
+        if (index < 0 || index >= islandSave.size())
+            break;
+
         QSharedPointer<IslandBase> next_island = islandSave[index];
 
         // The next part is the one who owns the next island. Save the next part to the results list
@@ -163,11 +175,16 @@ int IslandBaseOrderOptimizer::computeLeastRecentlyVisited() {
 
 int IslandBaseOrderOptimizer::extremumIslandBase(Point start_point, bool closest) {
     Distance start_point_distance = closest ? Distance(std::numeric_limits<float>::max()) : Distance(0);
-    int extremum_island_index = 0;
+    int extremum_island_index = -1;
     for (int i = 0, end = m_island_list.size(); i < end; ++i) {
         QSharedPointer<IslandBase> isl = m_island_list[i];
+        if (isl.isNull() || isl->getGeometry().isEmpty())
+            continue;
 
         Polygon polygon = isl->getGeometry()[0];
+        if (polygon.isEmpty())
+            continue;
+
         for (Point point : polygon) {
             Distance dis = point.distance(start_point);
             if (closest) {
@@ -205,8 +222,8 @@ int IslandBaseOrderOptimizer::computeExtremumDistance(bool shortest) {
         m_tsp_result = tsp.getOptimizedIslandBases();
     }
 
-    if (m_tsp_result.size() <= 0)
-        return 0;
+    if (first_island_index < 0 || m_tsp_result.size() <= 0)
+        return -1;
 
     for (int i = 0, end = m_island_list.size(); i < end; ++i) {
 
@@ -215,7 +232,7 @@ int IslandBaseOrderOptimizer::computeExtremumDistance(bool shortest) {
             return i;
         }
     }
-    return 0;
+    return -1;
 }
 
 void IslandBaseOrderOptimizer::removeValue(QVector<int>& index_list, int value) {
@@ -241,8 +258,13 @@ int IslandBaseOrderOptimizer::computeNextFarthest() {
 int IslandBaseOrderOptimizer::computeApproximate() {
     QVector<Point> center_list;
     for (QSharedPointer<IslandBase>& island : m_island_list) {
+        if (island.isNull() || island.data()->getGeometry().isEmpty())
+            continue;
+
         center_list += island.data()->getGeometry()[0].boundingRectCenter();
     }
+    if (center_list.size() != m_island_list.size())
+        return computeNextClosest();
 
     //! \note Find the minimal spanning tree, represented with an adjacency matrix
     QVector<QVector<int>> minimal_spanning_tree = minimalSpanningTree(center_list);

--- a/src/optimizers/path_order_optimizer.cpp
+++ b/src/optimizers/path_order_optimizer.cpp
@@ -42,13 +42,19 @@ void PathOrderOptimizer::setPathsToEvaluate(QVector<Path> paths) {
     for (Path& path : m_paths)
         path.removeTravels();
 
-    if (paths.size() > 0)
-        m_current_region_type = paths.front().getSegments().front()->getSb()->setting<RegionType>(SS::kRegionType);
+    for (int i = m_paths.size() - 1; i >= 0; --i) {
+        if (m_paths[i].size() == 0)
+            m_paths.removeAt(i);
+    }
+
+    if (m_paths.size() > 0 && !m_paths.front().getSegments().front().isNull())
+        m_current_region_type = m_paths.front().getSegments().front()->getSb()->setting<RegionType>(SS::kRegionType);
     else
         m_current_region_type = RegionType::kUnknown;
 
     m_has_computed_heirarchy = false;
     m_topo_level = 0;
+    m_topo_order.clear();
 }
 
 void PathOrderOptimizer::setParameters(InfillPatterns infillPattern, PolygonList border_geometry) {
@@ -119,6 +125,11 @@ Path PathOrderOptimizer::linkNextInfillPath(QVector<Path>& paths) {
             break;
     }
 
+    if (nextPath.size() == 0) {
+        m_current_location = savedLocation;
+        return nextPath;
+    }
+
     Distance minDist;
     if (nextPath.back()->getSb()->setting<RegionType>(SS::kRegionType) == RegionType::kInfill)
         minDist = m_sb->setting<Distance>(PS::Infill::kMinPathLength);
@@ -138,6 +149,9 @@ Path PathOrderOptimizer::linkNextInfillPath(QVector<Path>& paths) {
 }
 
 Path PathOrderOptimizer::linkNextInfillLines(QVector<Path>& paths) {
+    if (m_paths.isEmpty())
+        return Path();
+
     //! Gather settings for line segment links
     Distance bead_width = m_paths.front().front()->getSb()->setting<Distance>(SS::kWidth);
     Distance layer_height = m_paths.front().front()->getSb()->setting<Distance>(SS::kHeight);
@@ -148,6 +162,8 @@ Path PathOrderOptimizer::linkNextInfillLines(QVector<Path>& paths) {
     Path new_path;
     QPair<int, bool> indexAndStart = closestOpenPath(m_paths);
     int index = indexAndStart.first;
+    if (index < 0 || index >= m_paths.size())
+        return Path();
 
     // if false, indicates index is closest if you start at the end point, so reverse
     if (indexAndStart.second == false)
@@ -175,6 +191,9 @@ Path PathOrderOptimizer::linkNextInfillLines(QVector<Path>& paths) {
             if (m_paths.size() > 0) {
                 indexAndStart = closestOpenPath(m_paths);
                 index = indexAndStart.first;
+                if (index < 0 || index >= m_paths.size())
+                    break;
+
                 // if false, indicates index is closest if you start at the end point, so reverse
                 if (indexAndStart.second == false)
                     m_paths[index].reverseSegments();
@@ -238,6 +257,8 @@ Path PathOrderOptimizer::linkNextSkeletonPath() {
         QPair<int, bool> location = closestOpenPath(m_paths);
         int index = location.first;
         bool start = location.second;
+        if (index < 0 || index >= m_paths.size())
+            return new_path;
 
         new_path.setCCW(m_paths[index].getCCW());
 
@@ -282,6 +303,8 @@ Path PathOrderOptimizer::linkNextRadialPath(const Point& center) {
     QPair<int, bool> location = radialOpenPath(center);
     int index = location.first;
     bool start = location.second;
+    if (index < 0 || index >= m_paths.size())
+        return new_path;
 
     new_path.setCCW(m_paths[index].getCCW());
 
@@ -312,6 +335,9 @@ Path PathOrderOptimizer::linkNextRadialPath(const Point& center) {
 }
 
 QPair<int, bool> PathOrderOptimizer::radialOpenPath(const Point& center) {
+    if (m_paths.isEmpty())
+        return QPair<int, bool>(-1, true);
+
     PathOrderOptimization path_order =
         static_cast<PathOrderOptimization>(m_sb->setting<int>(PS::Optimizations::kPathOrder));
     Point query_point = radialPathQueryPoint(path_order);
@@ -469,10 +495,14 @@ bool PathOrderOptimizer::linkIntersects(Point link_start, Point link_end, QVecto
 }
 
 QPair<int, bool> PathOrderOptimizer::closestOpenPath(QVector<Path> paths) {
+    if (paths.isEmpty())
+        return QPair<int, bool>(-1, true);
+
     Distance shortest = Distance(std::numeric_limits<float>::max());
 
     int index = 0;
-    bool start;
+    bool start = true;
+    bool found_path = false;
 
     Point queryPoint;
     if (m_override_used)
@@ -481,18 +511,26 @@ QPair<int, bool> PathOrderOptimizer::closestOpenPath(QVector<Path> paths) {
         queryPoint = m_current_location;
 
     for (int i = 0, end = paths.size(); i < end; ++i) {
+        if (paths[i].size() == 0)
+            continue;
+
         if (queryPoint.distance(paths[i].front()->start()) < shortest) {
             shortest = queryPoint.distance(paths[i].front()->start());
             index = i;
             start = true;
+            found_path = true;
         }
 
         if (queryPoint.distance(paths[i].back()->end()) < shortest) {
             shortest = queryPoint.distance(paths[i].back()->end());
             index = i;
             start = false;
+            found_path = true;
         }
     }
+    if (!found_path)
+        return QPair<int, bool>(-1, true);
+
     return QPair<int, bool>(index, start);
 }
 
@@ -510,6 +548,9 @@ void PathOrderOptimizer::addTravel(int index, Path& path) {
 }
 
 Path PathOrderOptimizer::linkTo() {
+    if (m_paths.isEmpty())
+        return Path();
+
     int pathIndex;
     PathOrderOptimization orderOptimization =
         static_cast<PathOrderOptimization>(m_sb->setting<int>(PS::Optimizations::kPathOrder));
@@ -533,9 +574,13 @@ Path PathOrderOptimizer::linkTo() {
             pathIndex = findShortestOrLongestDistance();
             break;
     }
+    if (pathIndex < 0 || pathIndex >= m_paths.size())
+        return Path();
 
     Path nextPath = m_paths[pathIndex];
     m_paths.removeAt(pathIndex);
+    if (nextPath.size() == 0)
+        return Path();
 
     Point queryPoint;
     PointOrderOptimization pointOrderOptimization =
@@ -566,20 +611,28 @@ Path PathOrderOptimizer::linkTo() {
 }
 
 int PathOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
+    if (m_paths.isEmpty())
+        return -1;
+
     Point queryPoint;
     if (m_override_used)
         queryPoint = m_override_location;
     else
         queryPoint = m_current_location;
 
-    int pathIndex;
+    int pathIndex = -1;
     Distance closest;
     if (shortest)
         closest = Distance(DBL_MAX);
+    else
+        closest = Distance(0);
 
     for (int i = 0, end = m_paths.size(); i < end; ++i) {
         for (int j = 0, end2 = m_paths[i].size(); j < end2; ++j) {
             QSharedPointer<SegmentBase> seg = m_paths[i][j];
+            if (seg.isNull())
+                continue;
+
             Distance closestSegment = MathUtils::distanceFromLineSegSqrd(queryPoint, seg->start(), seg->end());
             if (shortest) {
                 if (closestSegment < closest) {
@@ -599,9 +652,17 @@ int PathOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
     return pathIndex;
 }
 
-int PathOrderOptimizer::linkToRandom() { return QRandomGenerator::global()->bounded(m_paths.size()); }
+int PathOrderOptimizer::linkToRandom() {
+    if (m_paths.isEmpty())
+        return -1;
+
+    return QRandomGenerator::global()->bounded(m_paths.size());
+}
 
 int PathOrderOptimizer::findInteriorExterior(bool ExtToInt) {
+    if (m_paths.isEmpty())
+        return -1;
+
     if (!m_has_computed_heirarchy && m_paths.size() > 0) {
         QSharedPointer<TopologicalNode> root = computeTopologicalHeirarchy();
         // inOrderTraversal(root);
@@ -611,6 +672,9 @@ int PathOrderOptimizer::findInteriorExterior(bool ExtToInt) {
 
         m_has_computed_heirarchy = true;
     }
+
+    if (m_topo_order.isEmpty() || m_topo_order.first().isEmpty())
+        return findShortestOrLongestDistance();
 
     int result = m_topo_order.first().first();
     m_topo_order.first().pop_front();
@@ -630,13 +694,19 @@ QSharedPointer<PathOrderOptimizer::TopologicalNode> PathOrderOptimizer::computeT
     all_nodes.reserve(m_paths.size());
 
     for (int i = 0, end = m_paths.size(); i < end; ++i) {
+        if (m_paths[i].size() == 0)
+            continue;
+
         Polygon poly;
         poly.reserve(m_paths[i].size());
         for (QSharedPointer<SegmentBase> seg : m_paths[i].getSegments())
             poly.push_back(Point(seg->start()));
 
-        all_nodes.push_back(QSharedPointer<TopologicalNode>::create(TopologicalNode(i, poly)));
+        if (!poly.isEmpty())
+            all_nodes.push_back(QSharedPointer<TopologicalNode>::create(TopologicalNode(i, poly)));
     }
+    if (all_nodes.isEmpty())
+        return QSharedPointer<TopologicalNode>();
 
     // assume first path is outer contour
     QSharedPointer<TopologicalNode> root;
@@ -675,6 +745,9 @@ void PathOrderOptimizer::insert(QSharedPointer<TopologicalNode> root, QSharedPoi
 }
 
 void PathOrderOptimizer::levelOrder(QSharedPointer<TopologicalNode> root) {
+    if (root.isNull())
+        return;
+
     if (m_topo_order.size() == m_topo_level)
         m_topo_order.push_back({root->m_path_index});
     else
@@ -690,6 +763,9 @@ void PathOrderOptimizer::levelOrder(QSharedPointer<TopologicalNode> root) {
 
 Path PathOrderOptimizer::linkSpiralPath2D(bool last_spiral) {
     int pathIndex = findShortestOrLongestDistance();
+    if (pathIndex < 0 || pathIndex >= m_paths.size())
+        return Path();
+
     Path newPath = m_paths[pathIndex];
     m_paths.removeAt(pathIndex);
 

--- a/src/optimizers/path_order_optimizer.cpp
+++ b/src/optimizers/path_order_optimizer.cpp
@@ -1,7 +1,6 @@
 #include "optimizers/path_order_optimizer.h"
 
 #include <algorithm>
-#include <cfloat>
 #include <cmath>
 #include <limits>
 
@@ -621,11 +620,7 @@ int PathOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
         queryPoint = m_current_location;
 
     int pathIndex = -1;
-    Distance closest;
-    if (shortest)
-        closest = Distance(DBL_MAX);
-    else
-        closest = Distance(0);
+    Distance selected_distance;
 
     for (int i = 0, end = m_paths.size(); i < end; ++i) {
         for (int j = 0, end2 = m_paths[i].size(); j < end2; ++j) {
@@ -634,17 +629,10 @@ int PathOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
                 continue;
 
             Distance closestSegment = MathUtils::distanceFromLineSegSqrd(queryPoint, seg->start(), seg->end());
-            if (shortest) {
-                if (closestSegment < closest) {
-                    closest = closestSegment;
-                    pathIndex = i;
-                }
-            }
-            else {
-                if (closestSegment > closest) {
-                    closest = closestSegment;
-                    pathIndex = i;
-                }
+            if (pathIndex < 0 || (shortest && closestSegment < selected_distance) ||
+                (!shortest && closestSegment > selected_distance)) {
+                selected_distance = closestSegment;
+                pathIndex = i;
             }
         }
     }

--- a/src/optimizers/polyline_order_optimizer.cpp
+++ b/src/optimizers/polyline_order_optimizer.cpp
@@ -32,10 +32,16 @@ int PolylineOrderOptimizer::getCurrentPolylineCount() { return m_polylines.size(
 void PolylineOrderOptimizer::setGeometryToEvaluate(QVector<Polyline> polylines, RegionType type,
                                                    PathOrderOptimization optimization) {
     m_polylines = polylines;
+    for (int i = m_polylines.size() - 1; i >= 0; --i) {
+        if (m_polylines[i].size() < 2)
+            m_polylines.removeAt(i);
+    }
+
     m_current_region_type = type;
     m_optimization = optimization;
     m_has_computed_heirarchy = false;
     m_topo_level = 0;
+    m_topo_order.clear();
     m_open_path_selection_count = 0;
 }
 
@@ -159,6 +165,8 @@ Polyline PolylineOrderOptimizer::linkNextInfillLines(QVector<Polyline>& polyline
                 closestOpenPolyline({m_polylines.front(), m_polylines.back()}, temp_current_location);
             index = (endpoint_index == 0) ? 0 : (m_polylines.size() - 1);
         }
+        if (index < 0 || index >= m_polylines.size())
+            return new_polyline;
 
         // if false, indicates index is closest if you start at the end point, so reverse
         if (start == false) {
@@ -175,6 +183,8 @@ Polyline PolylineOrderOptimizer::linkNextInfillLines(QVector<Polyline>& polyline
         for (int i = 0, end = m_polylines.size(); i < end; ++i) {
             if (m_polylines.size() > 0) {
                 const auto& [index, start] = closestOpenPolyline(m_polylines, temp_current_location);
+                if (index < 0 || index >= m_polylines.size())
+                    break;
 
                 // if false, indicates index is closest if you start at the end point, so reverse
                 if (start == false) {
@@ -244,6 +254,8 @@ Polyline PolylineOrderOptimizer::linkNextSkeletonPolyline() {
     Polyline new_polyline;
     if (!m_polylines.isEmpty()) {
         const auto& [index, start] = closestOpenPolyline(m_polylines, m_current_location);
+        if (index < 0 || index >= m_polylines.size())
+            return new_polyline;
 
         new_polyline = m_polylines[index];
         if (!start) {
@@ -257,6 +269,9 @@ Polyline PolylineOrderOptimizer::linkNextSkeletonPolyline() {
         queryPoint = m_point_override_location;
     else
         queryPoint = m_current_location;
+
+    if (new_polyline.isEmpty())
+        return new_polyline;
 
     // If polyline is closed loop, apply point optimization strategies for a closed-loop path not a skeleton
     if (new_polyline.front() == new_polyline.back()) {
@@ -334,6 +349,9 @@ QPair<int, bool> PolylineOrderOptimizer::closestOpenPolyline(QVector<Polyline> p
 
 QPair<int, bool> PolylineOrderOptimizer::extremumOpenPolyline(QVector<Polyline> polylines, Point currentLocation,
                                                               bool closest) {
+    if (polylines.isEmpty())
+        return QPair<int, bool>(-1, true);
+
     Distance selected_distance;
 
     int index = 0;
@@ -362,6 +380,9 @@ QPair<int, bool> PolylineOrderOptimizer::extremumOpenPolyline(QVector<Polyline> 
 }
 
 QPair<int, bool> PolylineOrderOptimizer::orderedOpenPolyline(QVector<Polyline> polylines, Point currentLocation) {
+    if (polylines.isEmpty())
+        return QPair<int, bool>(-1, true);
+
     Point query_point = currentLocation;
     if (m_optimization == PathOrderOptimization::kCustomPoint && m_override_used)
         query_point = m_override_location;
@@ -427,6 +448,9 @@ void PolylineOrderOptimizer::applyPointOrderSelection(Polyline& polyline,
 }
 
 Polyline PolylineOrderOptimizer::linkTo() {
+    if (m_polylines.isEmpty())
+        return Polyline();
+
     int polylineIndex;
     switch (m_optimization) {
         case PathOrderOptimization::kNextClosest:
@@ -448,9 +472,13 @@ Polyline PolylineOrderOptimizer::linkTo() {
             polylineIndex = findShortestOrLongestDistance();
             break;
     }
+    if (polylineIndex < 0 || polylineIndex >= m_polylines.size())
+        return Polyline();
 
     Polyline nextPolyline = m_polylines[polylineIndex];
     m_polylines.removeAt(polylineIndex);
+    if (nextPolyline.size() < 2)
+        return Polyline();
 
     Point queryPoint;
     if (usesCustomPointLocation(m_point_optimization))
@@ -469,16 +497,21 @@ Polyline PolylineOrderOptimizer::linkTo() {
 }
 
 int PolylineOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
+    if (m_polylines.isEmpty())
+        return -1;
+
     Point queryPoint;
     if (m_optimization == PathOrderOptimization::kCustomPoint && m_override_used)
         queryPoint = m_override_location;
     else
         queryPoint = m_current_location;
 
-    int polylineIndex;
+    int polylineIndex = -1;
     Distance closest;
     if (shortest)
         closest = Distance(DBL_MAX);
+    else
+        closest = Distance(0);
 
     for (int i = 0, end = m_polylines.size(); i < end; ++i) {
         if (m_polylines[i].size() < 2)
@@ -506,9 +539,17 @@ int PolylineOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
     return polylineIndex;
 }
 
-int PolylineOrderOptimizer::linkToRandom() { return QRandomGenerator::global()->bounded(m_polylines.size()); }
+int PolylineOrderOptimizer::linkToRandom() {
+    if (m_polylines.isEmpty())
+        return -1;
+
+    return QRandomGenerator::global()->bounded(m_polylines.size());
+}
 
 int PolylineOrderOptimizer::findInteriorExterior(bool ExtToInt) {
+    if (m_polylines.isEmpty())
+        return -1;
+
     if (!m_has_computed_heirarchy && m_polylines.size() > 0) {
         QSharedPointer<TopologicalNode> root = computeTopologicalHeirarchy();
         // inOrderTraversal(root);
@@ -522,6 +563,9 @@ int PolylineOrderOptimizer::findInteriorExterior(bool ExtToInt) {
 
         m_has_computed_heirarchy = true;
     }
+
+    if (m_topo_order.isEmpty() || m_topo_order.first().isEmpty())
+        return findShortestOrLongestDistance();
 
     int result = m_topo_order.first().first();
     m_topo_order.first().pop_front();
@@ -540,8 +584,14 @@ QSharedPointer<PolylineOrderOptimizer::TopologicalNode> PolylineOrderOptimizer::
     QVector<QSharedPointer<TopologicalNode>> all_nodes;
     all_nodes.reserve(m_polylines.size());
 
-    for (int i = 0, end = m_polylines.size(); i < end; ++i)
+    for (int i = 0, end = m_polylines.size(); i < end; ++i) {
+        if (m_polylines[i].size() < 2)
+            continue;
+
         all_nodes.push_back(QSharedPointer<TopologicalNode>::create(TopologicalNode(i, m_polylines[i])));
+    }
+    if (all_nodes.isEmpty())
+        return QSharedPointer<TopologicalNode>();
 
     // assume first Polyline is outer contour
     QSharedPointer<TopologicalNode> root;
@@ -580,6 +630,9 @@ void PolylineOrderOptimizer::insert(QSharedPointer<TopologicalNode> root, QShare
 }
 
 void PolylineOrderOptimizer::levelOrder(QSharedPointer<TopologicalNode> root) {
+    if (root.isNull())
+        return;
+
     if (m_topo_order.size() == m_topo_level)
         m_topo_order.push_back({root->m_Polyline_index});
     else
@@ -596,6 +649,9 @@ void PolylineOrderOptimizer::levelOrder(QSharedPointer<TopologicalNode> root) {
 Polyline PolylineOrderOptimizer::linkSpiralPolyline2D(bool last_spiral, Distance layerHeight,
                                                       PointOrderOptimization pointOrder) {
     int polylineIndex = findShortestOrLongestDistance();
+    if (polylineIndex < 0 || polylineIndex >= m_polylines.size())
+        return Polyline();
+
     Polyline newPolyline = m_polylines[polylineIndex];
     m_polylines.removeAt(polylineIndex);
     auto pointSelection = PointOrderOptimizer::linkToPoint(m_current_location, newPolyline, m_layer_num,

--- a/src/optimizers/polyline_order_optimizer.cpp
+++ b/src/optimizers/polyline_order_optimizer.cpp
@@ -1,7 +1,6 @@
 #include "optimizers/polyline_order_optimizer.h"
 
 #include <algorithm>
-#include <cfloat>
 #include <tuple>
 
 #include <QRandomGenerator>
@@ -507,11 +506,7 @@ int PolylineOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
         queryPoint = m_current_location;
 
     int polylineIndex = -1;
-    Distance closest;
-    if (shortest)
-        closest = Distance(DBL_MAX);
-    else
-        closest = Distance(0);
+    Distance selected_distance;
 
     for (int i = 0, end = m_polylines.size(); i < end; ++i) {
         if (m_polylines[i].size() < 2)
@@ -521,17 +516,10 @@ int PolylineOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
             int next_index = (j + 1) % m_polylines[i].size();
             Distance closestSegment =
                 MathUtils::distanceFromLineSegSqrd(queryPoint, m_polylines[i][j], m_polylines[i][next_index]);
-            if (shortest) {
-                if (closestSegment < closest) {
-                    closest = closestSegment;
-                    polylineIndex = i;
-                }
-            }
-            else {
-                if (closestSegment > closest) {
-                    closest = closestSegment;
-                    polylineIndex = i;
-                }
+            if (polylineIndex < 0 || (shortest && closestSegment < selected_distance) ||
+                (!shortest && closestSegment > selected_distance)) {
+                selected_distance = closestSegment;
+                polylineIndex = i;
             }
         }
     }

--- a/src/step/global_layer.cpp
+++ b/src/step/global_layer.cpp
@@ -7,6 +7,7 @@
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlist.h>
+#include <qlogging.h>
 #include <qmap.h>
 #include <qsharedpointer.h>
 #include <quuid.h>
@@ -38,6 +39,9 @@ void GlobalLayer::unorient() {
     QMap<QUuid, QSharedPointer<Part::StepPair>>::ConstIterator itr;
     for (itr = m_step_pairs.constBegin(); itr != m_step_pairs.constEnd(); ++itr) {
         auto step_pair = itr.value();
+        if (step_pair.isNull() || step_pair->printing_layer.isNull())
+            continue;
+
         step_pair->printing_layer->unorient();
     }
 }
@@ -46,6 +50,9 @@ void GlobalLayer::reorient() {
     QMap<QUuid, QSharedPointer<Part::StepPair>>::ConstIterator itr;
     for (itr = m_step_pairs.constBegin(); itr != m_step_pairs.constEnd(); ++itr) {
         auto step_pair = itr.value();
+        if (step_pair.isNull() || step_pair->printing_layer.isNull())
+            continue;
+
         step_pair->printing_layer->reorient();
     }
 }
@@ -53,48 +60,56 @@ void GlobalLayer::reorient() {
 void GlobalLayer::calculateModifiers(QSharedPointer<SettingsBase> global_sb, Point& current_location, int layer_num) {
     if (!m_island_order.isEmpty()) {
         QSharedPointer<IslandBase> firstIsland = m_island_order.front();
+        if (!firstIsland.isNull() && !firstIsland->getRegions().isEmpty()) {
+            // Retrieve relevant settings
+            bool perimeter_enabled = firstIsland->getSb()->setting<bool>(PS::Perimeter::kEnable);
+            bool perimeter_lead_in_enabled = firstIsland->getSb()->setting<bool>(PS::Perimeter::kEnableLeadIn);
+            bool perimeter_lead_in_first_layer_only = global_sb->setting<bool>(PS::Perimeter::kLeadInFirstLayerOnly);
 
-        // Retrieve relevant settings
-        bool perimeter_enabled = firstIsland->getSb()->setting<bool>(PS::Perimeter::kEnable);
-        bool perimeter_lead_in_enabled = firstIsland->getSb()->setting<bool>(PS::Perimeter::kEnableLeadIn);
-        bool perimeter_lead_in_first_layer_only = global_sb->setting<bool>(PS::Perimeter::kLeadInFirstLayerOnly);
+            if (perimeter_enabled && perimeter_lead_in_enabled &&
+                (layer_num == 0 || !perimeter_lead_in_first_layer_only)) {
+                Point leadIn = Point(firstIsland->getSb()->setting<Distance>(PS::Perimeter::kEnableLeadInX),
+                                     firstIsland->getSb()->setting<Distance>(PS::Perimeter::kEnableLeadInY), 0.0);
 
-        if (perimeter_enabled && perimeter_lead_in_enabled && (layer_num == 0 || !perimeter_lead_in_first_layer_only)) {
-            Point leadIn = Point(firstIsland->getSb()->setting<Distance>(PS::Perimeter::kEnableLeadInX),
-                                 firstIsland->getSb()->setting<Distance>(PS::Perimeter::kEnableLeadInY), 0.0);
-
-            Q_ASSERT(firstIsland->getType() == IslandType::kPolymer);
-            QSharedPointer<RegionBase> firstRegion = (firstIsland->getRegions()).front();
-
-            PathModifierGenerator::GenerateLayerLeadIn(firstRegion->getPaths().front(), leadIn, global_sb);
-        }
-    }
-
-    if (global_sb->setting<bool>(MS::SpiralLift::kLayerEnable)) {
-        if (!m_island_order.isEmpty()) {
-            auto lastIsland = m_island_order.back();
-
-            Q_ASSERT(lastIsland->getType() == IslandType::kPolymer);
-            QList<QSharedPointer<RegionBase>> regions = lastIsland->getRegions();
-            QSharedPointer<RegionBase> lastRegion = regions.back();
-            Path finalPath = lastRegion->getPaths().back();
-
-            if (finalPath.back()->getSb()->setting<PathModifiers>(SS::kPathModifiers) != PathModifiers::kSpiralLift) {
-                PathModifierGenerator::GenerateSpiralLift(finalPath,
-                                                          global_sb->setting<Distance>(MS::SpiralLift::kLiftRadius),
-                                                          global_sb->setting<Distance>(MS::SpiralLift::kLiftHeight),
-                                                          global_sb->setting<int>(MS::SpiralLift::kLiftPoints),
-                                                          global_sb->setting<Velocity>(MS::SpiralLift::kLiftSpeed),
-                                                          global_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
-
-                // move current location to the end of the spiral lift
-                current_location = getIslands().last()->getRegions().last()->getPaths().last().back()->end();
+                Q_ASSERT(firstIsland->getType() == IslandType::kPolymer);
+                QSharedPointer<RegionBase> firstRegion = (firstIsland->getRegions()).front();
+                if (!firstRegion.isNull() && !firstRegion->getPaths().isEmpty() &&
+                    firstRegion->getPaths().front().size() > 0) {
+                    PathModifierGenerator::GenerateLayerLeadIn(firstRegion->getPaths().front(), leadIn, global_sb);
+                }
             }
         }
     }
 
-    for (QSharedPointer<IslandBase> island : m_island_order)
-        island->fitCircularArcs(global_sb);
+    if (global_sb->setting<bool>(MS::SpiralLift::kLayerEnable) && !m_island_order.isEmpty()) {
+        auto lastIsland = m_island_order.back();
+        if (!lastIsland.isNull() && !lastIsland->getRegions().isEmpty()) {
+            Q_ASSERT(lastIsland->getType() == IslandType::kPolymer);
+            QList<QSharedPointer<RegionBase>> regions = lastIsland->getRegions();
+            QSharedPointer<RegionBase> lastRegion = regions.back();
+            if (!lastRegion.isNull() && !lastRegion->getPaths().isEmpty() && lastRegion->getPaths().back().size() > 0) {
+                Path finalPath = lastRegion->getPaths().back();
+
+                if (finalPath.back()->getSb()->setting<PathModifiers>(SS::kPathModifiers) !=
+                    PathModifiers::kSpiralLift) {
+                    PathModifierGenerator::GenerateSpiralLift(
+                        finalPath, global_sb->setting<Distance>(MS::SpiralLift::kLiftRadius),
+                        global_sb->setting<Distance>(MS::SpiralLift::kLiftHeight),
+                        global_sb->setting<int>(MS::SpiralLift::kLiftPoints),
+                        global_sb->setting<Velocity>(MS::SpiralLift::kLiftSpeed),
+                        global_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+
+                    // move current location to the end of the spiral lift
+                    current_location = finalPath.back()->end();
+                }
+            }
+        }
+    }
+
+    for (QSharedPointer<IslandBase> island : m_island_order) {
+        if (!island.isNull())
+            island->fitCircularArcs(global_sb);
+    }
 }
 
 void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& start, int& start_index,
@@ -102,9 +117,16 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
     // this function "connects" paths by inserting travels between disconnected pathing. Also orders parts & islands.
 
     for (auto i = m_step_pairs.constBegin(); i != m_step_pairs.constEnd(); ++i) {
+        if (i.value().isNull())
+            continue;
+
         QSharedPointer<Layer> printing_layer = i.value()->printing_layer;
+        if (printing_layer.isNull())
+            continue;
+
         for (QSharedPointer<IslandBase> island : printing_layer->getIslands()) {
-            island->setOptimizationFrame(printing_layer->getSlicingPlane(), printing_layer->getShift());
+            if (!island.isNull())
+                island->setOptimizationFrame(printing_layer->getSlicingPlane(), printing_layer->getShift());
         }
     }
 
@@ -124,10 +146,13 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
         for (auto i = m_step_pairs.constBegin(); i != m_step_pairs.constEnd(); ++i) {
             QUuid part_id = i.key();
             QSharedPointer<Part::StepPair> step_pair = i.value();
+            if (step_pair.isNull() || step_pair->printing_layer.isNull())
+                continue;
 
             auto part_islands = step_pair->printing_layer->getIslands().toVector();
             for (auto island : part_islands) {
-                islands_for_all_parts.insert(island, part_id);
+                if (!island.isNull() && !island->getGeometry().isEmpty())
+                    islands_for_all_parts.insert(island, part_id);
             }
         }
 
@@ -135,7 +160,8 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
         Point start_point = start;
         if (islandOrderMethod == IslandOrderOptimization::kCustomPoint) {
             const auto first_step_pair = m_step_pairs.constBegin();
-            if (first_step_pair != m_step_pairs.constEnd()) {
+            if (first_step_pair != m_step_pairs.constEnd() && !first_step_pair.value().isNull() &&
+                !first_step_pair.value()->printing_layer.isNull()) {
                 QSharedPointer<Layer> printing_layer = first_step_pair.value()->printing_layer;
                 start_point = OptimizationAnchor::customIslandOrderPoint(global_sb, printing_layer->getSlicingPlane(),
                                                                          printing_layer->getShift());
@@ -150,7 +176,7 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
         bool is_first_scan = true;
         for (auto part : m_part_order) {
             QSharedPointer<Part::StepPair> step_pair = m_step_pairs[part];
-            if (step_pair->scan_layer != nullptr) {
+            if (!step_pair.isNull() && step_pair->scan_layer != nullptr) {
                 if (is_first_scan) {
                     step_pair->scan_layer->setFirst();
                     is_first_scan = false;
@@ -167,8 +193,12 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
     // 2) Order and connect all printed islands.
     m_island_order.clear();
     QMultiMap<int, QSharedPointer<IslandBase>> islands_for_layer;
-    for (auto island : getIslands())
+    for (auto island : getIslands()) {
+        if (island.isNull() || island->getGeometry().isEmpty())
+            continue;
+
         islands_for_layer.insert(static_cast<int>(island->getType()), island);
+    }
 
     // make an optimizer to do the ordering
     IslandBaseOrderOptimizer island_optimizer(start, islands_for_layer.values(), start_index,
@@ -178,7 +208,8 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
     if (islandOrderMethod == IslandOrderOptimization::kCustomPoint) {
         Point start_override = start;
         const auto first_step_pair = m_step_pairs.constBegin();
-        if (first_step_pair != m_step_pairs.constEnd()) {
+        if (first_step_pair != m_step_pairs.constEnd() && !first_step_pair.value().isNull() &&
+            !first_step_pair.value()->printing_layer.isNull()) {
             QSharedPointer<Layer> printing_layer = first_step_pair.value()->printing_layer;
             start_override = OptimizationAnchor::customIslandOrderPoint(global_sb, printing_layer->getSlicingPlane(),
                                                                         printing_layer->getShift());
@@ -246,6 +277,12 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
         island_optimizer.setIslands(islandSet);
         while (islandSet.size() > 0) {
             int index = island_optimizer.computeNextIndex();
+            if (index < 0 || index >= islandSet.size()) {
+                qWarning() << "Skipping invalid island optimizer index" << index << "for" << islandSet.size()
+                           << "islands";
+                break;
+            }
+
             QSharedPointer<IslandBase> currentIsland = islandSet[index];
             if (!visited_islands.contains(currentIsland)) {
                 currentIsland->optimize(m_layer_number, start, previous_regions);
@@ -257,6 +294,12 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
                 island_optimizer.setIslands(childrenSet);
                 while (childrenSet.size() > 0) {
                     int index = island_optimizer.computeNextIndex();
+                    if (index < 0 || index >= childrenSet.size()) {
+                        qWarning() << "Skipping invalid child island optimizer index" << index << "for"
+                                   << childrenSet.size() << "islands";
+                        break;
+                    }
+
                     QSharedPointer<IslandBase> currentIsland = childrenSet[index];
                     currentIsland->optimize(m_layer_number, start, previous_regions);
                     m_island_order.push_back(currentIsland);
@@ -274,6 +317,12 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
         island_optimizer.setIslands(thermal_scan_islands);
         while (thermal_scan_islands.size() > 0) {
             int index = island_optimizer.computeNextIndex();
+            if (index < 0 || index >= thermal_scan_islands.size()) {
+                qWarning() << "Skipping invalid thermal-scan island optimizer index" << index << "for"
+                           << thermal_scan_islands.size() << "islands";
+                break;
+            }
+
             QSharedPointer<IslandBase> isl = thermal_scan_islands[index];
             thermal_scan_islands.removeAt(index);
             isl->optimize(m_layer_number, start, previous_regions);
@@ -308,6 +357,10 @@ GlobalLayer::createSequence(QList<QSharedPointer<IslandBase>> parent,
             for (int i = 0; i < children_size; ++i) {
                 QList<QSharedPointer<IslandBase>> islandSet = children[i];
                 for (QSharedPointer<IslandBase> isl : islandSet) {
+                    if (brim.isNull() || isl.isNull() || brim->getGeometry().isEmpty() ||
+                        isl->getGeometry().isEmpty() || isl->getGeometry().first().isEmpty())
+                        continue;
+
                     if (brim->getGeometry().first().inside(isl->getGeometry().first().first())) {
                         result[i][brim].append(isl);
                     }
@@ -322,6 +375,9 @@ bool GlobalLayer::containsScanLayers() {
     QMap<QUuid, QSharedPointer<Part::StepPair>>::ConstIterator itr;
     for (itr = m_step_pairs.constBegin(); itr != m_step_pairs.constEnd(); ++itr) {
         auto step_pair = itr.value();
+        if (step_pair.isNull())
+            continue;
+
         if (step_pair->scan_layer != nullptr)
             return true;
     }
@@ -333,6 +389,9 @@ QVector<QSharedPointer<IslandBase>> GlobalLayer::getIslands() {
     QMap<QUuid, QSharedPointer<Part::StepPair>>::ConstIterator itr;
     for (itr = m_step_pairs.constBegin(); itr != m_step_pairs.constEnd(); ++itr) {
         auto step_pair = itr.value();
+        if (step_pair.isNull() || step_pair->printing_layer.isNull())
+            continue;
+
         auto part_islands = step_pair->printing_layer->getIslands().toVector();
         layer_islands.append(part_islands);
     }

--- a/src/step/global_layer.cpp
+++ b/src/step/global_layer.cpp
@@ -88,7 +88,7 @@ void GlobalLayer::calculateModifiers(QSharedPointer<SettingsBase> global_sb, Poi
             QList<QSharedPointer<RegionBase>> regions = lastIsland->getRegions();
             QSharedPointer<RegionBase> lastRegion = regions.back();
             if (!lastRegion.isNull() && !lastRegion->getPaths().isEmpty() && lastRegion->getPaths().back().size() > 0) {
-                Path finalPath = lastRegion->getPaths().back();
+                Path& finalPath = lastRegion->getPaths().back();
 
                 if (finalPath.back()->getSb()->setting<PathModifiers>(SS::kPathModifiers) !=
                     PathModifiers::kSpiralLift) {
@@ -345,7 +345,17 @@ GlobalLayer::createSequence(QList<QSharedPointer<IslandBase>> parent,
     result.reserve(children_size);
     for (int i = 0; i < children_size; ++i)
         result.append(QMap<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>());
-    if (parent.size() == 0) {
+    auto hasSequenceGeometry = [](const QSharedPointer<IslandBase>& island) {
+        return !island.isNull() && !island->getGeometry().isEmpty() && !island->getGeometry().first().isEmpty();
+    };
+
+    QList<QSharedPointer<IslandBase>> valid_parent;
+    for (const QSharedPointer<IslandBase>& brim : parent) {
+        if (hasSequenceGeometry(brim))
+            valid_parent.append(brim);
+    }
+
+    if (valid_parent.size() == 0) {
         for (int i = 0; i < children_size; ++i) {
             QList<QSharedPointer<IslandBase>> islandSet = children[i];
             for (QSharedPointer<IslandBase> isl : islandSet)
@@ -353,12 +363,11 @@ GlobalLayer::createSequence(QList<QSharedPointer<IslandBase>> parent,
         }
     }
     else {
-        for (QSharedPointer<IslandBase> brim : parent) {
+        for (QSharedPointer<IslandBase> brim : valid_parent) {
             for (int i = 0; i < children_size; ++i) {
                 QList<QSharedPointer<IslandBase>> islandSet = children[i];
                 for (QSharedPointer<IslandBase> isl : islandSet) {
-                    if (brim.isNull() || isl.isNull() || brim->getGeometry().isEmpty() ||
-                        isl->getGeometry().isEmpty() || isl->getGeometry().first().isEmpty())
+                    if (!hasSequenceGeometry(isl))
                         continue;
 
                     if (brim->getGeometry().first().inside(isl->getGeometry().first().first())) {

--- a/src/step/layer/layer.cpp
+++ b/src/step/layer/layer.cpp
@@ -9,6 +9,7 @@
 #include <qhash.h>
 #include <qhashfunctions.h>
 #include <qlist.h>
+#include <qlogging.h>
 #include <qquaternion.h>
 #include <qsharedpointer.h>
 #include <qtypes.h>
@@ -168,7 +169,8 @@ void Layer::connectPaths(Point& start, int& start_index, QVector<QSharedPointer<
     m_island_order.clear();
 
     for (QSharedPointer<IslandBase> island : m_islands) {
-        island->setOptimizationFrame(m_slicing_plane, m_shift_amount);
+        if (!island.isNull())
+            island->setOptimizationFrame(m_slicing_plane, m_shift_amount);
     }
 
     // Optimize the layer.
@@ -238,6 +240,12 @@ void Layer::connectPaths(Point& start, int& start_index, QVector<QSharedPointer<
 
         while (islandSet.size() > 0) {
             int index = ioo.computeNextIndex();
+            if (index < 0 || index >= islandSet.size()) {
+                qWarning() << "Skipping invalid layer island optimizer index" << index << "for" << islandSet.size()
+                           << "islands";
+                break;
+            }
+
             QSharedPointer<IslandBase> currentIsland = islandSet[index];
 
             if (!alreadyVisited.contains(currentIsland)) {
@@ -251,6 +259,12 @@ void Layer::connectPaths(Point& start, int& start_index, QVector<QSharedPointer<
 
                 while (childrenSet.size() > 0) {
                     int index = ioo.computeNextIndex();
+                    if (index < 0 || index >= childrenSet.size()) {
+                        qWarning() << "Skipping invalid layer child island optimizer index" << index << "for"
+                                   << childrenSet.size() << "islands";
+                        break;
+                    }
+
                     QSharedPointer<IslandBase> currentIsland = childrenSet[index];
                     currentIsland->optimize(m_layer_nr, start, previousRegions);
                     m_island_order.push_back(currentIsland);
@@ -268,6 +282,12 @@ void Layer::connectPaths(Point& start, int& start_index, QVector<QSharedPointer<
 
         while (currentIslands.size() > 0) {
             int index = ioo.computeNextIndex();
+            if (index < 0 || index >= currentIslands.size()) {
+                qWarning() << "Skipping invalid thermal-scan layer island optimizer index" << index << "for"
+                           << currentIslands.size() << "islands";
+                break;
+            }
+
             QSharedPointer<IslandBase> isl = currentIslands[index];
             currentIslands.removeAt(index);
             isl->optimize(m_layer_nr, start, previousRegions);
@@ -307,6 +327,10 @@ Layer::createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSha
             for (int i = 0; i < children_size; ++i) {
                 QList<QSharedPointer<IslandBase>> islandSet = children[i];
                 for (QSharedPointer<IslandBase> isl : islandSet) {
+                    if (brim.isNull() || isl.isNull() || brim->getGeometry().isEmpty() ||
+                        isl->getGeometry().isEmpty() || isl->getGeometry().first().isEmpty())
+                        continue;
+
                     if (brim->getGeometry().first().inside(isl->getGeometry().first().first())) {
                         result[i][brim].append(isl);
                     }

--- a/src/step/layer/layer.cpp
+++ b/src/step/layer/layer.cpp
@@ -313,7 +313,17 @@ Layer::createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSha
         result.append(QHash<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>());
     }
 
-    if (parent.size() == 0) {
+    auto hasSequenceGeometry = [](const QSharedPointer<IslandBase>& island) {
+        return !island.isNull() && !island->getGeometry().isEmpty() && !island->getGeometry().first().isEmpty();
+    };
+
+    QList<QSharedPointer<IslandBase>> validParent;
+    for (const QSharedPointer<IslandBase>& brim : parent) {
+        if (hasSequenceGeometry(brim))
+            validParent.append(brim);
+    }
+
+    if (validParent.size() == 0) {
         for (int i = 0; i < children_size; ++i) {
             QList<QSharedPointer<IslandBase>> islandSet = children[i];
 
@@ -323,12 +333,11 @@ Layer::createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSha
         }
     }
     else {
-        for (QSharedPointer<IslandBase> brim : parent) {
+        for (QSharedPointer<IslandBase> brim : validParent) {
             for (int i = 0; i < children_size; ++i) {
                 QList<QSharedPointer<IslandBase>> islandSet = children[i];
                 for (QSharedPointer<IslandBase> isl : islandSet) {
-                    if (brim.isNull() || isl.isNull() || brim->getGeometry().isEmpty() ||
-                        isl->getGeometry().isEmpty() || isl->getGeometry().first().isEmpty())
+                    if (!hasSequenceGeometry(isl))
                         continue;
 
                     if (brim->getGeometry().first().inside(isl->getGeometry().first().first())) {

--- a/src/step/layer/regions/skeleton.cpp
+++ b/src/step/layer/regions/skeleton.cpp
@@ -576,8 +576,28 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
     if (path_.isEmpty())
         return;
 
+    struct EdgeEndpoints {
+        SkeletonVertex source;
+        SkeletonVertex target;
+    };
+
+    auto sameUndirectedEdge = [](const EdgeEndpoints& lhs, const EdgeEndpoints& rhs) {
+        return (lhs.source == rhs.source && lhs.target == rhs.target) ||
+               (lhs.source == rhs.target && lhs.target == rhs.source);
+    };
+
+    auto trackEdge = [&sameUndirectedEdge](QVector<EdgeEndpoints>& edges, SkeletonVertex source,
+                                           SkeletonVertex target) {
+        EdgeEndpoints endpoints {source, target};
+        const auto duplicate = std::any_of(edges.cbegin(), edges.cend(), [&sameUndirectedEdge, &endpoints](const auto& edge) {
+            return sameUndirectedEdge(edge, endpoints);
+        });
+        if (!duplicate)
+            edges.push_back(endpoints);
+    };
+
     Polyline path;
-    QVector<SkeletonEdge> edges_to_remove;
+    QVector<EdgeEndpoints> edges_to_remove;
     QVector<SkeletonVertex> touched_vertices;
 
     auto trackVertex = [&touched_vertices](SkeletonVertex vertex) {
@@ -589,7 +609,7 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
     SkeletonVertex source = boost::source(e, m_skeleton_graph);
     SkeletonVertex target = boost::target(e, m_skeleton_graph);
     path << m_skeleton_graph[source] << m_skeleton_graph[target];
-    edges_to_remove.push_back(e);
+    trackEdge(edges_to_remove, source, target);
     trackVertex(source);
     trackVertex(target);
 
@@ -597,14 +617,17 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
         source = boost::source(e, m_skeleton_graph);
         target = boost::target(e, m_skeleton_graph);
         path << m_skeleton_graph[target];
-        edges_to_remove.push_back(e);
+        trackEdge(edges_to_remove, source, target);
         trackVertex(source);
         trackVertex(target);
     }
 
-    // Remove the exact collected edges after all path points have been copied, then prune isolated vertices.
-    for (const SkeletonEdge& edge : edges_to_remove) {
-        boost::remove_edge(edge, m_skeleton_graph);
+    // Re-resolve each edge before removal. A DFS path can contain the same undirected edge more than once; removing
+    // by a stale descriptor a second time corrupts Boost's list-backed edge container.
+    for (const EdgeEndpoints& edge : edges_to_remove) {
+        auto [edge_descriptor, found] = boost::edge(edge.source, edge.target, m_skeleton_graph);
+        if (found)
+            boost::remove_edge(edge_descriptor, m_skeleton_graph);
     }
 
     for (SkeletonVertex vertex : touched_vertices) {

--- a/src/threading/slicers/planar_slicer.cpp
+++ b/src/threading/slicers/planar_slicer.cpp
@@ -34,6 +34,7 @@
 #include "units/unit.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
+#include "utilities/runtime_diagnostics.h"
 
 namespace ORNL {
 
@@ -908,7 +909,13 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
 }
 
 void PlanarSlicer::postProcess(nlohmann::json opt_data) {
-    if (anythingDirty()) {
+    const bool dirty = anythingDirty();
+    Diagnostics::logLine(QString("Planar postprocess starting dirty=%1 global_layers=%2")
+                             .arg(dirty ? QStringLiteral("true") : QStringLiteral("false"))
+                             .arg(m_global_layers.size()));
+    emit statusUpdate(StatusUpdateStepType::kPostProcess, 0);
+
+    if (dirty) {
         QSharedPointer<SettingsBase> global_sb = QSharedPointer<SettingsBase>::create(*GSM->getGlobal());
         global_sb->makeGlobalAdjustments();
 
@@ -919,6 +926,27 @@ void PlanarSlicer::postProcess(nlohmann::json opt_data) {
         QVector<QSharedPointer<RegionBase>> previous_regions;
 
         for (int g_layer_num = 0, max_layers = m_global_layers.size(); g_layer_num < max_layers; ++g_layer_num) {
+            auto islands = m_global_layers[g_layer_num]->getIslands();
+            int region_count = 0;
+            int path_count = 0;
+            for (const auto& island : islands) {
+                if (island.isNull())
+                    continue;
+
+                const auto regions = island->getRegions();
+                region_count += regions.size();
+                for (const auto& region : regions) {
+                    if (!region.isNull())
+                        path_count += region->getPaths().size();
+                }
+            }
+            Diagnostics::logLine(QString("Planar postprocess layer %1/%2 islands=%3 regions=%4 paths=%5")
+                                     .arg(g_layer_num + 1)
+                                     .arg(max_layers)
+                                     .arg(islands.size())
+                                     .arg(region_count)
+                                     .arg(path_count));
+
             m_global_layers[g_layer_num]->unorient();
 
             // current_point, start_index, & previous_regions are updated during method execution
@@ -937,6 +965,8 @@ void PlanarSlicer::postProcess(nlohmann::json opt_data) {
     else {
         emit statusUpdate(StatusUpdateStepType::kPostProcess, 100); // Mark layerbar as done
     }
+
+    Diagnostics::logLine(QStringLiteral("Planar postprocess finished"));
 }
 
 void PlanarSlicer::writeGCode() {

--- a/src/threading/step_thread.cpp
+++ b/src/threading/step_thread.cpp
@@ -1,6 +1,8 @@
 #include "threading/step_thread.h"
 
+#include <QMetaObject>
 #include <qsharedpointer.h>
+#include <qthread.h>
 #include <qtmetamacros.h>
 
 #include "step/step.h"
@@ -12,11 +14,23 @@ StepThread::StepThread() {
 }
 
 StepThread::~StepThread() {
-    m_internal_thread.quit();
-    m_internal_thread.wait();
+    stop();
 }
 
 void StepThread::setStep(const QSharedPointer<Step>& value) { m_step = value; }
+
+void StepThread::stop() {
+    if (!m_internal_thread.isRunning())
+        return;
+
+    if (QThread::currentThread() == &m_internal_thread) {
+        m_internal_thread.quit();
+        return;
+    }
+
+    QMetaObject::invokeMethod(this, [this] { m_internal_thread.quit(); }, Qt::BlockingQueuedConnection);
+    m_internal_thread.wait();
+}
 
 void StepThread::doStep() {
     if (!m_step.isNull()) {

--- a/src/threading/traditional_ast.cpp
+++ b/src/threading/traditional_ast.cpp
@@ -15,6 +15,7 @@
 #include "step/step.h"
 #include "threading/step_thread.h"
 #include "utilities/enums.h"
+#include "utilities/runtime_diagnostics.h"
 
 namespace ORNL {
 TraditionalAST::TraditionalAST(QString outputLocation, bool skipGcode)
@@ -38,7 +39,9 @@ void TraditionalAST::doSlice() {
 
     this->setMaxSteps(0);
 
+    Diagnostics::logLine(QStringLiteral("Slicing preprocess starting"));
     this->preProcess();
+    Diagnostics::logLine(QStringLiteral("Slicing preprocess complete"));
 
     int total_steps = 0;
     for (QSharedPointer<Part> part : CSM->parts()) {
@@ -88,20 +91,25 @@ void TraditionalAST::doSlice() {
     if (m_queue_start_size == 0) {
         emit statusUpdate(StatusUpdateStepType::kCompute, 100);
 
+        Diagnostics::logLine(QStringLiteral("Slicing compute complete; starting postprocess"));
         this->postProcess();
+        Diagnostics::logLine(QStringLiteral("Slicing postprocess complete"));
 
         if (this->shouldCancel())
             return;
 
         if (!m_skip_gcode) {
             // Gcode output
+            Diagnostics::logLine(QStringLiteral("Slicing G-code generation starting"));
             this->writeGCodeSetup();
             this->writeGCode();
             this->writeGCodeShutdown();
+            Diagnostics::logLine(QStringLiteral("Slicing G-code generation complete"));
         }
         if (this->shouldCancel())
             return;
 
+        Diagnostics::logLine(QStringLiteral("Slicing sliceComplete emitted"));
         emit sliceComplete();
     }
     else
@@ -117,6 +125,9 @@ void TraditionalAST::cleanThread() {
 
     if (this->shouldCancel()) {
         m_step_threads.removeOne(st);
+        st->stop();
+        delete st;
+
         if (m_step_threads.isEmpty())
             m_step_queue.clear();
     }
@@ -131,12 +142,15 @@ void TraditionalAST::cleanThread() {
         // If the queue is empty, then start destroying unused threads.
         if (m_step_queue.empty()) {
             m_step_threads.removeOne(st);
+            st->stop();
             delete st;
 
             // If all threads have been destroyed, the slice is complete.
             if (m_step_threads.empty()) {
 
+                Diagnostics::logLine(QStringLiteral("Slicing compute complete; starting postprocess"));
                 this->postProcess();
+                Diagnostics::logLine(QStringLiteral("Slicing postprocess complete"));
 
                 m_elapsed_time = m_timer.elapsed();
 
@@ -145,13 +159,16 @@ void TraditionalAST::cleanThread() {
 
                 if (!m_skip_gcode) {
                     // Gcode output
+                    Diagnostics::logLine(QStringLiteral("Slicing G-code generation starting"));
                     this->writeGCodeSetup();
                     this->writeGCode();
                     this->writeGCodeShutdown();
+                    Diagnostics::logLine(QStringLiteral("Slicing G-code generation complete"));
                 }
                 if (this->shouldCancel())
                     return;
 
+                Diagnostics::logLine(QStringLiteral("Slicing sliceComplete emitted"));
                 emit sliceComplete();
             }
 

--- a/src/utilities/runtime_diagnostics.cpp
+++ b/src/utilities/runtime_diagnostics.cpp
@@ -1,0 +1,26 @@
+#include "utilities/runtime_diagnostics.h"
+
+#include <iostream>
+
+#include <qglobal.h>
+
+#include "ornlslicer/build_info.h"
+
+namespace ORNL::Diagnostics {
+QString runtimeSummary(const QString& mode) {
+    return QString("runtime mode=%1 version=%2 git=%3 build=%4 package=%5 qt_runtime=%6 qt_build=%7")
+        .arg(mode)
+        .arg(QString::fromUtf8(ORNL::BuildInfo::Version))
+        .arg(QString::fromUtf8(ORNL::BuildInfo::GitRevision))
+        .arg(QString::fromUtf8(ORNL::BuildInfo::BuildConfiguration))
+        .arg(QString::fromUtf8(ORNL::BuildInfo::PackageType))
+        .arg(QString::fromUtf8(qVersion()))
+        .arg(QString::fromUtf8(QT_VERSION_STR));
+}
+
+void logLine(const QString& message) {
+    std::cerr << "[ornlslicer] " << message.toStdString() << std::endl;
+}
+
+void logRuntimeSummary(const QString& mode) { logLine(runtimeSummary(mode)); }
+} // namespace ORNL::Diagnostics

--- a/tests/optimizer_empty_input_tests.cpp
+++ b/tests/optimizer_empty_input_tests.cpp
@@ -10,10 +10,12 @@
 #include "geometry/path.h"
 #include "geometry/point.h"
 #include "geometry/polyline.h"
+#include "geometry/segments/line.h"
 #include "optimizers/island_order_optimizer.h"
 #include "optimizers/path_order_optimizer.h"
 #include "optimizers/polyline_order_optimizer.h"
 #include "step/layer/island/island_base.h"
+#include "utilities/constants.h"
 #include "utilities/enums.h"
 
 namespace {
@@ -42,6 +44,22 @@ int main() {
     passed &= expect(path_optimizer.getCurrentPathCount() == 0, "Expected empty paths to be filtered.");
     passed &= expect(path_optimizer.linkNextPath().size() == 0, "Expected empty path optimizer result.");
 
+    settings->setSetting(ORNL::PS::Optimizations::kPathOrder,
+                         static_cast<int>(ORNL::PathOrderOptimization::kNextFarthest));
+    settings->setSetting(ORNL::PS::Optimizations::kPointOrder,
+                         static_cast<int>(ORNL::PointOrderOptimization::kNextClosest));
+    settings->setSetting(ORNL::PS::Optimizations::kMinDistanceEnabled, false);
+    settings->setSetting(ORNL::PS::Optimizations::kLocalRandomnessEnable, false);
+
+    ORNL::Path zero_distance_path;
+    zero_distance_path.append(QSharedPointer<ORNL::LineSegment>::create(start, start));
+    ORNL::PathOrderOptimizer farthest_path_optimizer(start, 0, settings);
+    farthest_path_optimizer.setPathsToEvaluate({zero_distance_path});
+    passed &= expect(farthest_path_optimizer.linkNextPath().size() > 0,
+                     "Expected farthest path optimizer to consume a zero-distance path.");
+    passed &= expect(farthest_path_optimizer.getCurrentPathCount() == 0,
+                     "Expected farthest path optimizer to make progress.");
+
     ORNL::PolylineOrderOptimizer polyline_optimizer(start, 0);
     ORNL::Polyline one_point_polyline;
     one_point_polyline.append(ORNL::Point(1.0f, 0.0f, 0.0f));
@@ -52,6 +70,19 @@ int main() {
                                              ORNL::PathOrderOptimization::kNextClosest);
     passed &= expect(polyline_optimizer.getCurrentPolylineCount() == 0, "Expected degenerate polylines to be filtered.");
     passed &= expect(polyline_optimizer.linkNextPolyline().isEmpty(), "Expected empty polyline optimizer result.");
+
+    ORNL::Polyline zero_distance_polyline;
+    zero_distance_polyline.append(start);
+    zero_distance_polyline.append(start);
+    ORNL::PolylineOrderOptimizer farthest_polyline_optimizer(start, 0);
+    farthest_polyline_optimizer.setPointParameters(ORNL::PointOrderOptimization::kNextClosest, false, ORNL::Distance(),
+                                                   ORNL::Distance(), false, ORNL::Distance(), false);
+    farthest_polyline_optimizer.setGeometryToEvaluate({zero_distance_polyline}, ORNL::RegionType::kInset,
+                                                      ORNL::PathOrderOptimization::kNextFarthest);
+    passed &= expect(!farthest_polyline_optimizer.linkNextPolyline().isEmpty(),
+                     "Expected farthest polyline optimizer to consume a zero-distance polyline.");
+    passed &= expect(farthest_polyline_optimizer.getCurrentPolylineCount() == 0,
+                     "Expected farthest polyline optimizer to make progress.");
 
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/optimizer_empty_input_tests.cpp
+++ b/tests/optimizer_empty_input_tests.cpp
@@ -1,0 +1,57 @@
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <QList>
+#include <QSharedPointer>
+#include <QVector>
+
+#include "configs/settings_base.h"
+#include "geometry/path.h"
+#include "geometry/point.h"
+#include "geometry/polyline.h"
+#include "optimizers/island_order_optimizer.h"
+#include "optimizers/path_order_optimizer.h"
+#include "optimizers/polyline_order_optimizer.h"
+#include "step/layer/island/island_base.h"
+#include "utilities/enums.h"
+
+namespace {
+bool expect(bool condition, const std::string& message) {
+    if (condition)
+        return true;
+
+    std::cerr << message << '\n';
+    return false;
+}
+} // namespace
+
+int main() {
+    bool passed = true;
+
+    ORNL::Point start(0.0f, 0.0f, 0.0f);
+
+    ORNL::IslandBaseOrderOptimizer island_optimizer(start, QList<QSharedPointer<ORNL::IslandBase>>(), -1);
+    passed &= expect(island_optimizer.computeNextIndex() == -1, "Expected empty island optimizer to return -1.");
+
+    QSharedPointer<ORNL::SettingsBase> settings = QSharedPointer<ORNL::SettingsBase>::create();
+    ORNL::PathOrderOptimizer path_optimizer(start, 0, settings);
+    QVector<ORNL::Path> paths;
+    paths.append(ORNL::Path());
+    path_optimizer.setPathsToEvaluate(paths);
+    passed &= expect(path_optimizer.getCurrentPathCount() == 0, "Expected empty paths to be filtered.");
+    passed &= expect(path_optimizer.linkNextPath().size() == 0, "Expected empty path optimizer result.");
+
+    ORNL::PolylineOrderOptimizer polyline_optimizer(start, 0);
+    ORNL::Polyline one_point_polyline;
+    one_point_polyline.append(ORNL::Point(1.0f, 0.0f, 0.0f));
+    QVector<ORNL::Polyline> polylines;
+    polylines.append(ORNL::Polyline());
+    polylines.append(one_point_polyline);
+    polyline_optimizer.setGeometryToEvaluate(polylines, ORNL::RegionType::kSkeleton,
+                                             ORNL::PathOrderOptimization::kNextClosest);
+    passed &= expect(polyline_optimizer.getCurrentPolylineCount() == 0, "Expected degenerate polylines to be filtered.");
+    passed &= expect(polyline_optimizer.linkNextPolyline().isEmpty(), "Expected empty polyline optimizer result.");
+
+    return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/run_project_slice_regression.cmake
+++ b/tests/run_project_slice_regression.cmake
@@ -1,0 +1,50 @@
+foreach(required_var ORNLSLICER_EXECUTABLE PROJECT_FILE OUTPUT_PREFIX)
+    if(NOT DEFINED ${required_var} OR "${${required_var}}" STREQUAL "")
+        message(FATAL_ERROR "${required_var} is required.")
+    endif()
+endforeach()
+
+if(NOT EXISTS "${ORNLSLICER_EXECUTABLE}")
+    message(FATAL_ERROR "Slicer executable does not exist: ${ORNLSLICER_EXECUTABLE}")
+endif()
+
+if(NOT EXISTS "${PROJECT_FILE}")
+    message(FATAL_ERROR "Project file does not exist: ${PROJECT_FILE}")
+endif()
+
+get_filename_component(output_dir "${OUTPUT_PREFIX}" DIRECTORY)
+file(REMOVE_RECURSE "${output_dir}")
+file(MAKE_DIRECTORY "${output_dir}")
+
+set(stdout_log "${OUTPUT_PREFIX}.stdout.log")
+set(stderr_log "${OUTPUT_PREFIX}.stderr.log")
+set(gcode_file "${OUTPUT_PREFIX}.gcode")
+
+execute_process(
+    COMMAND
+        "${ORNLSLICER_EXECUTABLE}"
+        --input_project_file "${PROJECT_FILE}"
+        --output_location "${OUTPUT_PREFIX}"
+    RESULT_VARIABLE slice_result
+    OUTPUT_FILE "${stdout_log}"
+    ERROR_FILE "${stderr_log}"
+)
+
+if(NOT slice_result EQUAL 0)
+    message(FATAL_ERROR
+        "Slicing failed with exit code ${slice_result}.\n"
+        "stdout: ${stdout_log}\n"
+        "stderr: ${stderr_log}"
+    )
+endif()
+
+if(NOT EXISTS "${gcode_file}")
+    message(FATAL_ERROR "Expected generated G-code does not exist: ${gcode_file}")
+endif()
+
+file(SIZE "${gcode_file}" gcode_size)
+if(gcode_size LESS_EQUAL 0)
+    message(FATAL_ERROR "Generated G-code is empty: ${gcode_file}")
+endif()
+
+message(STATUS "Generated ${gcode_file} (${gcode_size} bytes).")


### PR DESCRIPTION
## Summary

Fixes a crash seen when slicing a large test project in the installed build path. The local/debug executable now completes compute, planar post-processing, G-code generation, parsing, and visualization for that project.

## Root Cause

The deterministic crash reproduced during compute, not after post-processing started. `Skeleton::extractPath()` could collect the same undirected Boost graph edge more than once, then remove the original edge descriptor repeatedly. With the list-backed Boost edge container, the second stale-descriptor removal could corrupt/unhook the edge node and segfault.

## What Changed

- Deduplicate skeleton edge removals by endpoint pair and re-resolve each edge before removing it.
- Add visible runtime/build diagnostics and compute-to-postprocess phase breadcrumbs for installed-build triage.
- Emit `Post-Process: 0` at planar post-process entry and log per-layer island/region/path counts.
- Harden planar post-processing and path/island/polyline ordering against empty or null geometry.
- Stop worker `StepThread` instances before deletion.
- Add focused empty-input optimizer tests and an optional local `new-impact.s2p` regression CTest that asserts non-empty G-code output.

## Validation

- `nix develop -c cmake --build build/generic-llvm-ninja --config Debug --target ornlslicer_optimizer_empty_input_tests ornlslicer -j 4`
- `nix develop -c ctest --test-dir build/generic-llvm-ninja -C Debug --output-on-failure`
- Result: `3/3` tests passed, including `new_impact_project_regression`.
- Regression output: generated non-empty `new-impact.gcode` (~6.5 MB).
- `build/generic-llvm-ninja/Debug/ornlslicer --version` now prints version, git revision/dirty state, build configuration, package type, and Qt runtime/build versions.