### PR TITLE
Add G-Code to S2C importer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,17 @@ if(ORNLSLICER_BUILD_TESTS)
     target_link_libraries(${PROJECT_NAME}_optimizer_empty_input_tests PRIVATE ${PROJECT_NAME}_obj)
     add_test(NAME optimizer_empty_input_tests COMMAND ${PROJECT_NAME}_optimizer_empty_input_tests)
 
+    add_executable(${PROJECT_NAME}_gcode_settings_importer_tests tests/gcode_settings_importer_tests.cpp)
+    target_include_directories(
+        ${PROJECT_NAME}_gcode_settings_importer_tests
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+            ${ORNLSLICER_INCLUDE_DIRS}
+    )
+    target_link_libraries(${PROJECT_NAME}_gcode_settings_importer_tests PRIVATE ${PROJECT_NAME}_obj)
+    add_test(NAME gcode_settings_importer_tests COMMAND ${PROJECT_NAME}_gcode_settings_importer_tests)
+
     set(ORNLSLICER_NEW_IMPACT_PROJECT "/home/rhc/develop/new-impact.s2p" CACHE FILEPATH
         "Optional local project used for the new-impact planar slicing regression test.")
     if(EXISTS "${ORNLSLICER_NEW_IMPACT_PROJECT}")

--- a/include/gcode/gcode_settings_importer.h
+++ b/include/gcode/gcode_settings_importer.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+
+#include <QString>
+#include <QStringList>
+
+#include "utilities/qt_json_conversion.h"
+
+namespace ORNL {
+
+class GcodeSettingsImporter {
+  public:
+    struct ImportResult {
+        fifojson settings_file;
+        QStringList errors;
+        QStringList warnings;
+        QStringList imported_keys;
+        QStringList defaulted_keys;
+        QStringList prompted_keys;
+        QStringList missing_keys;
+        QStringList unknown_keys;
+    };
+
+    using MissingValueCallback =
+        std::function<std::optional<fifojson>(const QString& key, const fifojson& master_entry)>;
+
+    static ImportResult importFile(const QString& gcode_path, bool use_defaults_for_missing,
+                                   const MissingValueCallback& missing_value_callback = MissingValueCallback());
+
+    static bool validateValue(const QString& key, const fifojson& master_entry, const fifojson& value,
+                              fifojson& normalized_value, QString& error, bool enforce_ranges = true);
+
+    static QString displayName(const fifojson& master_entry);
+    static QStringList settingOptions(const fifojson& master_entry);
+};
+
+} // namespace ORNL

--- a/include/managers/settings/settings_version_control.h
+++ b/include/managers/settings/settings_version_control.h
@@ -20,6 +20,10 @@ class SettingsVersionControl {
     //! \param settings: settings to modify
     static void formatSettings(double version, fifojson& settings);
 
+    //! \brief Migrate known legacy setting keys to their current names without changing values
+    //! \param settings_group: a single settings object to modify
+    static void migrateLegacySettingKeys(fifojson& settings_group);
+
   private:
     //! \brief Rolls initial settings templates without a version to version 1.0
     //! \param version: current version in settings file

--- a/include/windows/gcode_to_s2c.h
+++ b/include/windows/gcode_to_s2c.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <optional>
+
+#include <QDialog>
+#include <QLabel>
+#include <QLineEdit>
+#include <qcheckbox.h>
+#include <qdialogbuttonbox.h>
+#include <qgridlayout.h>
+#include <qpushbutton.h>
+#include <qtmetamacros.h>
+
+#include "utilities/qt_json_conversion.h"
+
+namespace ORNL {
+
+class GcodeToS2CDialog : public QDialog {
+    Q_OBJECT
+  public:
+    explicit GcodeToS2CDialog(QWidget* parent = nullptr);
+
+    QString outputFilePath() const;
+
+  private slots:
+    void browseGcodeFile();
+    void browseOutputFile();
+    void refreshAcceptState();
+    void accept() override;
+
+  private:
+    void setupUi();
+    void setDefaultOutputPath();
+    std::optional<fifojson> promptForMissingValue(const QString& key, const fifojson& master_entry);
+
+    QGridLayout* m_layout;
+    QLineEdit* m_gcode_edit;
+    QLineEdit* m_output_edit;
+    QPushButton* m_gcode_browse;
+    QPushButton* m_output_browse;
+    QCheckBox* m_use_defaults;
+    QLabel* m_status_label;
+    QDialogButtonBox* m_buttons;
+};
+
+} // namespace ORNL

--- a/include/windows/main_window.h
+++ b/include/windows/main_window.h
@@ -162,6 +162,9 @@ class MainWindow : public QMainWindow {
     //! \brief Load a template.
     void loadTemplate();
 
+    //! \brief Create and load an S2C settings file from a G-Code settings footer.
+    void convertGcodeToS2C();
+
     //! \brief Set setting folder to load from.
     void setSettingFolder();
 
@@ -238,6 +241,9 @@ class MainWindow : public QMainWindow {
 
     //! \brief Check whether the project has unsaved changes.
     bool hasUnsavedProjectChanges();
+
+    //! \brief Load a template file from a known path.
+    void loadTemplateFile(const QString& filename);
 
   private:
     //! \brief Struct to retain action information efficiently.

--- a/src/gcode/gcode_settings_importer.cpp
+++ b/src/gcode/gcode_settings_importer.cpp
@@ -5,7 +5,7 @@
 
 #include <QFile>
 #include <QHash>
-#include <QRegularExpression>
+#include <QIODevice>
 #include <qchar.h>
 #include <qcontainerfwd.h>
 
@@ -129,12 +129,11 @@ int firstSpaceIndex(const QString& value) {
     return -1;
 }
 
-bool parseFooterSettings(const QString& contents, QHash<QString, QString>& raw_values, QStringList& warnings) {
-    const QStringList lines = contents.split(QRegularExpression("\r\n|\n|\r"));
+bool parseFooterSettings(QIODevice& contents, QHash<QString, QString>& raw_values, QStringList& warnings) {
     bool in_footer = false;
 
-    for (const QString& line : lines) {
-        const QString text = commentText(line);
+    while (!contents.atEnd()) {
+        const QString text = commentText(QString::fromUtf8(contents.readLine()));
         if (text.isEmpty())
             continue;
 
@@ -165,6 +164,21 @@ bool parseFooterSettings(const QString& contents, QHash<QString, QString>& raw_v
     }
 
     return in_footer;
+}
+
+void migrateLegacyRawSettingKeys(QHash<QString, QString>& raw_values) {
+    fifojson raw_settings = fifojson::object();
+    for (auto raw = raw_values.constBegin(); raw != raw_values.constEnd(); ++raw) {
+        raw_settings[raw.key().toStdString()] = raw.value().toStdString();
+    }
+
+    SettingsVersionControl::migrateLegacySettingKeys(raw_settings);
+
+    raw_values.clear();
+    for (const auto& item : raw_settings.items()) {
+        if (item.value().is_string())
+            raw_values[QString::fromStdString(item.key())] = QString::fromStdString(item.value().get<std::string>());
+    }
 }
 
 bool parseRawValue(const QString& key, const fifojson& master_entry, const QString& raw_value, fifojson& parsed_value,
@@ -602,7 +616,7 @@ GcodeSettingsImporter::importFile(const QString& gcode_path, bool use_defaults_f
     }
 
     QHash<QString, QString> raw_values;
-    const bool footer_found = parseFooterSettings(QString::fromUtf8(gcode_file.readAll()), raw_values, result.warnings);
+    const bool footer_found = parseFooterSettings(gcode_file, raw_values, result.warnings);
     if (!footer_found) {
         result.errors.append("The selected G-Code file does not contain a Settings Footer.");
         return result;
@@ -612,6 +626,7 @@ GcodeSettingsImporter::importFile(const QString& gcode_path, bool use_defaults_f
         result.errors.append("The Settings Footer did not contain any setting values.");
         return result;
     }
+    migrateLegacyRawSettingKeys(raw_values);
 
     const fifojson master = GSM->getMaster()->json();
     fifojson settings = fifojson::object();
@@ -652,7 +667,7 @@ GcodeSettingsImporter::importFile(const QString& gcode_path, bool use_defaults_f
             const std::optional<fifojson> prompted_value = missing_value_callback(key, master_entry);
             if (!prompted_value.has_value()) {
                 result.errors.append("Import canceled while prompting for missing setting " + key + ".");
-                continue;
+                return result;
             }
 
             candidate = prompted_value.value();

--- a/src/gcode/gcode_settings_importer.cpp
+++ b/src/gcode/gcode_settings_importer.cpp
@@ -1,0 +1,820 @@
+#include "gcode/gcode_settings_importer.h"
+
+#include <cmath>
+#include <limits>
+
+#include <QFile>
+#include <QHash>
+#include <QRegularExpression>
+#include <qchar.h>
+#include <qcontainerfwd.h>
+
+#include "managers/settings/settings_manager.h"
+#include "managers/settings/settings_version_control.h"
+#include "utilities/constants.h"
+
+namespace ORNL {
+namespace {
+constexpr double kIntegerTolerance = 1e-9;
+constexpr double kModifyFeedrateLayerTimeMethod = 1.0;
+
+const QString kSettingsFooter = "Settings Footer";
+const QString kInfillMaximumPathLength = "infill_maximum_path_length";
+
+QString jsonString(const fifojson& object, const std::string& key) {
+    if (!object.contains(key) || !object.at(key).is_string())
+        return QString();
+
+    return QString::fromStdString(object.at(key).get<std::string>());
+}
+
+QString settingType(const fifojson& master_entry) {
+    return jsonString(master_entry, Constants::Settings::Master::kType);
+}
+
+QString settingDisplay(const QString& key, const fifojson& master) {
+    const auto entry = master.find(key.toStdString());
+    if (entry == master.end())
+        return key;
+
+    const QString display = GcodeSettingsImporter::displayName(entry.value());
+    return display.isEmpty() ? key : display;
+}
+
+bool numberValue(const fifojson& value, double& result) {
+    if (!value.is_number())
+        return false;
+
+    result = value.get<double>();
+    return std::isfinite(result);
+}
+
+bool integerValue(const fifojson& value, int& result) {
+    double number = 0.0;
+    if (!numberValue(value, number))
+        return false;
+
+    const double rounded = std::round(number);
+    if (std::abs(number - rounded) > kIntegerTolerance || rounded < std::numeric_limits<int>::min() ||
+        rounded > std::numeric_limits<int>::max()) {
+        return false;
+    }
+
+    result = static_cast<int>(rounded);
+    return true;
+}
+
+bool boolValue(const fifojson& value, bool& result) {
+    if (value.is_boolean()) {
+        result = value.get<bool>();
+        return true;
+    }
+
+    if (value.is_number()) {
+        double number = 0.0;
+        if (!numberValue(value, number))
+            return false;
+
+        if (std::abs(number) <= kIntegerTolerance) {
+            result = false;
+            return true;
+        }
+
+        if (std::abs(number - 1.0) <= kIntegerTolerance) {
+            result = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    if (value.is_string()) {
+        const QString text = QString::fromStdString(value.get<std::string>()).trimmed().toLower();
+        if (text == "true" || text == "1") {
+            result = true;
+            return true;
+        }
+
+        if (text == "false" || text == "0") {
+            result = false;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+QString commentText(const QString& line) {
+    const QString trimmed = line.trimmed();
+    if (trimmed.isEmpty())
+        return QString();
+
+    if (trimmed.startsWith(';') || trimmed.startsWith('\'')) {
+        return trimmed.mid(1).trimmed();
+    }
+
+    if (trimmed.startsWith('(') && trimmed.endsWith(')') && trimmed.size() >= 2) {
+        return trimmed.mid(1, trimmed.size() - 2).trimmed();
+    }
+
+    return QString();
+}
+
+int firstSpaceIndex(const QString& value) {
+    for (int i = 0, end = value.size(); i < end; ++i) {
+        if (value.at(i).isSpace())
+            return i;
+    }
+
+    return -1;
+}
+
+bool parseFooterSettings(const QString& contents, QHash<QString, QString>& raw_values, QStringList& warnings) {
+    const QStringList lines = contents.split(QRegularExpression("\r\n|\n|\r"));
+    bool in_footer = false;
+
+    for (const QString& line : lines) {
+        const QString text = commentText(line);
+        if (text.isEmpty())
+            continue;
+
+        if (!in_footer) {
+            if (text.compare(kSettingsFooter, Qt::CaseInsensitive) == 0)
+                in_footer = true;
+            continue;
+        }
+
+        const int separator = firstSpaceIndex(text);
+        if (separator < 0) {
+            warnings.append("Ignoring footer line without a setting value: " + text);
+            continue;
+        }
+
+        const QString key = text.left(separator).trimmed();
+        const QString value = text.mid(separator + 1).trimmed();
+
+        if (key.isEmpty() || value.isEmpty()) {
+            warnings.append("Ignoring malformed footer line: " + text);
+            continue;
+        }
+
+        if (raw_values.contains(key))
+            warnings.append("Duplicate footer value for " + key + "; using the last value.");
+
+        raw_values[key] = value;
+    }
+
+    return in_footer;
+}
+
+bool parseRawValue(const QString& key, const fifojson& master_entry, const QString& raw_value, fifojson& parsed_value,
+                   QString& error) {
+    try {
+        parsed_value = fifojson::parse(raw_value.toStdString());
+        return true;
+    } catch (const std::exception& e) {
+        const QString type = settingType(master_entry);
+        if (type == "string" || type == "multiline_text") {
+            parsed_value = raw_value.toStdString();
+            return true;
+        }
+
+        error = "Could not parse " + key + " value `" + raw_value + "` as JSON: " + e.what();
+        return false;
+    }
+}
+
+bool validateDoubleRange(const QString& key, const QString& type, double value, QString& error) {
+    double minimum = 0.0;
+    double maximum = static_cast<double>(std::numeric_limits<float>::max());
+
+    if (type == "location") {
+        minimum = static_cast<double>(std::numeric_limits<float>::lowest());
+    }
+    else if (type == "unitless_float") {
+        minimum = Constants::Limits::Minimums::kMinUnitlessFloat;
+        maximum = Constants::Limits::Maximums::kMaxUnitlessFloat;
+    }
+    else if (type == "percentage") {
+        maximum = 500.0;
+    }
+    else if (type == "percentage100") {
+        maximum = 100.0;
+    }
+    else if (type == "rpm") {
+        maximum = 9999.99;
+    }
+    else if (type == "density") {
+        maximum = 9999.9999;
+    }
+    else if (type == "angle") {
+        minimum = Constants::Limits::Minimums::kMinAngle();
+        maximum = Constants::Limits::Maximums::kMaxAngle();
+    }
+    else if (type == "temperature") {
+        minimum = 0.0;
+    }
+
+    if (value < minimum || value > maximum) {
+        error = key + " is outside the allowed " + type + " range.";
+        return false;
+    }
+
+    return true;
+}
+
+bool isDoubleType(const QString& type) {
+    return type == "location" || type == "distance" || type == "unitless_float" || type == "voltage" ||
+           type == "speed" || type == "rpm" || type == "accel" || type == "density" || type == "ang_vel" ||
+           type == "time" || type == "percentage" || type == "percentage100" || type == "temperature" ||
+           type == "angle" || type == "area";
+}
+
+double settingDouble(const fifojson& settings, const QString& key) {
+    const auto value = settings.find(key.toStdString());
+    if (value == settings.end())
+        return 0.0;
+
+    double result = 0.0;
+    if (numberValue(value.value(), result))
+        return result;
+
+    bool bool_result = false;
+    if (boolValue(value.value(), bool_result))
+        return bool_result ? 1.0 : 0.0;
+
+    return 0.0;
+}
+
+bool settingBool(const fifojson& settings, const QString& key) {
+    const auto value = settings.find(key.toStdString());
+    if (value == settings.end())
+        return false;
+
+    bool result = false;
+    return boolValue(value.value(), result) && result;
+}
+
+int settingInt(const fifojson& settings, const QString& key) {
+    const auto value = settings.find(key.toStdString());
+    if (value == settings.end())
+        return 0;
+
+    int result = 0;
+    if (integerValue(value.value(), result))
+        return result;
+
+    return static_cast<int>(settingDouble(settings, key));
+}
+
+bool jsonValuesMatch(const fifojson& actual, const fifojson& expected) {
+    if (expected.is_boolean()) {
+        bool actual_bool = false;
+        return boolValue(actual, actual_bool) && actual_bool == expected.get<bool>();
+    }
+
+    if (expected.is_number()) {
+        double actual_number = 0.0;
+        double expected_number = 0.0;
+        return numberValue(actual, actual_number) && numberValue(expected, expected_number) &&
+               std::abs(actual_number - expected_number) <= kIntegerTolerance;
+    }
+
+    if (expected.is_string() && actual.is_string())
+        return actual.get<std::string>() == expected.get<std::string>();
+
+    return actual == expected;
+}
+
+bool dependencyIsActive(const fifojson& dependency, const fifojson& settings);
+
+bool dependencyArrayIsActive(const fifojson& dependencies, bool require_all, const fifojson& settings) {
+    if (!dependencies.is_array())
+        return true;
+
+    if (require_all) {
+        for (const auto& dependency : dependencies) {
+            if (!dependencyIsActive(dependency, settings))
+                return false;
+        }
+        return true;
+    }
+
+    for (const auto& dependency : dependencies) {
+        if (dependencyIsActive(dependency, settings))
+            return true;
+    }
+    return false;
+}
+
+bool dependencyIsActive(const fifojson& dependency, const fifojson& settings) {
+    if (dependency.is_null())
+        return true;
+
+    if (dependency.is_string())
+        return dependency.get<std::string>().empty();
+
+    if (dependency.is_array())
+        return dependencyArrayIsActive(dependency, true, settings);
+
+    if (!dependency.is_object())
+        return true;
+
+    for (const auto& item : dependency.items()) {
+        const QString key = QString::fromStdString(item.key());
+        if (key == "AND") {
+            if (!dependencyArrayIsActive(item.value(), true, settings))
+                return false;
+        }
+        else if (key == "OR") {
+            if (!dependencyArrayIsActive(item.value(), false, settings))
+                return false;
+        }
+        else {
+            const auto actual = settings.find(item.key());
+            if (actual == settings.end() || !jsonValuesMatch(actual.value(), item.value()))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+bool settingIsActive(const QString& key, const fifojson& master, const fifojson& settings) {
+    const auto entry = master.find(key.toStdString());
+    if (entry == master.end())
+        return false;
+
+    const auto dependency = entry.value().find(Constants::Settings::Master::kDepends);
+    return dependency == entry.value().end() || dependencyIsActive(dependency.value(), settings);
+}
+
+bool configuredRange(double minimum, double maximum) { return minimum != 0.0 || maximum != 0.0; }
+
+bool validRange(double minimum, double maximum) { return configuredRange(minimum, maximum) && minimum < maximum; }
+
+QString numberText(double value) { return QString::number(value, 'g', 6); }
+
+void addDimensionRangeError(const QString& min_key, const QString& max_key, const QString& min_label,
+                            const QString& max_label, const fifojson& settings, const fifojson& master,
+                            QStringList& errors) {
+    if (!settingIsActive(min_key, master, settings) && !settingIsActive(max_key, master, settings))
+        return;
+
+    const double minimum = settingDouble(settings, min_key);
+    const double maximum = settingDouble(settings, max_key);
+    if (configuredRange(minimum, maximum) && minimum >= maximum) {
+        errors.append(min_label + " (" + numberText(minimum) + ") must be less than " + max_label + " (" +
+                      numberText(maximum) + ").");
+    }
+}
+
+void addBoundsError(const QString& key, const QString& min_key, const QString& max_key, const QString& axis,
+                    const fifojson& settings, const fifojson& master, QStringList& errors) {
+    if (!settingIsActive(key, master, settings))
+        return;
+
+    const double minimum = settingDouble(settings, min_key);
+    const double maximum = settingDouble(settings, max_key);
+    const double value = settingDouble(settings, key);
+    if (validRange(minimum, maximum) && (value < minimum || value > maximum)) {
+        errors.append(settingDisplay(key, master) + " (" + numberText(value) + ") is outside the " + axis +
+                      " build volume range (" + numberText(minimum) + " to " + numberText(maximum) + ").");
+    }
+}
+
+void validateActiveStaticSettings(const fifojson& settings, const fifojson& master, QStringList& errors) {
+    for (const auto& item : master.items()) {
+        const QString key = QString::fromStdString(item.key());
+        if (!settingIsActive(key, master, settings))
+            continue;
+
+        const auto value = settings.find(item.key());
+        if (value == settings.end()) {
+            errors.append("Missing active setting " + key + ".");
+            continue;
+        }
+
+        fifojson normalized;
+        QString error;
+        if (!GcodeSettingsImporter::validateValue(key, item.value(), value.value(), normalized, error, true))
+            errors.append(error);
+    }
+}
+
+void validateDynamicSettings(const fifojson& settings, const fifojson& master, QStringList& errors) {
+    addDimensionRangeError(PRS::Dimensions::kXMin, PRS::Dimensions::kXMax, "Minimum X", "Maximum X", settings, master,
+                           errors);
+    addDimensionRangeError(PRS::Dimensions::kYMin, PRS::Dimensions::kYMax, "Minimum Y", "Maximum Y", settings, master,
+                           errors);
+    addDimensionRangeError(PRS::Dimensions::kZMin, PRS::Dimensions::kZMax, "Minimum Z", "Maximum Z", settings, master,
+                           errors);
+    addDimensionRangeError(PRS::Dimensions::kWMin, PRS::Dimensions::kWMax, "Minimum W", "Maximum W", settings, master,
+                           errors);
+
+    const double min_extruder_speed = settingDouble(settings, PRS::MachineSpeed::kMinExtruderSpeed);
+    const double max_extruder_speed = settingDouble(settings, PRS::MachineSpeed::kMaxExtruderSpeed);
+    const bool has_min_extruder_speed = min_extruder_speed > 0.0;
+    const bool has_max_extruder_speed = max_extruder_speed > 0.0;
+    const bool invalid_extruder_range =
+        has_min_extruder_speed && has_max_extruder_speed && min_extruder_speed > max_extruder_speed;
+
+    if (invalid_extruder_range) {
+        errors.append("Minimum Extruder Speed (" + numberText(min_extruder_speed) +
+                      ") is greater than Maximum Extruder Speed (" + numberText(max_extruder_speed) + ").");
+    }
+
+    const double min_xy_speed = settingDouble(settings, PRS::MachineSpeed::kMinXYSpeed);
+    const double max_xy_speed = settingDouble(settings, PRS::MachineSpeed::kMaxXYSpeed);
+    if (min_xy_speed > 0.0 && max_xy_speed > 0.0 && min_xy_speed > max_xy_speed) {
+        errors.append("Minimum XY Speed (" + numberText(min_xy_speed) + ") is greater than Maximum XY Speed (" +
+                      numberText(max_xy_speed) + ").");
+    }
+
+    for (const auto& item : master.items()) {
+        const QString key = QString::fromStdString(item.key());
+        if (!settingIsActive(key, master, settings))
+            continue;
+
+        const QString type = settingType(item.value());
+        const double value = settingDouble(settings, key);
+        const QString display = settingDisplay(key, master);
+
+        if (type == "rpm" && key != PRS::MachineSpeed::kMinExtruderSpeed &&
+            key != PRS::MachineSpeed::kMaxExtruderSpeed && !invalid_extruder_range) {
+            if (has_min_extruder_speed && value < min_extruder_speed) {
+                errors.append(display + " (" + numberText(value) + ") is below Minimum Extruder Speed (" +
+                              numberText(min_extruder_speed) + ").");
+            }
+            if (has_max_extruder_speed && value > max_extruder_speed) {
+                errors.append(display + " (" + numberText(value) + ") exceeds Maximum Extruder Speed (" +
+                              numberText(max_extruder_speed) + ").");
+            }
+        }
+    }
+
+    addBoundsError(PRS::Dimensions::kPurgeX, PRS::Dimensions::kXMin, PRS::Dimensions::kXMax, "X", settings, master,
+                   errors);
+    addBoundsError(PRS::Dimensions::kPurgeY, PRS::Dimensions::kYMin, PRS::Dimensions::kYMax, "Y", settings, master,
+                   errors);
+    addBoundsError(PRS::Dimensions::kPurgeZ, PRS::Dimensions::kZMin, PRS::Dimensions::kZMax, "Z", settings, master,
+                   errors);
+    addBoundsError(PRS::Dimensions::kDoffingHeight, PRS::Dimensions::kWMin, PRS::Dimensions::kWMax, "W", settings,
+                   master, errors);
+    addBoundsError(PS::Perimeter::kEnableLeadInX, PRS::Dimensions::kXMin, PRS::Dimensions::kXMax, "X", settings, master,
+                   errors);
+    addBoundsError(PS::Perimeter::kEnableLeadInY, PRS::Dimensions::kYMin, PRS::Dimensions::kYMax, "Y", settings, master,
+                   errors);
+
+    if (settingIsActive(PS::Layer::kLayerHeight, master, settings) &&
+        settingDouble(settings, PS::Layer::kLayerHeight) <= 0.0) {
+        errors.append("Layer Height must be greater than zero.");
+    }
+
+    const QStringList bead_width_keys {PS::Layer::kBeadWidth,
+                                       PS::Perimeter::kBeadWidth,
+                                       PS::Inset::kBeadWidth,
+                                       PS::Skeleton::kBeadWidth,
+                                       PS::Skin::kBeadWidth,
+                                       PS::Infill::kBeadWidth,
+                                       MS::PlatformAdhesion::kRaftBeadWidth,
+                                       MS::PlatformAdhesion::kBrimBeadWidth,
+                                       MS::PlatformAdhesion::kSkirtBeadWidth};
+
+    const double layer_height = settingDouble(settings, PS::Layer::kLayerHeight);
+    for (const QString& key : bead_width_keys) {
+        if (!settingIsActive(key, master, settings))
+            continue;
+
+        const double value = settingDouble(settings, key);
+        const QString display = settingDisplay(key, master);
+        if (value <= 0.0) {
+            errors.append(display + " must be greater than zero.");
+        }
+        else if (layer_height > 0.0 && value < layer_height) {
+            errors.append(display + " (" + numberText(value) + ") is smaller than Layer Height (" +
+                          numberText(layer_height) + ").");
+        }
+    }
+
+    if ((settingIsActive(PS::Infill::kMinPathLength, master, settings) ||
+         settingIsActive(kInfillMaximumPathLength, master, settings)) &&
+        settingDouble(settings, PS::Infill::kMinPathLength) > 0.0 &&
+        settingDouble(settings, kInfillMaximumPathLength) > 0.0 &&
+        settingDouble(settings, PS::Infill::kMinPathLength) > settingDouble(settings, kInfillMaximumPathLength)) {
+        errors.append("Minimum Infill Path Length is greater than Maximum Infill Path Length.");
+    }
+
+    const QStringList lift_distance_keys {PS::Travel::kLiftHeight,           PS::Travel::kFinalLiftDistance,
+                                          MS::SpiralLift::kLiftHeight,       MS::Slowdown::kPerimeterLiftDistance,
+                                          MS::Slowdown::kInsetLiftDistance,  MS::Slowdown::kSkinLiftDistance,
+                                          MS::Slowdown::kInfillLiftDistance, MS::Slowdown::kSkeletonLiftDistance,
+                                          MS::TipWipe::kPerimeterLiftHeight, MS::TipWipe::kInsetLiftHeight,
+                                          MS::TipWipe::kSkinLiftHeight,      MS::TipWipe::kInfillLiftHeight,
+                                          MS::TipWipe::kSkeletonLiftHeight};
+
+    const double z_min = settingDouble(settings, PRS::Dimensions::kZMin);
+    const double z_max = settingDouble(settings, PRS::Dimensions::kZMax);
+    for (const QString& key : lift_distance_keys) {
+        if (!settingIsActive(key, master, settings))
+            continue;
+
+        const double value = settingDouble(settings, key);
+        if (value <= 0.0)
+            continue;
+
+        if (settingDouble(settings, PRS::MachineSpeed::kZSpeed) <= 0.0)
+            errors.append(settingDisplay(key, master) + " requires Z Speed to be greater than zero.");
+
+        if (validRange(z_min, z_max) && value > (z_max - z_min)) {
+            errors.append(settingDisplay(key, master) + " exceeds the Z build volume range.");
+        }
+    }
+
+    if (settingIsActive(PS::Travel::kMinTravelForLift, master, settings) &&
+        settingDouble(settings, PS::Travel::kMinTravelForLift) > 0.0 &&
+        settingDouble(settings, PS::Travel::kLiftHeight) <= 0.0) {
+        errors.append("Minimum Travel For Lift is set, but Travel Lift Height is zero.");
+    }
+
+    const double fan_min_speed = settingDouble(settings, MS::Cooling::kMinSpeed);
+    const double fan_max_speed = settingDouble(settings, MS::Cooling::kMaxSpeed);
+    if ((settingIsActive(MS::Cooling::kMinSpeed, master, settings) ||
+         settingIsActive(MS::Cooling::kMaxSpeed, master, settings)) &&
+        fan_min_speed > fan_max_speed) {
+        errors.append("Min Fan Speed (" + numberText(fan_min_speed) + ") is greater than Max Fan Speed (" +
+                      numberText(fan_max_speed) + ").");
+    }
+
+    const bool force_layer_time = settingBool(settings, MS::Cooling::kForceMinLayerTime);
+    const bool use_feedrate_layer_time =
+        settingInt(settings, MS::Cooling::kForceMinLayerTimeMethod) == static_cast<int>(kModifyFeedrateLayerTimeMethod);
+    const double min_layer_time = settingDouble(settings, MS::Cooling::kMinLayerTime);
+    const double max_layer_time = settingDouble(settings, MS::Cooling::kMaxLayerTime);
+
+    if (force_layer_time && min_layer_time <= 0.0)
+        errors.append("Minimum Layer Time must be greater than zero when Force Min / Max Layer Time is enabled.");
+
+    if (force_layer_time && use_feedrate_layer_time) {
+        if (max_layer_time <= 0.0)
+            errors.append("Maximum Layer Time must be greater than zero when Modify Feedrate layer-time control is "
+                          "selected.");
+        else if (min_layer_time > 0.0 && min_layer_time > max_layer_time)
+            errors.append("Minimum Layer Time is greater than Maximum Layer Time.");
+
+        if (settingDouble(settings, MS::Cooling::kExtruderScaleFactor) <= 0.0) {
+            errors.append("Extruder Scale Factor must be greater than zero when Modify Feedrate layer-time control is "
+                          "selected.");
+        }
+    }
+}
+
+double currentMasterVersion() {
+    QFile versions(":/configs/versions.conf");
+    if (!versions.open(QIODevice::ReadOnly))
+        return 0.0;
+
+    try {
+        const fifojson version_data = fifojson::parse(QString(versions.readAll()).toStdString());
+        return version_data.at("master_version").get<double>();
+    } catch (...) { return 0.0; }
+}
+
+QString limitedList(const QStringList& values, int maximum = 12) {
+    if (values.size() <= maximum)
+        return values.join("\n");
+
+    QStringList limited = values.mid(0, maximum);
+    limited.append(QString("...and %1 more.").arg(values.size() - maximum));
+    return limited.join("\n");
+}
+} // namespace
+
+GcodeSettingsImporter::ImportResult
+GcodeSettingsImporter::importFile(const QString& gcode_path, bool use_defaults_for_missing,
+                                  const MissingValueCallback& missing_value_callback) {
+    ImportResult result;
+
+    QFile gcode_file(gcode_path);
+    if (!gcode_file.exists() || !gcode_file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        result.errors.append("Could not open G-Code file: " + gcode_path);
+        return result;
+    }
+
+    QHash<QString, QString> raw_values;
+    const bool footer_found = parseFooterSettings(QString::fromUtf8(gcode_file.readAll()), raw_values, result.warnings);
+    if (!footer_found) {
+        result.errors.append("The selected G-Code file does not contain a Settings Footer.");
+        return result;
+    }
+
+    if (raw_values.isEmpty()) {
+        result.errors.append("The Settings Footer did not contain any setting values.");
+        return result;
+    }
+
+    const fifojson master = GSM->getMaster()->json();
+    fifojson settings = fifojson::object();
+
+    for (auto raw = raw_values.constBegin(); raw != raw_values.constEnd(); ++raw) {
+        if (master.find(raw.key().toStdString()) == master.end())
+            result.unknown_keys.append(raw.key());
+    }
+
+    for (const auto& item : master.items()) {
+        const QString key = QString::fromStdString(item.key());
+        const fifojson& master_entry = item.value();
+        fifojson candidate;
+        bool value_was_prompted = false;
+
+        const auto raw_value = raw_values.constFind(key);
+        if (raw_value != raw_values.constEnd()) {
+            QString parse_error;
+            if (!parseRawValue(key, master_entry, raw_value.value(), candidate, parse_error)) {
+                result.errors.append(parse_error);
+                continue;
+            }
+
+            result.imported_keys.append(key);
+        }
+        else if (use_defaults_for_missing) {
+            candidate = master_entry.at(Constants::Settings::Master::kDefault);
+            result.defaulted_keys.append(key);
+            result.missing_keys.append(key);
+        }
+        else {
+            result.missing_keys.append(key);
+            if (!missing_value_callback) {
+                result.errors.append("Missing setting value for " + key + ".");
+                continue;
+            }
+
+            const std::optional<fifojson> prompted_value = missing_value_callback(key, master_entry);
+            if (!prompted_value.has_value()) {
+                result.errors.append("Import canceled while prompting for missing setting " + key + ".");
+                continue;
+            }
+
+            candidate = prompted_value.value();
+            value_was_prompted = true;
+            result.prompted_keys.append(key);
+        }
+
+        fifojson normalized;
+        QString validation_error;
+        if (!validateValue(key, master_entry, candidate, normalized, validation_error, false)) {
+            result.errors.append(validation_error);
+            continue;
+        }
+
+        settings[item.key()] = normalized;
+        if (value_was_prompted && !result.prompted_keys.contains(key))
+            result.prompted_keys.append(key);
+    }
+
+    if (!result.unknown_keys.isEmpty()) {
+        result.warnings.append("Unknown footer settings were ignored:\n" + limitedList(result.unknown_keys));
+    }
+
+    if (!result.errors.isEmpty())
+        return result;
+
+    validateActiveStaticSettings(settings, master, result.errors);
+    validateDynamicSettings(settings, master, result.errors);
+    if (!result.errors.isEmpty())
+        return result;
+
+    fifojson settings_array = fifojson::array();
+    settings_array.push_back(settings);
+    SettingsVersionControl::formatSettings(currentMasterVersion(), settings_array);
+    result.settings_file = settings_array;
+
+    return result;
+}
+
+bool GcodeSettingsImporter::validateValue(const QString& key, const fifojson& master_entry, const fifojson& value,
+                                          fifojson& normalized_value, QString& error, bool enforce_ranges) {
+    const QString type = settingType(master_entry);
+    if (type.isEmpty()) {
+        error = "Missing type metadata for " + key + ".";
+        return false;
+    }
+
+    if (type == "boolean") {
+        bool result = false;
+        if (!boolValue(value, result)) {
+            error = key + " must be a boolean value.";
+            return false;
+        }
+
+        normalized_value = result;
+        return true;
+    }
+
+    if (type == "enumeration") {
+        int index = -1;
+        if (value.is_string()) {
+            const QString option = QString::fromStdString(value.get<std::string>()).trimmed();
+            const QStringList options = settingOptions(master_entry);
+            for (int i = 0, end = options.size(); i < end; ++i) {
+                if (options[i].compare(option, Qt::CaseInsensitive) == 0) {
+                    index = i;
+                    break;
+                }
+            }
+        }
+        else if (!integerValue(value, index)) {
+            error = key + " must be an enumeration index.";
+            return false;
+        }
+
+        const QStringList options = settingOptions(master_entry);
+        if (index < 0 || index >= options.size()) {
+            error = key + " enumeration index " + QString::number(index) + " is outside the available options.";
+            return false;
+        }
+
+        normalized_value = index;
+        return true;
+    }
+
+    if (type == "number" || type == "positive_int" || type == "power") {
+        int result = 0;
+        if (!integerValue(value, result)) {
+            error = key + " must be an integer value.";
+            return false;
+        }
+
+        if (enforce_ranges && (type == "positive_int" || type == "power") && result < 1) {
+            error = key + " must be greater than zero.";
+            return false;
+        }
+
+        if (enforce_ranges && type == "number" && result < 0) {
+            error = key + " must be zero or greater.";
+            return false;
+        }
+
+        normalized_value = result;
+        return true;
+    }
+
+    if (isDoubleType(type)) {
+        double result = 0.0;
+        if (!numberValue(value, result)) {
+            error = key + " must be a numeric value.";
+            return false;
+        }
+
+        if (enforce_ranges && !validateDoubleRange(key, type, result, error))
+            return false;
+
+        normalized_value = result;
+        return true;
+    }
+
+    if (type == "string" || type == "multiline_text") {
+        if (!value.is_string()) {
+            error = key + " must be a string value.";
+            return false;
+        }
+
+        normalized_value = value;
+        return true;
+    }
+
+    if (type == "numbered_list") {
+        if (!value.is_array()) {
+            error = key + " must be a list of strings.";
+            return false;
+        }
+
+        for (const auto& entry : value) {
+            if (!entry.is_string()) {
+                error = key + " must be a list of strings.";
+                return false;
+            }
+        }
+
+        normalized_value = value;
+        return true;
+    }
+
+    error = "Unsupported setting type `" + type + "` for " + key + ".";
+    return false;
+}
+
+QString GcodeSettingsImporter::displayName(const fifojson& master_entry) {
+    return jsonString(master_entry, Constants::Settings::Master::kDisplay);
+}
+
+QStringList GcodeSettingsImporter::settingOptions(const fifojson& master_entry) {
+    QStringList options =
+        jsonString(master_entry, Constants::Settings::Master::kOptions).split(',', Qt::SkipEmptyParts);
+    for (QString& option : options)
+        option = option.trimmed();
+
+    return options;
+}
+
+} // namespace ORNL

--- a/src/managers/settings/settings_version_control.cpp
+++ b/src/managers/settings/settings_version_control.cpp
@@ -335,6 +335,10 @@ void SettingsVersionControl::formatSettings(double version, fifojson& settings) 
     settings = new_format;
 }
 
+void SettingsVersionControl::migrateLegacySettingKeys(fifojson& settings_group) {
+    migrateSlicingSettingKeys(settings_group);
+}
+
 void SettingsVersionControl::pre_1_0To1_0(double& version, fifojson& settings) {
     QString dt = QDateTime::currentDateTime().toString();
     fifojson new_format;

--- a/src/windows/gcode_to_s2c.cpp
+++ b/src/windows/gcode_to_s2c.cpp
@@ -1,0 +1,183 @@
+#include "windows/gcode_to_s2c.h"
+
+#include <QApplication>
+#include <QFile>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QInputDialog>
+#include <QMessageBox>
+#include <QStringBuilder>
+#include <qcontainerfwd.h>
+
+#include "gcode/gcode_settings_importer.h"
+#include "utilities/constants.h"
+
+namespace ORNL {
+namespace {
+QString errorPreview(const QStringList& errors) {
+    constexpr int kMaxErrors = 10;
+    QStringList preview = errors.mid(0, kMaxErrors);
+    if (errors.size() > kMaxErrors)
+        preview.append(QString("...and %1 more.").arg(errors.size() - kMaxErrors));
+    return preview.join("\n");
+}
+} // namespace
+
+GcodeToS2CDialog::GcodeToS2CDialog(QWidget* parent) : QDialog(parent) { setupUi(); }
+
+QString GcodeToS2CDialog::outputFilePath() const { return m_output_edit->text().trimmed(); }
+
+void GcodeToS2CDialog::setupUi() {
+    setWindowTitle("G-Code to S2C");
+    setMinimumWidth(620);
+
+    m_layout = new QGridLayout(this);
+
+    QLabel* gcode_label = new QLabel("G-Code file:", this);
+    m_gcode_edit = new QLineEdit(this);
+    m_gcode_edit->setReadOnly(true);
+    m_gcode_browse = new QPushButton("Browse...", this);
+
+    QLabel* output_label = new QLabel("Settings file:", this);
+    m_output_edit = new QLineEdit(this);
+    m_output_edit->setReadOnly(true);
+    m_output_browse = new QPushButton("Browse...", this);
+
+    m_use_defaults = new QCheckBox("Use default values for missing settings", this);
+    m_use_defaults->setChecked(true);
+
+    m_status_label = new QLabel(this);
+    m_status_label->setWordWrap(true);
+
+    m_buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    m_buttons->button(QDialogButtonBox::Ok)->setText("Create");
+    m_buttons->button(QDialogButtonBox::Ok)->setEnabled(false);
+
+    m_layout->addWidget(gcode_label, 0, 0);
+    m_layout->addWidget(m_gcode_edit, 0, 1);
+    m_layout->addWidget(m_gcode_browse, 0, 2);
+    m_layout->addWidget(output_label, 1, 0);
+    m_layout->addWidget(m_output_edit, 1, 1);
+    m_layout->addWidget(m_output_browse, 1, 2);
+    m_layout->addWidget(m_use_defaults, 2, 1, 1, 2);
+    m_layout->addWidget(m_status_label, 3, 0, 1, 3);
+    m_layout->addWidget(m_buttons, 4, 0, 1, 3);
+
+    connect(m_gcode_browse, &QPushButton::clicked, this, &GcodeToS2CDialog::browseGcodeFile);
+    connect(m_output_browse, &QPushButton::clicked, this, &GcodeToS2CDialog::browseOutputFile);
+    connect(m_buttons, &QDialogButtonBox::accepted, this, &GcodeToS2CDialog::accept);
+    connect(m_buttons, &QDialogButtonBox::rejected, this, &GcodeToS2CDialog::reject);
+    connect(m_gcode_edit, &QLineEdit::textChanged, this, &GcodeToS2CDialog::refreshAcceptState);
+    connect(m_output_edit, &QLineEdit::textChanged, this, &GcodeToS2CDialog::refreshAcceptState);
+}
+
+void GcodeToS2CDialog::browseGcodeFile() {
+    QFileDialog dialog(this);
+    dialog.setWindowTitle("Select G-Code File");
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setNameFilters(QStringList() << "G-Code Files (*.gcode *.nc *.mpf *.eia *.txt)" << "Any Files (*)");
+
+    if (!dialog.exec())
+        return;
+
+    m_gcode_edit->setText(dialog.selectedFiles().first());
+    setDefaultOutputPath();
+}
+
+void GcodeToS2CDialog::browseOutputFile() {
+    QFileDialog dialog(this);
+    dialog.setWindowTitle("Save Settings File");
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setNameFilters(QStringList() << "ORNLSlicer Configuration/Template File (*.s2c)" << "Any Files (*)");
+    dialog.setDefaultSuffix("s2c");
+
+    if (!m_output_edit->text().isEmpty())
+        dialog.selectFile(m_output_edit->text());
+
+    if (!dialog.exec())
+        return;
+
+    m_output_edit->setText(dialog.selectedFiles().first());
+}
+
+void GcodeToS2CDialog::refreshAcceptState() {
+    const bool ready = !m_gcode_edit->text().trimmed().isEmpty() && !m_output_edit->text().trimmed().isEmpty();
+    m_buttons->button(QDialogButtonBox::Ok)->setEnabled(ready);
+}
+
+void GcodeToS2CDialog::accept() {
+    m_status_label->setText("Creating settings file...");
+    QApplication::processEvents();
+
+    auto missing_callback = [this](const QString& key, const fifojson& master_entry) {
+        return promptForMissingValue(key, master_entry);
+    };
+
+    GcodeSettingsImporter::ImportResult result = GcodeSettingsImporter::importFile(
+        m_gcode_edit->text().trimmed(), m_use_defaults->isChecked(), missing_callback);
+
+    if (!result.errors.isEmpty()) {
+        m_status_label->setText("Could not create settings file.");
+        QMessageBox::critical(this, "G-Code to S2C", errorPreview(result.errors));
+        return;
+    }
+
+    QFile output_file(outputFilePath());
+    if (!output_file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        m_status_label->setText("Could not write settings file.");
+        QMessageBox::critical(this, "G-Code to S2C", "Could not write settings file:\n" + outputFilePath());
+        return;
+    }
+
+    output_file.write(result.settings_file.dump(4).c_str());
+    output_file.close();
+
+    QString message = QString("Created %1 from %2 footer values.")
+                          .arg(QFileInfo(outputFilePath()).fileName())
+                          .arg(result.imported_keys.size());
+    if (!result.defaulted_keys.isEmpty())
+        message += QString(" Used defaults for %1 missing settings.").arg(result.defaulted_keys.size());
+    if (!result.prompted_keys.isEmpty())
+        message += QString(" Prompted for %1 missing settings.").arg(result.prompted_keys.size());
+    if (!result.warnings.isEmpty())
+        message += "\n\nWarnings:\n" + errorPreview(result.warnings);
+
+    QMessageBox::information(this, "G-Code to S2C", message);
+    QDialog::accept();
+}
+
+void GcodeToS2CDialog::setDefaultOutputPath() {
+    if (m_gcode_edit->text().isEmpty() || !m_output_edit->text().isEmpty())
+        return;
+
+    QFileInfo info(m_gcode_edit->text());
+    m_output_edit->setText(info.absolutePath() % "/" % info.completeBaseName() % ".s2c");
+}
+
+std::optional<fifojson> GcodeToS2CDialog::promptForMissingValue(const QString& key, const fifojson& master_entry) {
+    const QString display = GcodeSettingsImporter::displayName(master_entry);
+    const QString label = display + " (" + key + ") is missing.\nEnter the raw setting value:";
+    const QString default_text = QString::fromStdString(master_entry.at(Constants::Settings::Master::kDefault).dump());
+
+    while (true) {
+        bool ok = false;
+        const QString text =
+            QInputDialog::getText(this, "Missing Setting Value", label, QLineEdit::Normal, default_text, &ok);
+        if (!ok)
+            return std::nullopt;
+
+        fifojson candidate;
+        try {
+            candidate = fifojson::parse(text.toStdString());
+        } catch (...) { candidate = text.toStdString(); }
+
+        fifojson normalized;
+        QString error;
+        if (GcodeSettingsImporter::validateValue(key, master_entry, candidate, normalized, error, false))
+            return normalized;
+
+        QMessageBox::warning(this, "Invalid Setting Value", error);
+    }
+}
+
+} // namespace ORNL

--- a/src/windows/gcode_to_s2c.cpp
+++ b/src/windows/gcode_to_s2c.cpp
@@ -21,6 +21,25 @@ QString errorPreview(const QStringList& errors) {
         preview.append(QString("...and %1 more.").arg(errors.size() - kMaxErrors));
     return preview.join("\n");
 }
+
+QString comparableFilePath(const QString& path) {
+    QFileInfo info(path);
+    const QString canonical = info.canonicalFilePath();
+    return canonical.isEmpty() ? info.absoluteFilePath() : canonical;
+}
+
+bool pathsReferToSameFile(const QString& first, const QString& second) {
+    if (first.isEmpty() || second.isEmpty())
+        return false;
+
+    const QString first_path = comparableFilePath(first);
+    const QString second_path = comparableFilePath(second);
+#ifdef Q_OS_WIN
+    return first_path.compare(second_path, Qt::CaseInsensitive) == 0;
+#else
+    return first_path == second_path;
+#endif
+}
 } // namespace
 
 GcodeToS2CDialog::GcodeToS2CDialog(QWidget* parent) : QDialog(parent) { setupUi(); }
@@ -109,12 +128,20 @@ void GcodeToS2CDialog::accept() {
     m_status_label->setText("Creating settings file...");
     QApplication::processEvents();
 
+    const QString gcode_path = m_gcode_edit->text().trimmed();
+    const QString output_path = outputFilePath();
+    if (pathsReferToSameFile(gcode_path, output_path)) {
+        m_status_label->setText("Choose a different settings file path.");
+        QMessageBox::critical(this, "G-Code to S2C", "The settings file cannot overwrite the selected G-Code file.");
+        return;
+    }
+
     auto missing_callback = [this](const QString& key, const fifojson& master_entry) {
         return promptForMissingValue(key, master_entry);
     };
 
-    GcodeSettingsImporter::ImportResult result = GcodeSettingsImporter::importFile(
-        m_gcode_edit->text().trimmed(), m_use_defaults->isChecked(), missing_callback);
+    GcodeSettingsImporter::ImportResult result =
+        GcodeSettingsImporter::importFile(gcode_path, m_use_defaults->isChecked(), missing_callback);
 
     if (!result.errors.isEmpty()) {
         m_status_label->setText("Could not create settings file.");
@@ -122,10 +149,10 @@ void GcodeToS2CDialog::accept() {
         return;
     }
 
-    QFile output_file(outputFilePath());
+    QFile output_file(output_path);
     if (!output_file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
         m_status_label->setText("Could not write settings file.");
-        QMessageBox::critical(this, "G-Code to S2C", "Could not write settings file:\n" + outputFilePath());
+        QMessageBox::critical(this, "G-Code to S2C", "Could not write settings file:\n" + output_path);
         return;
     }
 
@@ -133,7 +160,7 @@ void GcodeToS2CDialog::accept() {
     output_file.close();
 
     QString message = QString("Created %1 from %2 footer values.")
-                          .arg(QFileInfo(outputFilePath()).fileName())
+                          .arg(QFileInfo(output_path).fileName())
                           .arg(result.imported_keys.size());
     if (!result.defaulted_keys.isEmpty())
         message += QString(" Used defaults for %1 missing settings.").arg(result.defaulted_keys.size());

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -72,6 +72,7 @@
 #include "windows/dialogs/template_save.h"
 #include "windows/flowratecalc.h"
 #include "windows/gcode_export.h"
+#include "windows/gcode_to_s2c.h"
 #include "windows/layer_times_window.h"
 #include "windows/preferences_window.h"
 #include "windows/xtrudecalc.h"
@@ -550,6 +551,7 @@ void MainWindow::setupActions() {
                                   QKeySequence(tr("Ctrl+t")), nullptr};
     m_actions["template_save"] = {"Save as Template", ":/icons/settings_save_black.png", false,
                                   QKeySequence(tr("Ctrl+Shift+t")), nullptr};
+    m_actions["gcode_to_s2c"] = {"G-Code to S2C", ":/icons/settings_save_black.png", false, QKeySequence(), nullptr};
     m_actions["setting_folder"] = {"Additional Setting Location", ":/icons/settings_folder_black.png", false,
                                    QKeySequence(), nullptr};
     m_actions["layer_bar_setting_folder"] = {"Additional Layer Bar Setting Location",
@@ -676,6 +678,7 @@ void MainWindow::setupActions() {
     // Settings
     m_menu_settings->addAction(m_actions["template_load"].action);
     m_menu_settings->addAction(m_actions["template_save"].action);
+    m_menu_settings->addAction(m_actions["gcode_to_s2c"].action);
     m_menu_settings->addSeparator();
     m_menu_settings->addAction(m_actions["setting_folder"].action);
     m_menu_settings->addAction(m_actions["layer_bar_setting_folder"].action);
@@ -862,6 +865,7 @@ void MainWindow::setupEvents() {
 
     connect(m_actions["template_load"].action, &QAction::triggered, this, &MainWindow::loadTemplate);
     connect(m_actions["template_save"].action, &QAction::triggered, this, &MainWindow::saveTemplate);
+    connect(m_actions["gcode_to_s2c"].action, &QAction::triggered, this, &MainWindow::convertGcodeToS2C);
     connect(m_actions["setting_folder"].action, &QAction::triggered, this, &MainWindow::setSettingFolder);
     connect(m_actions["layer_bar_setting_folder"].action, &QAction::triggered, this,
             &MainWindow::setLayerBarSettingFolder);
@@ -1711,8 +1715,14 @@ void MainWindow::loadTemplate() {
     if (filename.isEmpty())
         return;
 
-    GSM->loadGlobalJson(filename);
+    loadTemplateFile(filename);
+}
 
+void MainWindow::loadTemplateFile(const QString& filename) {
+    if (filename.isEmpty())
+        return;
+
+    GSM->loadGlobalJson(filename);
     QFileInfo fileInfo(filename);
     QString actualFilename = fileInfo.completeBaseName();
     QStringList tabs {Constants::Settings::SettingTab::kPrinter, Constants::Settings::SettingTab::kMaterial,
@@ -1728,6 +1738,14 @@ void MainWindow::loadTemplate() {
     }
     m_settingbar->displayNewSetting(tabs, actualFilename);
     markProjectModified();
+}
+
+void MainWindow::convertGcodeToS2C() {
+    GcodeToS2CDialog dialog(this);
+    if (!dialog.exec())
+        return;
+
+    loadTemplateFile(dialog.outputFilePath());
 }
 
 void MainWindow::setSettingFolder() {

--- a/tests/gcode_settings_importer_tests.cpp
+++ b/tests/gcode_settings_importer_tests.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <iostream>
+#include <optional>
 
 #include <QCoreApplication>
 #include <QFile>
@@ -75,6 +76,66 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
     if (!expect(paren_settings.at(ORNL::PS::Layer::kBeadWidth.toStdString()).get<double>() == 500.0,
                 "Did not import default width from parenthesized footer."))
+        return EXIT_FAILURE;
+
+    const QString legacy_path = temp_dir.path() + "/legacy.gcode";
+    const QString legacy_gcode = ";Settings Footer\n"
+                                 ";layer_height 200\n"
+                                 ";default_width 400\n"
+                                 ";slicer_type 0\n"
+                                 ";slicing_vector_x 0.25\n"
+                                 ";slicing_vector_y 0.5\n"
+                                 ";slicing_vector_z 0.75\n"
+                                 ";image_resolution_x 0.8\n"
+                                 ";image_resolution_y 0.9\n";
+    if (!expect(writeFile(legacy_path, legacy_gcode), "Could not write legacy key fixture."))
+        return EXIT_FAILURE;
+
+    const ORNL::GcodeSettingsImporter::ImportResult legacy_result =
+        ORNL::GcodeSettingsImporter::importFile(legacy_path, true);
+
+    if (!expect(legacy_result.errors.isEmpty(), qPrintable(legacy_result.errors.join("\n"))))
+        return EXIT_FAILURE;
+
+    const auto legacy_settings = legacy_result.settings_file[ORNL::Constants::SettingFileStrings::kSettings].at(0);
+    using Slicing = ORNL::Constants::ProfileSettings::Slicing;
+    if (!expect(legacy_settings.at(Slicing::kSlicingMode.toStdString()).get<int>() == 0,
+                "Did not migrate legacy slicer_type footer key."))
+        return EXIT_FAILURE;
+    if (!expect(legacy_settings.at(Slicing::kSlicePlaneNormalX.toStdString()).get<double>() == 0.25,
+                "Did not migrate legacy slicing_vector_x footer key."))
+        return EXIT_FAILURE;
+    if (!expect(legacy_settings.at(Slicing::kSlicePlaneNormalY.toStdString()).get<double>() == 0.5,
+                "Did not migrate legacy slicing_vector_y footer key."))
+        return EXIT_FAILURE;
+    if (!expect(legacy_settings.at(Slicing::kSlicePlaneNormalZ.toStdString()).get<double>() == 0.75,
+                "Did not migrate legacy slicing_vector_z footer key."))
+        return EXIT_FAILURE;
+    if (!expect(legacy_settings.at(Slicing::kImagePixelSizeX.toStdString()).get<double>() == 0.8,
+                "Did not migrate legacy image_resolution_x footer key."))
+        return EXIT_FAILURE;
+    if (!expect(legacy_settings.at(Slicing::kImagePixelSizeY.toStdString()).get<double>() == 0.9,
+                "Did not migrate legacy image_resolution_y footer key."))
+        return EXIT_FAILURE;
+    if (!expect(legacy_result.unknown_keys.isEmpty(), "Migrated legacy footer keys were still reported as unknown."))
+        return EXIT_FAILURE;
+
+    const QString cancel_path = temp_dir.path() + "/cancel.gcode";
+    const QString cancel_gcode = ";Settings Footer\n"
+                                 ";layer_height 200\n";
+    if (!expect(writeFile(cancel_path, cancel_gcode), "Could not write cancel fixture."))
+        return EXIT_FAILURE;
+
+    int prompt_count = 0;
+    const ORNL::GcodeSettingsImporter::ImportResult cancel_result =
+        ORNL::GcodeSettingsImporter::importFile(cancel_path, false, [&prompt_count](const QString&, const fifojson&) {
+            ++prompt_count;
+            return std::optional<fifojson>();
+        });
+
+    if (!expect(!cancel_result.errors.isEmpty(), "Canceling a missing setting prompt did not fail the import."))
+        return EXIT_FAILURE;
+    if (!expect(prompt_count == 1, "Canceling a missing setting prompt did not stop further prompts."))
         return EXIT_FAILURE;
 
     return EXIT_SUCCESS;

--- a/tests/gcode_settings_importer_tests.cpp
+++ b/tests/gcode_settings_importer_tests.cpp
@@ -1,0 +1,81 @@
+#include <cstdlib>
+#include <iostream>
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QStringBuilder>
+#include <QTemporaryDir>
+
+#include "gcode/gcode_settings_importer.h"
+#include "utilities/constants.h"
+
+namespace {
+bool writeFile(const QString& path, const QString& text) {
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
+        return false;
+
+    file.write(text.toUtf8());
+    return true;
+}
+
+bool expect(bool condition, const char* message) {
+    if (!condition)
+        std::cerr << message << '\n';
+    return condition;
+}
+} // namespace
+
+int main(int argc, char* argv[]) {
+    QCoreApplication app(argc, argv);
+
+    QTemporaryDir temp_dir;
+    if (!expect(temp_dir.isValid(), "Could not create temporary directory."))
+        return EXIT_FAILURE;
+
+    const QString semicolon_path = temp_dir.path() + "/semicolon.gcode";
+    const QString semicolon_gcode = "G1 X0 Y0\n"
+                                    ";Settings Footer\n"
+                                    ";layer_height 200\n"
+                                    ";default_width 400\n";
+    if (!expect(writeFile(semicolon_path, semicolon_gcode), "Could not write semicolon fixture."))
+        return EXIT_FAILURE;
+
+    const ORNL::GcodeSettingsImporter::ImportResult semicolon_result =
+        ORNL::GcodeSettingsImporter::importFile(semicolon_path, true);
+
+    if (!expect(semicolon_result.errors.isEmpty(), qPrintable(semicolon_result.errors.join("\n"))))
+        return EXIT_FAILURE;
+
+    const auto semicolon_settings =
+        semicolon_result.settings_file[ORNL::Constants::SettingFileStrings::kSettings].at(0);
+    if (!expect(semicolon_settings.at(ORNL::PS::Layer::kLayerHeight.toStdString()).get<double>() == 200.0,
+                "Did not import layer height from semicolon footer."))
+        return EXIT_FAILURE;
+    if (!expect(semicolon_settings.at(ORNL::PS::Layer::kBeadWidth.toStdString()).get<double>() == 400.0,
+                "Did not import default width from semicolon footer."))
+        return EXIT_FAILURE;
+
+    const QString paren_path = temp_dir.path() + "/paren.nc";
+    const QString paren_gcode = "(Settings Footer)\n"
+                                "(layer_height 300)\n"
+                                "(default_width 500)\n";
+    if (!expect(writeFile(paren_path, paren_gcode), "Could not write parenthesized fixture."))
+        return EXIT_FAILURE;
+
+    const ORNL::GcodeSettingsImporter::ImportResult paren_result =
+        ORNL::GcodeSettingsImporter::importFile(paren_path, true);
+
+    if (!expect(paren_result.errors.isEmpty(), qPrintable(paren_result.errors.join("\n"))))
+        return EXIT_FAILURE;
+
+    const auto paren_settings = paren_result.settings_file[ORNL::Constants::SettingFileStrings::kSettings].at(0);
+    if (!expect(paren_settings.at(ORNL::PS::Layer::kLayerHeight.toStdString()).get<double>() == 300.0,
+                "Did not import layer height from parenthesized footer."))
+        return EXIT_FAILURE;
+    if (!expect(paren_settings.at(ORNL::PS::Layer::kBeadWidth.toStdString()).get<double>() == 500.0,
+                "Did not import default width from parenthesized footer."))
+        return EXIT_FAILURE;
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- Add a Settings > G-Code to S2C workflow for creating `.s2c` files from G-code settings footers.
- Add a reusable `GcodeSettingsImporter` that parses footer values, fills missing settings from defaults or prompts, validates active settings, and formats a current-version settings file.
- Add importer tests for semicolon and parenthesized footer formats.

## Impact
Users can recover a complete settings template from old G-code files that contain ORNLSlicer settings footers, then immediately load that template into the Slicer.

Closes #228.

## Validation
- `nix develop -c cmake --build build/generic-llvm-ninja --target ornlslicer_gcode_settings_importer_tests -j2`
- `nix develop -c ctest --test-dir build/generic-llvm-ninja -C Debug --output-on-failure`