### PR TITLE
Update Arc Specialties welder command handling

### DIFF
--- a/docs/gcode/arc-specialties.md
+++ b/docs/gcode/arc-specialties.md
@@ -102,7 +102,7 @@ The layer marker is held until after the initial world approach and kinematics b
 Travel moves use `G00`. Cylindrical travel lift moves outward from the cylinder axis; planar travel lift follows the slice-plane normal. Non-first cylindrical travel may be split into `TRAVEL ARC` waypoints around the cylinder axis when the angular move is long enough. Travel lower is emitted as a feed move:
 
 ```gcode
-;G80 ;OPTIONAL STOP ROUTINE
+G81 ;OPTIONAL STOP ROUTINE
 G01 X=... Y=... Z=... XR=180.0000 YR=0.0000 ZR=-135.0000 AP=... CP=... F... ;TRAVEL LOWER
 ```
 
@@ -118,7 +118,7 @@ M151 ;WIRE ARC WELDER OFF
 #CHANNEL INIT [CMDPOS]
 ```
 
-`M06`, `G80`, and `M160` are currently emitted as comments because the inline writer TODOs identify controller issues with those commands as of 2026-07-29. They should be re-enabled or replaced only after the controller behavior is resolved.
+`M06` and `M160` are currently emitted as comments because the inline writer TODOs identify controller issues with those commands as of 2026-07-29. They should be re-enabled or replaced only after the controller behavior is resolved.
 
 Shutdown writes any configured end code, emits `G164` when absolute center mode was active, sends the robot home, initializes the channel, and ends the program with `M02`.
 

--- a/docs/gcode/arc-specialties.md
+++ b/docs/gcode/arc-specialties.md
@@ -106,6 +106,9 @@ G81 ;OPTIONAL STOP ROUTINE
 G01 X=... Y=... Z=... XR=180.0000 YR=0.0000 ZR=-135.0000 AP=... CP=... F... ;TRAVEL LOWER
 ```
 
+When `Arc Specialties G2/G3 Optional Stop` is selected, non-initial `G02`/`G03` print arcs also emit `G81` before
+the arc move.
+
 The writer turns welding and blending on before print motion and off before longer travel or shutdown:
 
 ```gcode

--- a/docs/gcode/arc-specialties.md
+++ b/docs/gcode/arc-specialties.md
@@ -112,13 +112,11 @@ the arc move.
 The writer turns welding and blending on before print motion and off before longer travel or shutdown:
 
 ```gcode
-M150 ;WIRE ARC WELDER ON
+G82 ;WIRE ARC WELDER ON
 G261 ;BLENDING ON
 ...
 G260 ;BLENDING OFF
-M151 ;WIRE ARC WELDER OFF
-;M160 ;CLIP WIRE
-#CHANNEL INIT [CMDPOS]
+G83 [0] ;WIRE ARC WELDER OFF
 ```
 
 `M06` is currently emitted as a comment because the inline writer TODOs identify controller issues with that command as of 2026-08-07. It should be re-enabled or replaced only after the controller behavior is resolved.
@@ -127,7 +125,7 @@ Shutdown writes any configured end code, emits `G164` when absolute center mode 
 
 ## Parser Behavior
 
-`ArcSpecialtiesParser` is selected for generated or imported files whose header identifies the `Arc Specialties` syntax. It normalizes `G00`, `G01`, `G02`, and `G03` to the shared parser's `G0`, `G1`, `G2`, and `G3` handlers after Arc Specialties-specific preprocessing.
+`ArcSpecialtiesParser` is selected for generated or imported files whose header identifies the `Arc Specialties` syntax. It normalizes `G00`, `G01`, `G02`, and `G03` to the shared parser's `G0`, `G1`, `G2`, and `G3` handlers after Arc Specialties-specific preprocessing. `G82` marks deposition active for subsequent motion metadata, and `G83` marks deposition inactive.
 
 The parser accepts:
 

--- a/docs/gcode/arc-specialties.md
+++ b/docs/gcode/arc-specialties.md
@@ -118,7 +118,7 @@ M151 ;WIRE ARC WELDER OFF
 #CHANNEL INIT [CMDPOS]
 ```
 
-`M06` and `M160` are currently emitted as comments because the inline writer TODOs identify controller issues with those commands as of 2026-07-29. They should be re-enabled or replaced only after the controller behavior is resolved.
+`M06` is currently emitted as a comment because the inline writer TODOs identify controller issues with that command as of 2026-08-07. It should be re-enabled or replaced only after the controller behavior is resolved.
 
 Shutdown writes any configured end code, emits `G164` when absolute center mode was active, sends the robot home, initializes the channel, and ends the program with `M02`.
 

--- a/include/gcode/gcode_command.h
+++ b/include/gcode/gcode_command.h
@@ -104,11 +104,11 @@ class GcodeCommand : public QObject {
     //! \brief Clears the comment string.
     void clearComment();
 
-    //! \brief sets whether the extruder is on for this command
-    void setExtruderOn(bool extruder_on);
+    //! \brief Sets whether deposition is active for this command.
+    void setDepositionActive(bool deposition_active);
 
-    //! \brief gets whether the extruder is on for this command
-    bool getExtruderOn() const;
+    //! \brief Gets whether deposition is active for this command.
+    bool getDepositionActive() const;
 
     //! \brief sets extruder speed for this command
     //! \param extruder_speed
@@ -135,7 +135,7 @@ class GcodeCommand : public QObject {
     int m_command_id;
     QMap<char, double> m_parameters;
     QMap<char, double> m_optional_parameters;
-    bool m_extruder_on;
+    bool m_deposition_active;
     double m_extruder_speed;
     QString m_comment;
     QString m_commandLine;

--- a/include/gcode/gcode_motion_estimate.h
+++ b/include/gcode/gcode_motion_estimate.h
@@ -13,13 +13,13 @@ class MotionEstimation {
     //! \brief Calculate time and volume contribution from motion
     //! \param layer, current layer number
     //! \param isFIncluded, if the current command statement include velocity / speed
-    //! \param isGOCommand, if the current command statement is the fast non extruding move (G0)
-    //! \param extruder_on, whether the extruder is on currently
+    //! \param isGOCommand, if the current command statement is the fast non-deposition move (G0)
+    //! \param deposition_active, whether deposition is active currently
     //! \param G1F_time, G1 commands execution time estimates
     //! \param layer_time, accumulated time estimate for the entire layer
     //! \param layer_volume, accumulated volume estimate for the entire layer
     //! \param use_b, if using B filament axis, time calculation is based on extrusion not X/Y/Z distance
-    static Distance calculateTimeAndVolume(int layer, bool isFIncluded, bool isGOCommand, bool extruder_on,
+    static Distance calculateTimeAndVolume(int layer, bool isFIncluded, bool isGOCommand, bool deposition_active,
                                            Time& G1F_time, Time& layer_time, Volume& layer_volume, bool use_b);
 
     //! \brief Calculate time and volume contribution for a non-linear path with a known path length.
@@ -27,10 +27,10 @@ class MotionEstimation {
                                                Distance start_direction_y, Distance start_direction_z,
                                                Distance end_direction_x, Distance end_direction_y,
                                                Distance end_direction_z, bool isFIncluded, bool isGOCommand,
-                                               bool extruder_on, Time& G1F_time, Time& layer_time,
+                                               bool deposition_active, Time& G1F_time, Time& layer_time,
                                                Volume& layer_volume);
 
-    //! \brief Set the bead dimensions to use for the next extrusion volume estimate.
+    //! \brief Set the bead dimensions to use for the next deposited volume estimate.
     //! \param bead_width Total bead width.
     //! \param bead_height Nominal bead height.
     static void setBeadGeometry(Distance bead_width, Distance bead_height);

--- a/include/gcode/parsers/arc_specialties_parser.h
+++ b/include/gcode/parsers/arc_specialties_parser.h
@@ -71,6 +71,12 @@ class ArcSpecialtiesParser : public CommonParser {
     //! @brief Disables absolute I/J arc-center parsing.
     void G164Handler(QVector<QString> params);
 
+    //! @brief Marks Arc Specialties welder output as active deposition.
+    void G82Handler(QVector<QString> params);
+
+    //! @brief Marks Arc Specialties welder output as inactive deposition.
+    void G83Handler(QVector<QString> params);
+
   private:
     /*!
      * @brief Validates Arc Specialties parameters and returns common-parser-compatible linear parameters.

--- a/include/gcode/parsers/arc_specialties_parser.h
+++ b/include/gcode/parsers/arc_specialties_parser.h
@@ -134,10 +134,10 @@ class ArcSpecialtiesParser : public CommonParser {
     QVector<QString> convertAbsoluteArcCenterParams(const QVector<QString>& params);
 
     /*!
-     * @brief Sets the extruder state used by CommonParser motion estimation.
-     * @param on True to mark the extruder as printing.
+     * @brief Sets the deposition state used by CommonParser motion estimation.
+     * @param on True to mark the parser as depositing material.
      */
-    void setExtruderActive(bool on);
+    void setDepositionActive(bool on);
 
     /*!
      * @brief Runs a CommonParser arc handler with optional cylindrical print classification.

--- a/include/gcode/parsers/common_parser.h
+++ b/include/gcode/parsers/common_parser.h
@@ -464,8 +464,8 @@ class CommonParser : public ParserBase {
     //! an integer conversion occurs. \throws IllegalParameterException
     void throwIntegerConversionErrorException();
 
-    //! \brief maintains whether the extruder is on or off
-    bool m_extruder_on = false;
+    //! \brief Tracks whether the parsed command stream is actively depositing material.
+    bool m_deposition_active = false;
 
     bool m_dynamic_spindle_control; // true if on, false if off.
     bool m_park;                    // true if parking, false if not.
@@ -532,8 +532,8 @@ class CommonParser : public ParserBase {
     //! for use in visualization construction.
     void preallocateVisualCommands();
 
-    //! \brief sets whether the extruder is on
-    void setExtruderOn(bool on);
+    //! \brief Sets the current deposition-active state.
+    void setDepositionActive(bool on);
 
     // STATE VARIABLES
 

--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -294,6 +294,9 @@ class ArcSpecialtiesWriter : public WriterBase {
     //! @brief Tracks whether any travel move has been emitted.
     bool m_first_travel = true;
 
+    //! @brief Tracks whether any deposition move has been emitted on the current layer.
+    bool m_first_deposition = true;
+
     //! @brief Forces feedrate output at the start of each layer.
     bool m_layer_start = true;
 

--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -156,10 +156,10 @@ class ArcSpecialtiesWriter : public WriterBase {
     QString writeDwell(Time time) override;
 
   private:
-    //! \brief Writes G-Code to enable extrusion
-    QString writeExtruderOn();
-    //! \brief Writes G-Code to disable extrusion
-    QString writeExtruderOff();
+    //! \brief Writes G-Code to enable the welder
+    QString writeWelderOn();
+    //! \brief Writes G-Code to disable the welder
+    QString writeWelderOff();
 
     /*!
      * @brief Writes a single Arc Specialties motion command.

--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -158,8 +158,13 @@ class ArcSpecialtiesWriter : public WriterBase {
   private:
     //! \brief Writes G-Code to enable the welder
     QString writeWelderOn();
-    //! \brief Writes G-Code to disable the welder
-    QString writeWelderOff();
+    /*!
+     * @brief Writes G-Code to disable the welder.
+     * @param mode Arc Specialties G83 mode: 0 stops welding, 1 retracts, 2 clips wire and homes, 3 moves linearly to
+     * the retract position, and 4 moves linearly back to the previous programmed position.
+     * @return Welder shutdown block.
+     */
+    QString writeWelderOff(int mode = 0);
 
     /*!
      * @brief Writes a single Arc Specialties motion command.

--- a/include/gcode/writers/writer_base.h
+++ b/include/gcode/writers/writer_base.h
@@ -197,7 +197,9 @@ class WriterBase {
     Velocity m_feedrate;
     Distance m_current_z, m_current_w, m_last_z, m_last_w;
     Point m_start_point;
-    bool m_extruder_on;
+
+    //! \brief Tracks whether the material deposition process is active.
+    bool m_deposition_active;
 
     //! \brief maintains the min z of the last layer so that we can determine if/when to move the table
     float m_min_z;

--- a/include/threading/gcode_loader.h
+++ b/include/threading/gcode_loader.h
@@ -135,11 +135,11 @@ class GCodeLoader : public QThread {
     //! \param segment: Segment to set meta info for.
     //! \param comment: Comment to parse for the segment type.
     //! \param info_end_pos: The end position of the segment.
-    //! \param extruder_on: Indicates if the extruder is on or off.
+    //! \param deposition_active: Indicates if the command is actively depositing material.
     //! \param info_speed_set: Indicates if the speed is set.
     //! \param extruder_speed: The speed of the extruder.
     void setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const QString& comment, QVector3D& info_end_pos,
-                            const bool& extruder_on, const bool& info_speed_set, const double& extruder_speed);
+                            const bool& deposition_active, const bool& info_speed_set, const double& extruder_speed);
 
     //! \brief generate additional export comments
     //! \return string
@@ -151,15 +151,15 @@ class GCodeLoader : public QThread {
     //! \param color: Color of segment based on comments from gcode
     //! \param command_id: the id of the gcode command for th segment
     //! \param parameters: Parameters of gcodecommand end (x, y, z, w, i, j, p, q)
-    //! \param extruder_on: whether the extruder is on
+    //! \param deposition_active: whether the command is actively depositing material
     //! \param extruder_speed: double value read from gcode
-    //! \param include_non_extruding_moves: if true, generates visual segments when the extruder is off
+    //! \param include_non_deposition_moves: if true, generates visual segments when deposition is inactive
     //! \param optional_parameters: Parameters of gcodecommand for start (x, y, z, w)
     //! \return List of generated visual segments.
     QVector<QSharedPointer<SegmentBase>>
     generateVisualSegment(int line_num, int layer_num, const QColor& color, int command_id,
-                          const QMap<char, double>& parameters, bool extruder_on, double extruder_speed,
-                          bool include_non_extruding_moves, const QString comment,
+                          const QMap<char, double>& parameters, bool deposition_active, double extruder_speed,
+                          bool include_non_deposition_moves, const QString comment,
                           const QMap<char, double>& optional_parameters = QMap<char, double>());
 
     //! \brief Filename.

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -268,6 +268,7 @@ class Constants {
             static const QString kEnableBoundingBox;
             static const QString kEnableSettingsFooter;
             static const QString kLayerTimeComments;
+            static const QString kArcSpecialtiesG2G3OptionalStop;
             static const QString kStartCode;
             static const QString kLayerCodeChange;
             static const QString kEndCode;

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -883,6 +883,19 @@
       "symbol":"kLayerTimeComments",
       "local":false
   },
+  "arc_specialties_g2_g3_optional_stop": {
+      "display":"Arc Specialties G2/G3 Optional Stop",
+      "type":"boolean",
+      "tooltip":"If selected, Arc Specialties G-Code emits a G81 optional stop routine before each non-initial G2/G3 arc move.",
+      "depends":{"AND":[{"syntax":31},{"supports_G2_3":true}]},
+      "options":"",
+      "default":true,
+      "minor":"G-Code",
+      "major":"Printer",
+      "namespace":"Printer::GCode",
+      "symbol":"kArcSpecialtiesG2G3OptionalStop",
+      "local":false
+  },
   "start_code": {
       "display":"Start Code",
       "type":"multiline_text",

--- a/resources/settings/006_printer_g_code.yaml
+++ b/resources/settings/006_printer_g_code.yaml
@@ -73,6 +73,18 @@ settings:
     namespace: "Printer::GCode"
     symbol: "kLayerTimeComments"
     local: false
+  - name: "arc_specialties_g2_g3_optional_stop"
+    display: "Arc Specialties G2/G3 Optional Stop"
+    type: "boolean"
+    tooltip: "If selected, Arc Specialties G-Code emits a G81 optional stop routine before each non-initial G2/G3 arc move."
+    depends: {"AND":[{"syntax":31},{"supports_G2_3":true}]}
+    options: []
+    default: true
+    minor: "G-Code"
+    major: "Printer"
+    namespace: "Printer::GCode"
+    symbol: "kArcSpecialtiesG2G3OptionalStop"
+    local: false
   - name: "start_code"
     display: "Start Code"
     type: "multiline_text"

--- a/src/gcode/gcode_command.cpp
+++ b/src/gcode/gcode_command.cpp
@@ -9,13 +9,13 @@
 namespace ORNL {
 GcodeCommand::GcodeCommand()
     : m_line_number(-1), m_command(0), m_command_id(-1), m_is_motion_command(false), m_is_end_of_layer(false),
-      m_extruder_on(false), m_extruder_speed(0) {}
+      m_deposition_active(false), m_extruder_speed(0) {}
 
 GcodeCommand::GcodeCommand(const GcodeCommand& other)
     : m_line_number(other.m_line_number), m_command(other.m_command), m_command_id(other.m_command_id),
       m_parameters(other.m_parameters), m_optional_parameters(other.m_optional_parameters), m_comment(other.m_comment),
       m_is_motion_command(other.m_is_motion_command), m_is_end_of_layer(other.m_is_end_of_layer),
-      m_extruder_on(other.m_extruder_on), m_extruder_speed(other.m_extruder_speed) {}
+      m_deposition_active(other.m_deposition_active), m_extruder_speed(other.m_extruder_speed) {}
 
 //! \brief Retrieves the line number of the command
 const int& GcodeCommand::getLineNumber() const { return m_line_number; }
@@ -97,9 +97,9 @@ GcodeCommand& GcodeCommand::operator=(const GcodeCommand& other) {
     return *this;
 }
 
-void GcodeCommand::setExtruderOn(bool extruder_on) { m_extruder_on = extruder_on; }
+void GcodeCommand::setDepositionActive(bool deposition_active) { m_deposition_active = deposition_active; }
 
-bool GcodeCommand::getExtruderOn() const { return m_extruder_on; }
+bool GcodeCommand::getDepositionActive() const { return m_deposition_active; }
 
 void GcodeCommand::setExtruderSpeed(double extruder_speed) { m_extruder_speed = extruder_speed; }
 

--- a/src/gcode/gcode_motion_estimate.cpp
+++ b/src/gcode/gcode_motion_estimate.cpp
@@ -45,7 +45,7 @@ void MotionEstimation::setBeadGeometry(Distance bead_width, Distance bead_height
 
 void MotionEstimation::resetBeadHeight() { m_current_bead_height = 0; }
 
-Distance MotionEstimation::calculateTimeAndVolume(int layer, bool isFIncluded, bool isGOCommand, bool extruder_on,
+Distance MotionEstimation::calculateTimeAndVolume(int layer, bool isFIncluded, bool isGOCommand, bool deposition_active,
                                                   Time& G1F_time, Time& layer_time, Volume& layer_volume, bool use_b) {
     static_cast<void>(layer);
 
@@ -120,14 +120,14 @@ Distance MotionEstimation::calculateTimeAndVolume(int layer, bool isFIncluded, b
     // the rest is for a predominantly XY move
     Distance length = sqrt(dx * dx + dy * dy + dz * dz);
     return MotionEstimation::calculatePathTimeAndVolume(length, dx, dy, dz, dx, dy, dz, isFIncluded, isGOCommand,
-                                                        extruder_on, G1F_time, layer_time, layer_volume);
+                                                        deposition_active, G1F_time, layer_time, layer_volume);
 }
 
 Distance MotionEstimation::calculatePathTimeAndVolume(Distance path_length, Distance start_direction_x,
                                                       Distance start_direction_y, Distance start_direction_z,
                                                       Distance end_direction_x, Distance end_direction_y,
                                                       Distance end_direction_z, bool isFIncluded, bool isGOCommand,
-                                                      bool extruder_on, Time& G1F_time, Time& layer_time,
+                                                      bool deposition_active, Time& G1F_time, Time& layer_time,
                                                       Volume& layer_volume) {
     // minimum distance to be considered move for estimate calculation
     double m_min_threshold = 10;
@@ -175,8 +175,8 @@ Distance MotionEstimation::calculatePathTimeAndVolume(Distance path_length, Dist
             MotionEstimation::setPreviousVelocityVector(m_incomingV, end_direction_x, end_direction_y, end_direction_z);
         }
 
-        // if the extruder is on, calculate the extruded volume
-        if (extruder_on) {
+        // If deposition is active, calculate the deposited volume.
+        if (deposition_active) {
             Distance height = m_current_bead_height > 0 ? m_current_bead_height : m_nominal_bead_height;
             Distance bead_width = m_current_bead_width > 0 ? m_current_bead_width : extrusionWidth;
 

--- a/src/gcode/parsers/arc_specialties_parser.cpp
+++ b/src/gcode/parsers/arc_specialties_parser.cpp
@@ -43,6 +43,8 @@ void ArcSpecialtiesParser::config() {
     addCommandMapping("G161", std::bind(&ArcSpecialtiesParser::G161Handler, this, std::placeholders::_1));
     addCommandMapping("G162", std::bind(&ArcSpecialtiesParser::G162Handler, this, std::placeholders::_1));
     addCommandMapping("G164", std::bind(&ArcSpecialtiesParser::G164Handler, this, std::placeholders::_1));
+    addCommandMapping("G82", std::bind(&ArcSpecialtiesParser::G82Handler, this, std::placeholders::_1));
+    addCommandMapping("G83", std::bind(&ArcSpecialtiesParser::G83Handler, this, std::placeholders::_1));
 }
 
 void ArcSpecialtiesParser::G0Handler(QVector<QString> params) {
@@ -79,6 +81,10 @@ void ArcSpecialtiesParser::G161Handler(QVector<QString>) { m_use_absolute_arc_ce
 void ArcSpecialtiesParser::G162Handler(QVector<QString>) { m_use_absolute_arc_centers = false; }
 
 void ArcSpecialtiesParser::G164Handler(QVector<QString>) { m_use_absolute_arc_centers = false; }
+
+void ArcSpecialtiesParser::G82Handler(QVector<QString>) { setDepositionActive(true); }
+
+void ArcSpecialtiesParser::G83Handler(QVector<QString>) { setDepositionActive(false); }
 
 QVector<QString> ArcSpecialtiesParser::normalizeAndStripOrientationAxes(QVector<QString> params) {
     QVector<QString> filtered_params;

--- a/src/gcode/parsers/arc_specialties_parser.cpp
+++ b/src/gcode/parsers/arc_specialties_parser.cpp
@@ -59,13 +59,13 @@ void ArcSpecialtiesParser::G1Handler(QVector<QString> params) {
     if (!filtered_params.isEmpty()) {
         const bool force_print_state = isCommentedPrintMove();
         if (force_print_state) {
-            setExtruderActive(true);
+            setDepositionActive(true);
         }
 
         CommonParser::G1Handler(filtered_params);
 
         if (force_print_state) {
-            setExtruderActive(false);
+            setDepositionActive(false);
         }
     }
 }
@@ -212,7 +212,7 @@ QVector<QString> ArcSpecialtiesParser::convertAbsoluteArcCenterParams(const QVec
     return converted_params;
 }
 
-void ArcSpecialtiesParser::setExtruderActive(bool on) { m_extruder_on = on; }
+void ArcSpecialtiesParser::setDepositionActive(bool on) { m_deposition_active = on; }
 
 void ArcSpecialtiesParser::handleArcFeedMove(QVector<QString> params, bool ccw) {
     QVector<QString> filtered_params = normalizeAndStripOrientationAxes(params);
@@ -224,7 +224,7 @@ void ArcSpecialtiesParser::handleArcFeedMove(QVector<QString> params, bool ccw) 
 
     const bool force_print_state = isCommentedPrintMove();
     if (force_print_state) {
-        setExtruderActive(true);
+        setDepositionActive(true);
     }
 
     if (ccw) {
@@ -235,7 +235,7 @@ void ArcSpecialtiesParser::handleArcFeedMove(QVector<QString> params, bool ccw) 
     }
 
     if (force_print_state) {
-        setExtruderActive(false);
+        setDepositionActive(false);
     }
 }
 } // namespace ORNL

--- a/src/gcode/parsers/beam_parser.cpp
+++ b/src/gcode/parsers/beam_parser.cpp
@@ -26,7 +26,7 @@ void BeamParser::M110Handler(QVector<QString> params) {
         return;
     }
 
-    m_extruder_on = true;
+    m_deposition_active = true;
 }
 
 void BeamParser::M111Handler(QVector<QString> params) {
@@ -34,6 +34,6 @@ void BeamParser::M111Handler(QVector<QString> params) {
         return;
     }
 
-    m_extruder_on = false;
+    m_deposition_active = false;
 }
 } // namespace ORNL

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -105,8 +105,9 @@ Distance CommonParser::getCurrentGXDistance() {
 
     const Time adjustable_time_before = m_layer_G1F_times[m_current_layer];
     const Distance distance = MotionEstimation::calculateTimeAndVolume(
-        m_current_layer, include_feedrate_adjustable_time, m_current_gcode_command.getCommandID() == 0, m_extruder_on,
-        m_layer_G1F_times[m_current_layer], m_layer_times[m_current_layer], m_layer_volumes[m_current_layer], uses_b);
+        m_current_layer, include_feedrate_adjustable_time, m_current_gcode_command.getCommandID() == 0,
+        m_deposition_active, m_layer_G1F_times[m_current_layer], m_layer_times[m_current_layer],
+        m_layer_volumes[m_current_layer], uses_b);
 
     const Time command_adjustable_time = m_layer_G1F_times[m_current_layer] - adjustable_time_before;
     if (command_adjustable_time > 0) {
@@ -137,8 +138,8 @@ Distance CommonParser::getCurrentArcDistance(Distance start_x, Distance start_y,
     const Time adjustable_time_before = m_layer_G1F_times[m_current_layer];
     const Distance distance = MotionEstimation::calculatePathTimeAndVolume(
         path_length, start_direction_x, start_direction_y, start_direction_z, end_direction_x, end_direction_y,
-        end_direction_z, include_feedrate_adjustable_time, false, m_extruder_on, m_layer_G1F_times[m_current_layer],
-        m_layer_times[m_current_layer], m_layer_volumes[m_current_layer]);
+        end_direction_z, include_feedrate_adjustable_time, false, m_deposition_active,
+        m_layer_G1F_times[m_current_layer], m_layer_times[m_current_layer], m_layer_volumes[m_current_layer]);
 
     const Time command_adjustable_time = m_layer_G1F_times[m_current_layer] - adjustable_time_before;
     if (command_adjustable_time > 0) {
@@ -535,7 +536,7 @@ QHash<QString, double> CommonParser::parseFooter() {
 
     checkAndSetNecessarySettings();
 
-    m_extruder_on = false;
+    m_deposition_active = false;
 
     // return copy to gcode loader as several settings are required to calculate visualization
     return m_file_settings;
@@ -681,11 +682,11 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
             continue;
         }
         else if (m_upper_lines[m_current_line].contains("EXTRUDER(0)")) {
-            m_extruder_on = false;
+            m_deposition_active = false;
             continue;
         }
         else if (m_upper_lines[m_current_line].contains("EXTRUDER(")) {
-            m_extruder_on = true;
+            m_deposition_active = true;
 
             int first = m_upper_lines[m_current_line].indexOf("(") + 1;
             int second = m_upper_lines[m_current_line].indexOf(")");
@@ -895,7 +896,7 @@ void CommonParser::reset() {
     m_wait_to_wipe_time = 0 * m_time_unit;
     m_wait_time_to_start_purge = 0 * m_time_unit;
 
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_dynamic_spindle_control = false;
     m_park = false;
     m_with_F_value = false;
@@ -1093,7 +1094,7 @@ void CommonParser::G0Handler(QVector<QString> params) {
                 break;
         }
     }
-    m_current_gcode_command.setExtruderOn(m_extruder_on);
+    m_current_gcode_command.setDepositionActive(m_deposition_active);
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (is_motion_command) {
@@ -1103,7 +1104,7 @@ void CommonParser::G0Handler(QVector<QString> params) {
     Distance temp = getCurrentGXDistance();
     MotionEstimation::m_total_distance += temp;
 
-    if (m_extruder_on)
+    if (m_deposition_active)
         MotionEstimation::m_printing_distance += temp;
     else
         MotionEstimation::m_travel_distance += temp;
@@ -1257,15 +1258,15 @@ void CommonParser::G1Handler(QVector<QString> params) {
                     current_value *= m_distance_unit();
                     if (m_e_absolute) {
                         if (current_value > MotionEstimation::m_previous_e)
-                            setExtruderOn(true);
+                            setDepositionActive(true);
                         else
-                            setExtruderOn(false);
+                            setDepositionActive(false);
                     }
                     else {
                         if (current_value > 0)
-                            setExtruderOn(true);
+                            setDepositionActive(true);
                         else
-                            setExtruderOn(false);
+                            setDepositionActive(false);
                     }
                     MotionEstimation::m_current_e = current_value;
                     e_not_used = false;
@@ -1285,7 +1286,7 @@ void CommonParser::G1Handler(QVector<QString> params) {
         }
         m_current_gcode_command.addParameter(current_parameter, current_value);
     }
-    m_current_gcode_command.setExtruderOn(m_extruder_on);
+    m_current_gcode_command.setDepositionActive(m_deposition_active);
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (!f_not_used)
@@ -1301,7 +1302,7 @@ void CommonParser::G1Handler(QVector<QString> params) {
 
     Distance temp = getCurrentGXDistance();
     MotionEstimation::m_total_distance += temp;
-    if (m_extruder_on)
+    if (m_deposition_active)
         MotionEstimation::m_printing_distance += temp;
     else
         MotionEstimation::m_travel_distance += temp;
@@ -1474,15 +1475,15 @@ void CommonParser::G2Handler(QVector<QString> params) {
                     current_value *= m_distance_unit();
                     if (m_e_absolute) {
                         if (current_value > MotionEstimation::m_previous_e)
-                            setExtruderOn(true);
+                            setDepositionActive(true);
                         else
-                            setExtruderOn(false);
+                            setDepositionActive(false);
                     }
                     else {
                         if (current_value > 0)
-                            setExtruderOn(true);
+                            setDepositionActive(true);
                         else
-                            setExtruderOn(false);
+                            setDepositionActive(false);
                     }
                     MotionEstimation::m_current_e = current_value;
                     e_not_used = false;
@@ -1500,7 +1501,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
                 throw IllegalParameterException(exceptionString);
         }
     }
-    m_current_gcode_command.setExtruderOn(m_extruder_on);
+    m_current_gcode_command.setDepositionActive(m_deposition_active);
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (!f_not_used)
@@ -1525,7 +1526,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
 
     Distance temp = getCurrentArcDistance(start_x, start_y, start_z, !i_not_used, !j_not_used, !r_not_used, false);
     MotionEstimation::m_total_distance += temp;
-    if (m_extruder_on)
+    if (m_deposition_active)
         MotionEstimation::m_printing_distance += temp;
     else
         MotionEstimation::m_travel_distance += temp;
@@ -1686,15 +1687,15 @@ void CommonParser::G3Handler(QVector<QString> params) {
                     current_value *= m_distance_unit();
                     if (m_e_absolute) {
                         if (current_value > MotionEstimation::m_previous_e)
-                            setExtruderOn(true);
+                            setDepositionActive(true);
                         else
-                            setExtruderOn(false);
+                            setDepositionActive(false);
                     }
                     else {
                         if (current_value > 0)
-                            setExtruderOn(true);
+                            setDepositionActive(true);
                         else
-                            setExtruderOn(false);
+                            setDepositionActive(false);
                     }
                     MotionEstimation::m_current_e = current_value;
                     e_not_used = false;
@@ -1712,7 +1713,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
                 throw IllegalParameterException(exceptionString);
         }
     }
-    m_current_gcode_command.setExtruderOn(m_extruder_on);
+    m_current_gcode_command.setDepositionActive(m_deposition_active);
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (!f_not_used)
@@ -1743,7 +1744,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
 
     Distance temp = getCurrentArcDistance(start_x, start_y, start_z, !i_not_used, !j_not_used, !r_not_used, true);
     MotionEstimation::m_total_distance += temp;
-    if (m_extruder_on)
+    if (m_deposition_active)
         MotionEstimation::m_printing_distance += temp;
     else
         MotionEstimation::m_travel_distance += temp;
@@ -1981,15 +1982,15 @@ void CommonParser::G5Handler(QVector<QString> params) {
                     current_value *= m_distance_unit();
                     if (m_e_absolute) {
                         if (current_value > MotionEstimation::m_previous_e)
-                            setExtruderOn(true);
+                            setDepositionActive(true);
                         else
-                            setExtruderOn(false);
+                            setDepositionActive(false);
                     }
                     else {
                         if (current_value > 0)
-                            setExtruderOn(true);
+                            setDepositionActive(true);
                         else
-                            setExtruderOn(false);
+                            setDepositionActive(false);
                     }
                     MotionEstimation::m_current_e = current_value;
                     e_not_used = false;
@@ -2007,7 +2008,7 @@ void CommonParser::G5Handler(QVector<QString> params) {
                 throw IllegalParameterException(exceptionString);
         }
     }
-    m_current_gcode_command.setExtruderOn(m_extruder_on);
+    m_current_gcode_command.setDepositionActive(m_deposition_active);
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (!f_not_used)
@@ -2044,12 +2045,12 @@ void CommonParser::M3Handler(QVector<QString> params) {
         }
     }
 
-    m_extruder_on = true;
+    m_deposition_active = true;
 }
 
 void CommonParser::M5Handler(QVector<QString> params) {
     m_current_spindle_speed = m_current_extruder_speed = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
 }
 
 void CommonParser::AddDwell(double dwellTime) {
@@ -2443,5 +2444,5 @@ void CommonParser::throwIntegerConversionErrorException() {
     throw IllegalParameterException(exceptionString);
 }
 
-void CommonParser::setExtruderOn(bool on) { m_extruder_on = on; }
+void CommonParser::setDepositionActive(bool on) { m_deposition_active = on; }
 } // namespace ORNL

--- a/src/gcode/parsers/mazak_parser.cpp
+++ b/src/gcode/parsers/mazak_parser.cpp
@@ -47,7 +47,7 @@ void MazakParser::G441Handler(QVector<QString> params) {
         return;
     }
 
-    m_extruder_on = true;
+    m_deposition_active = true;
 }
 
 // G442 (LASER OFF)
@@ -56,7 +56,7 @@ void MazakParser::G442Handler(QVector<QString> params) {
         return;
     }
 
-    m_extruder_on = false;
+    m_deposition_active = false;
 }
 
 void MazakParser::FeedRateHandler(QVector<QString> params) { m_feedrate = "F" % params[1]; }

--- a/src/gcode/parsers/tormach_parser.cpp
+++ b/src/gcode/parsers/tormach_parser.cpp
@@ -21,8 +21,8 @@ void TormachParser::config() {
     addCommandMapping("M65", std::bind(&TormachParser::M65Handler, this, std::placeholders::_1));
 }
 
-void TormachParser::M64Handler(QVector<QString> params) { m_extruder_on = true; }
+void TormachParser::M64Handler(QVector<QString> params) { m_deposition_active = true; }
 
-void TormachParser::M65Handler(QVector<QString> params) { m_extruder_on = false; }
+void TormachParser::M65Handler(QVector<QString> params) { m_deposition_active = false; }
 
 } // namespace ORNL

--- a/src/gcode/writers/aerobasic_writer.cpp
+++ b/src/gcode/writers/aerobasic_writer.cpp
@@ -18,7 +18,7 @@
 namespace ORNL {
 AeroBasicWriter::AeroBasicWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb) : WriterBase(meta, sb) {
     // Set to one extruder that is off
-    m_extruder_on = false;
+    m_deposition_active = false;
 }
 
 QString AeroBasicWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
@@ -132,7 +132,7 @@ QString AeroBasicWriter::writeTravel(Point start_location, Point target_location
     QString rv;
 
     // Disable extruder for travels
-    if (m_extruder_on)
+    if (m_deposition_active)
         rv += "$DO[0].X=0" % commentLine("Extruder Off for travel");
 
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
@@ -188,7 +188,7 @@ QString AeroBasicWriter::writeTravel(Point start_location, Point target_location
     }
 
     // Enable extruder after travel
-    if (m_extruder_on)
+    if (m_deposition_active)
         rv += "$DO[0].X=1" % commentLine("Extruder On after travel");
 
     m_first_travel = false;

--- a/src/gcode/writers/aml3d_writer.cpp
+++ b/src/gcode/writers/aml3d_writer.cpp
@@ -31,7 +31,7 @@ QString AML3DWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
                                        int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -214,13 +214,13 @@ QString AML3DWriter::writeLine(const Point& start_point, const Point& target_poi
 
     QString rv;
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0, params);
         setFeedrate(0);
     }
     if ((path_modifiers == PathModifiers::kForwardTipWipe || path_modifiers == PathModifiers::kReverseTipWipe ||
          path_modifiers == PathModifiers::kPerimeterTipWipe) &&
-        m_extruder_on && !m_tip_wipe) {
+        m_deposition_active && !m_tip_wipe) {
         m_tip_wipe = true;
         rv += commentLine("UPDATE VOLTAGE FOR TIP WIPE");
     }
@@ -273,7 +273,7 @@ QString AML3DWriter::writeArc(const Point& start_point, const Point& end_point, 
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0, params);
     }
 
@@ -412,7 +412,7 @@ QString AML3DWriter::writeTamperOff() {
 QString AML3DWriter::writeExtruderOn(RegionType type, int rpm, int extruder_number,
                                      const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -470,7 +470,7 @@ QString AML3DWriter::writeExtruderOff(int extruder_number) {
     // update to use extruder number
 
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -659,7 +659,7 @@ QString ArcSpecialtiesWriter::writeWelderOff() {
     if (m_deposition_active) {
         QString rv;
         rv += "G260" % commentSpaceLine("BLENDING OFF");
-        rv += "M151" % commentSpaceLine("WIRE ARC WELDER OFF");
+        rv += "G83" % commentSpaceLine("WIRE ARC WELDER OFF");
         /// TODO: M160 command does not work as of 2026-07-29 and is disabled for now. Must be re-enabled when the M160
         /// command is fixed in the Arc Specialties controller or be replaced with a different command that achieves the
         /// same effect.

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -568,7 +568,7 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
         rv += writeWelderOn();
     }
 
-    if(!m_first_deposition) {
+    if (m_sb->setting<bool>(PRS::GCode::kArcSpecialtiesG2G3OptionalStop) && !m_first_deposition) {
         rv += "G81" % commentSpaceLine("OPTIONAL STOP ROUTINE");
     }
 

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -512,10 +512,7 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
     }
 
     if (travel_lower_required) {
-        /// TODO: G80 command does not work as of 2026-07-29 and is disabled for now. Must be re-enabled when the G80
-        /// command is fixed in the Arc Specialties controller or be replaced with a different command that achieves the
-        /// same effect.
-        rv += ";G80" % commentSpaceLine("OPTIONAL STOP ROUTINE");
+        rv += "G81" % commentSpaceLine("OPTIONAL STOP ROUTINE");
         rv += writeMotion("G01", target_location, lift_speed, params, "TRAVEL LOWER");
     }
 

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -388,10 +388,10 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
     // Determine if travel length is short enough to keep extruder on
     Distance travel_distance = start_location.distance(target_location);
     if (m_extruder_on && travel_distance > m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
-        rv += writeExtruderOff();
+        rv += writeWelderOff();
     }
     else if (!m_first_travel && travel_distance < m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
-        rv += writeExtruderOn();
+        rv += writeWelderOn();
     }
 
     const Distance lift_height = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
@@ -532,7 +532,7 @@ QString ArcSpecialtiesWriter::writeLine(const Point&, const Point& target_point,
     m_layer_start = false;
 
     if (!m_extruder_on) {
-        rv += writeExtruderOn();
+        rv += writeWelderOn();
     }
 
     if (speed <= 0) {
@@ -554,7 +554,7 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
     rv += writePendingLayerChange();
 
     if (!m_extruder_on) {
-        rv += writeExtruderOn();
+        rv += writeWelderOn();
     }
 
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
@@ -574,7 +574,7 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
 QString ArcSpecialtiesWriter::writeAfterPath(RegionType type) {
     QString rv;
     if (!m_spiral_layer) {
-        // rv += writeExtruderOff(); // update to turn off the extruder
+        // rv += writeWelderOff(); // update to turn off the welder
         if (type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty()) {
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -622,7 +622,7 @@ QString ArcSpecialtiesWriter::writeAfterLayer() {
 
 QString ArcSpecialtiesWriter::writeShutdown() {
     QString rv;
-    rv += writeExtruderOff();
+    rv += writeWelderOff();
     if (!m_sb->setting<QString>(PRS::GCode::kEndCode).isEmpty()) {
         rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline;
     }
@@ -642,7 +642,7 @@ QString ArcSpecialtiesWriter::writeDwell(Time time) {
     return QString();
 }
 
-QString ArcSpecialtiesWriter::writeExtruderOn() {
+QString ArcSpecialtiesWriter::writeWelderOn() {
     if (!m_extruder_on) {
         QString rv;
         rv += "M150" % commentSpaceLine("WIRE ARC WELDER ON");
@@ -655,7 +655,7 @@ QString ArcSpecialtiesWriter::writeExtruderOn() {
     }
 }
 
-QString ArcSpecialtiesWriter::writeExtruderOff() {
+QString ArcSpecialtiesWriter::writeWelderOff() {
     if (m_extruder_on) {
         QString rv;
         rv += "G260" % commentSpaceLine("BLENDING OFF");

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -645,7 +645,7 @@ QString ArcSpecialtiesWriter::writeDwell(Time time) {
 QString ArcSpecialtiesWriter::writeWelderOn() {
     if (!m_deposition_active) {
         QString rv;
-        rv += "M150" % commentSpaceLine("WIRE ARC WELDER ON");
+        rv += "G82" % commentSpaceLine("WIRE ARC WELDER ON");
         rv += "G261" % commentSpaceLine("BLENDING ON");
         m_deposition_active = true;
         return rv;

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -367,6 +367,7 @@ QString ArcSpecialtiesWriter::writeBeforeLayer(float min_z, QSharedPointer<Setti
     m_layer_start = true;
     m_current_bead = 1;
     m_current_layer++;
+    m_first_deposition = true;
     return rv;
 }
 
@@ -549,6 +550,7 @@ QString ArcSpecialtiesWriter::writeLine(const Point&, const Point& target_point,
     }
 
     rv += writeMotion("G01", target_point, speed, params, printMoveComment());
+    m_first_deposition = false;
     return rv;
 }
 
@@ -566,6 +568,10 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
         rv += writeWelderOn();
     }
 
+    if(!m_first_deposition) {
+        rv += "G81" % commentSpaceLine("OPTIONAL STOP ROUTINE");
+    }
+
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
     if (speed <= 0) {
         speed = 10.0 * mm / s;
@@ -577,6 +583,7 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
     rv += QString(ccw ? "G03" : "G02") % writeCoordinates(end_point, params, kToolFrameZR) %
           writeArcCenterParameters(start_point, center_point) % m_f %
           QString::number(speed.to(m_meta.m_velocity_unit), 'f', 4) % commentSpaceLine(printMoveComment());
+    m_first_deposition = false;
     return rv;
 }
 

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -385,9 +385,9 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
         lift_speed = speed;
     }
 
-    // Determine if travel length is short enough to keep extruder on
+    // Determine if travel length is short enough to keep welder on
     Distance travel_distance = start_location.distance(target_location);
-    if (m_extruder_on && travel_distance > m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
+    if (m_deposition_active && travel_distance > m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
         rv += writeWelderOff();
     }
     else if (!m_first_travel && travel_distance < m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
@@ -531,7 +531,7 @@ QString ArcSpecialtiesWriter::writeLine(const Point&, const Point& target_point,
 
     m_layer_start = false;
 
-    if (!m_extruder_on) {
+    if (!m_deposition_active) {
         rv += writeWelderOn();
     }
 
@@ -553,7 +553,7 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
     rv += writeStartupKinematics();
     rv += writePendingLayerChange();
 
-    if (!m_extruder_on) {
+    if (!m_deposition_active) {
         rv += writeWelderOn();
     }
 
@@ -643,11 +643,11 @@ QString ArcSpecialtiesWriter::writeDwell(Time time) {
 }
 
 QString ArcSpecialtiesWriter::writeWelderOn() {
-    if (!m_extruder_on) {
+    if (!m_deposition_active) {
         QString rv;
         rv += "M150" % commentSpaceLine("WIRE ARC WELDER ON");
         rv += "G261" % commentSpaceLine("BLENDING ON");
-        m_extruder_on = true;
+        m_deposition_active = true;
         return rv;
     }
     else {
@@ -656,7 +656,7 @@ QString ArcSpecialtiesWriter::writeWelderOn() {
 }
 
 QString ArcSpecialtiesWriter::writeWelderOff() {
-    if (m_extruder_on) {
+    if (m_deposition_active) {
         QString rv;
         rv += "G260" % commentSpaceLine("BLENDING OFF");
         rv += "M151" % commentSpaceLine("WIRE ARC WELDER OFF");
@@ -665,7 +665,7 @@ QString ArcSpecialtiesWriter::writeWelderOff() {
         /// same effect.
         rv += ";M160" % commentSpaceLine("CLIP WIRE");
         rv += "#CHANNEL INIT [CMDPOS]" % m_newline;
-        m_extruder_on = false;
+        m_deposition_active = false;
         return rv;
     }
     else {

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -670,11 +670,6 @@ QString ArcSpecialtiesWriter::writeWelderOff(int mode) {
         const int g83_mode = validatedG83Mode(mode);
         rv += "G260" % commentSpaceLine("BLENDING OFF");
         rv += "G83 [" % QString::number(g83_mode) % "]" % commentSpaceLine("WIRE ARC WELDER OFF");
-        /// TODO: M160 command does not work as of 2026-07-29 and is disabled for now. Must be re-enabled when the M160
-        /// command is fixed in the Arc Specialties controller or be replaced with a different command that achieves the
-        /// same effect.
-        rv += ";M160" % commentSpaceLine("CLIP WIRE");
-        rv += "#CHANNEL INIT [CMDPOS]" % m_newline;
         m_deposition_active = false;
         return rv;
     }

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -95,6 +95,15 @@ const Distance kMinTravelArcSegmentLength = 100.0 * micron;
 //! @brief Machine setup setting value for relative G02/G03 center interpretation.
 constexpr int kRelativeArcCenterMode = 1;
 
+//! @brief Default G83 mode: stop welding only.
+constexpr int kDefaultG83Mode = 0;
+
+//! @brief Highest supported Arc Specialties G83 mode.
+constexpr int kMaxG83Mode = 4;
+
+//! @brief Returns a supported G83 mode, falling back to weld-stop-only behavior for invalid input.
+int validatedG83Mode(int mode) { return mode >= kDefaultG83Mode && mode <= kMaxG83Mode ? mode : kDefaultG83Mode; }
+
 //! @brief Formats a distance using the output unit declared by the active gcode metadata.
 QString formatDistance(Distance value, Distance unit) {
     return QString::number(value.to(unit), 'f', 4) % unit.toString();
@@ -655,11 +664,12 @@ QString ArcSpecialtiesWriter::writeWelderOn() {
     }
 }
 
-QString ArcSpecialtiesWriter::writeWelderOff() {
+QString ArcSpecialtiesWriter::writeWelderOff(int mode) {
     if (m_deposition_active) {
         QString rv;
+        const int g83_mode = validatedG83Mode(mode);
         rv += "G260" % commentSpaceLine("BLENDING OFF");
-        rv += "G83" % commentSpaceLine("WIRE ARC WELDER OFF");
+        rv += "G83 [" % QString::number(g83_mode) % "]" % commentSpaceLine("WIRE ARC WELDER OFF");
         /// TODO: M160 command does not work as of 2026-07-29 and is disabled for now. Must be re-enabled when the M160
         /// command is fixed in the Arc Specialties controller or be replaced with a different command that achieves the
         /// same effect.

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -326,7 +326,7 @@ QString ArcSpecialtiesWriter::writeInitialSetup(Distance minimum_x, Distance min
     rv += "V.E.Sch.Crater.Control = 25   ;Arc Control in Crater Fill" % m_newline;
     rv += "V.E.Sch.Crater.Time = .5   ;Crater Fill Time in Seconds" % m_newline;
     rv += "#CONTOUR MODE [DEV PATH_DEV=2 CONST_VEL=1]" % m_newline;
-    /// TODO: M06 command does not work as of 2026-07-29 and is disabled for now. Must be re-enabled when the M06
+    /// TODO: M06 command does not work as of 2026-08-07 and is disabled for now. Must be re-enabled when the M06
     /// command is fixed in the Arc Specialties controller or be replaced with a different command that achieves the
     /// same effect.
     rv += ";M06 T1   ;Select Tool 1" % m_newline;

--- a/src/gcode/writers/cincinnati_writer.cpp
+++ b/src/gcode/writers/cincinnati_writer.cpp
@@ -32,7 +32,7 @@ QString CincinnatiWriter::writeInitialSetup(Distance minimum_x, Distance minimum
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_is_lift = false;
     m_is_travel = false;
@@ -326,7 +326,7 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
     RegionType rType = params->setting<RegionType>(SS::kRegionType);
     bool w_active_first_travel = false;
 
-    // Determine if travel length is short enough to keep extruder on
+    // Determine if travel length is short enough to keep deposition active.
     Distance travel_distance = start_location.distance(target_location);
     if (!m_first_travel && travel_distance < m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
         int rpm = params->contains(SS::kExtruderSpeed) ? params->setting<int>(SS::kExtruderSpeed)
@@ -547,7 +547,7 @@ QString CincinnatiWriter::writeLine(const Point& start_point, const Point& targe
         }
     }
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
         setFeedrate(0);
     }
@@ -642,7 +642,7 @@ QString CincinnatiWriter::writeArc(const Point& start_point, const Point& end_po
         }
     }
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -858,7 +858,7 @@ QString CincinnatiWriter::writeTamperOff() {
 
 QString CincinnatiWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -935,7 +935,7 @@ QString CincinnatiWriter::writeExtruderOff() {
     // update to use extruder number
 
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/dmg_dmu_writer.cpp
+++ b/src/gcode/writers/dmg_dmu_writer.cpp
@@ -22,7 +22,7 @@ QString DMGDMUWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -177,7 +177,7 @@ QString DMGDMUWriter::writeLine(const Point& start_point, const Point& target_po
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -230,7 +230,7 @@ QString DMGDMUWriter::writeArc(const Point& start_point, const Point& end_point,
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -344,7 +344,7 @@ QString DMGDMUWriter::writeDwell(Time time) {
 
 QString DMGDMUWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -397,7 +397,7 @@ QString DMGDMUWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPoi
 
 QString DMGDMUWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/gudel_writer.cpp
+++ b/src/gcode/writers/gudel_writer.cpp
@@ -22,7 +22,7 @@ QString GudelWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -173,7 +173,7 @@ QString GudelWriter::writeLine(const Point& start_point, const Point& target_poi
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -330,7 +330,7 @@ QString GudelWriter::writeDwell(Time time) {
 
 QString GudelWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -383,7 +383,7 @@ QString GudelWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPoin
 
 QString GudelWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/haas_metric_no_comments_writer.cpp
+++ b/src/gcode/writers/haas_metric_no_comments_writer.cpp
@@ -23,7 +23,7 @@ QString HaasMetricNoCommentsWriter::writeInitialSetup(Distance minimum_x, Distan
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -178,12 +178,12 @@ QString HaasMetricNoCommentsWriter::writeLine(const Point& start_point, const Po
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
     // turn off extruder with an M5 before the line, rather than in-line with S0
-    if (rpm == 0 && m_extruder_on == true) {
+    if (rpm == 0 && m_deposition_active == true) {
         rv += writeExtruderOff();
     }
 
@@ -232,7 +232,7 @@ QString HaasMetricNoCommentsWriter::writeArc(const Point& start_point, const Poi
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -350,7 +350,7 @@ QString HaasMetricNoCommentsWriter::writeDwell(Time time) {
 QString HaasMetricNoCommentsWriter::writeExtruderOn(RegionType type, int rpm,
                                                     const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -403,7 +403,7 @@ QString HaasMetricNoCommentsWriter::writeExtruderOn(RegionType type, int rpm,
 
 QString HaasMetricNoCommentsWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/haas_writer.cpp
+++ b/src/gcode/writers/haas_writer.cpp
@@ -22,7 +22,7 @@ QString HaasWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -187,12 +187,12 @@ QString HaasWriter::writeLine(const Point& start_point, const Point& target_poin
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
     // turn off extruder with an M5 before the line, rather than in-line with S0
-    if (rpm == 0 && m_extruder_on == true) {
+    if (rpm == 0 && m_deposition_active == true) {
         rv += writeExtruderOff();
     }
 
@@ -245,7 +245,7 @@ QString HaasWriter::writeArc(const Point& start_point, const Point& end_point, c
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -365,7 +365,7 @@ QString HaasWriter::writeDwell(Time time) {
 
 QString HaasWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -418,7 +418,7 @@ QString HaasWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPoint
 
 QString HaasWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/hurco_writer.cpp
+++ b/src/gcode/writers/hurco_writer.cpp
@@ -22,7 +22,7 @@ QString HurcoWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -181,7 +181,7 @@ QString HurcoWriter::writeLine(const Point& start_point, const Point& target_poi
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -234,7 +234,7 @@ QString HurcoWriter::writeArc(const Point& start_point, const Point& end_point, 
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -354,7 +354,7 @@ QString HurcoWriter::writeDwell(Time time) {
 
 QString HurcoWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -407,7 +407,7 @@ QString HurcoWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPoin
 
 QString HurcoWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/ingersoll_writer.cpp
+++ b/src/gcode/writers/ingersoll_writer.cpp
@@ -22,7 +22,7 @@ QString IngersollWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
                                            Distance maximum_y, int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -209,12 +209,12 @@ QString IngersollWriter::writeLine(const Point& start_point, const Point& target
 
     QString rv;
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0, params);
         m_current_rpm = rpm;
     }
     // Update extruder speed if needed
-    if (m_extruder_on && rpm != m_current_rpm) {
+    if (m_deposition_active && rpm != m_current_rpm) {
         rv += "EXTRUDER(" % QString::number(output_rpm) % ")" % commentSpaceLine("UPDATE EXTRUDER RPM");
         m_current_rpm = rpm;
     }
@@ -252,11 +252,11 @@ QString IngersollWriter::writeArc(const Point& start_point, const Point& end_poi
     auto region_type = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0, params);
     }
     // Update extruder speed if needed
-    if (m_extruder_on && rpm != m_current_rpm) {
+    if (m_deposition_active && rpm != m_current_rpm) {
         rv += "EXTRUDER(" % QString::number(output_rpm) % ")" % commentSpaceLine("UPDATE EXTRUDER RPM");
         m_current_rpm = rpm;
     }
@@ -378,7 +378,7 @@ QString IngersollWriter::writeExtruderOn(RegionType type, float rpm, int extrude
 
     rv += commentLine("Bead Start");
 
-    m_extruder_on = true;
+    m_deposition_active = true;
 
     // write dwell and initial extruder turn on depending on region type
     if (initial_rpm > 0) {
@@ -420,7 +420,7 @@ QString IngersollWriter::writeExtruderOff(int extruder_number) {
     // update to use extruder number
 
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/juggerbot_writer.cpp
+++ b/src/gcode/writers/juggerbot_writer.cpp
@@ -22,7 +22,7 @@ QString JuggerBotWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_rpm = 0;
     m_current_bead_area = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_material_number = -1;
     m_first_print = true;
     m_first_travel = true;
@@ -123,9 +123,9 @@ QString JuggerBotWriter::writeTravel(Point start_location, Point target_location
 
     m_current_bead_area = 0;
 
-    // Determine if travel length is short enough to keep extruder on
+    // Determine if travel length is short enough to keep deposition active.
     Distance travel_distance = start_location.distance(target_location);
-    if (m_extruder_on && travel_distance > m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
+    if (m_deposition_active && travel_distance > m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
         rv += writeExtruderOff();
     }
     else if (travel_distance < m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
@@ -215,7 +215,7 @@ QString JuggerBotWriter::writeLine(const Point& start_point, const Point& target
     }
 
     // determine if writeExtruderOn is necessary
-    bool requiresWriteExtruderOn = !m_extruder_on;
+    bool requiresWriteExtruderOn = !m_deposition_active;
 
     if (requiresWriteExtruderOn && rpm > 0) // && !m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight))
     {
@@ -284,7 +284,7 @@ QString JuggerBotWriter::writeArc(const Point& start_point, const Point& end_poi
     }
 
     // determine if writeExtruderOn is necessary
-    bool requiresWriteExtruderOn = !m_extruder_on;
+    bool requiresWriteExtruderOn = !m_deposition_active;
 
     if (requiresWriteExtruderOn && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, width, height, params);
@@ -408,7 +408,7 @@ QString JuggerBotWriter::writeDwell(Time time) {
 
 QString JuggerBotWriter::writeExtruderOn(RegionType type, int rpm, Distance width, Distance height,
                                          const QSharedPointer<SettingsBase>& params) {
-    m_extruder_on = true;
+    m_deposition_active = true;
     QString rv;
     Area bead_area = (width - height) * height +
                      (pi() * (height / 2) * (height / 2)); // Rectangle with two half circles used as cross-section
@@ -488,7 +488,7 @@ QString JuggerBotWriter::writeExtruderOn(RegionType type, int rpm, Distance widt
 }
 
 QString JuggerBotWriter::writeExtruderOff() {
-    m_extruder_on = false;
+    m_deposition_active = false;
 
     QString rv;
 

--- a/src/gcode/writers/kraussmaffei_writer.cpp
+++ b/src/gcode/writers/kraussmaffei_writer.cpp
@@ -22,7 +22,7 @@ KraussMaffeiWriter::KraussMaffeiWriter(GcodeMeta meta, const QSharedPointer<Sett
 QString KraussMaffeiWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
                                               Distance maximum_y, int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_print = true;
     m_first_travel = true;
     m_layer_start = true;
@@ -130,7 +130,7 @@ QString KraussMaffeiWriter::writeTravel(Point start_location, Point target_locat
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
     Point new_start_location;
 
-    m_extruder_on = false;
+    m_deposition_active = false;
 
     // Update Acceleration
     if (m_sb->setting<bool>(PRS::Acceleration::kEnableDynamic)) {
@@ -201,11 +201,11 @@ QString KraussMaffeiWriter::writeLine(const Point& start_point, const Point& tar
     QString rv;
 
     // check if extruder needs priming
-    bool needs_prime = !m_extruder_on;
-    m_extruder_on = true;
+    bool needs_prime = !m_deposition_active;
+    m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
-    // First segment of the path is signified by extruder being off and the modifier isn't one of five ending modifiers
+    // First segment of the path is signified by inactive deposition and the modifier isn't one of five ending modifiers
     if (needs_prime && path_modifiers != PathModifiers::kSlowDown && path_modifiers != PathModifiers::kForwardTipWipe &&
         path_modifiers != PathModifiers::kReverseTipWipe && path_modifiers != PathModifiers::kCoasting &&
         path_modifiers != PathModifiers::kSpiralLift) {
@@ -318,11 +318,11 @@ QString KraussMaffeiWriter::writeArc(const Point& start_point, const Point& end_
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // check if extruder needs priming
-    bool needs_prime = !m_extruder_on;
-    m_extruder_on = true;
+    bool needs_prime = !m_deposition_active;
+    m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
-    // First segment of the path is signified by extruder being off and the modifier isn't one of five ending modifiers
+    // First segment of the path is signified by inactive deposition and the modifier isn't one of five ending modifiers
     if (needs_prime && path_modifiers != PathModifiers::kSlowDown && path_modifiers != PathModifiers::kForwardTipWipe &&
         path_modifiers != PathModifiers::kReverseTipWipe && path_modifiers != PathModifiers::kCoasting &&
         path_modifiers != PathModifiers::kSpiralLift) {

--- a/src/gcode/writers/mach4_writer.cpp
+++ b/src/gcode/writers/mach4_writer.cpp
@@ -23,7 +23,7 @@ QString Mach4Writer::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
                                        int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_filament_location = 0.0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_print = true;
     m_first_travel = true;
     m_layer_start = true;
@@ -159,7 +159,7 @@ QString Mach4Writer::writeTravel(Point start_location, Point target_location, Tr
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
     Point new_start_location;
 
-    m_extruder_on = false;
+    m_deposition_active = false;
 
     // Update Acceleration
     if (m_sb->setting<bool>(PRS::Acceleration::kEnableDynamic)) {
@@ -232,11 +232,11 @@ QString Mach4Writer::writeLine(const Point& start_point, const Point& target_poi
     QString rv;
 
     // check if extruder needs priming
-    bool needs_prime = !m_extruder_on;
-    m_extruder_on = true;
+    bool needs_prime = !m_deposition_active;
+    m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
-    // First segment of the path is signified by extruder being off and the modifier isn't one of five ending modifiers
+    // First segment of the path is signified by inactive deposition and the modifier isn't one of five ending modifiers
     if (needs_prime && path_modifiers != PathModifiers::kSlowDown && path_modifiers != PathModifiers::kForwardTipWipe &&
         path_modifiers != PathModifiers::kReverseTipWipe && path_modifiers != PathModifiers::kCoasting &&
         path_modifiers != PathModifiers::kSpiralLift) {
@@ -361,11 +361,11 @@ QString Mach4Writer::writeArc(const Point& start_point, const Point& end_point, 
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // check if extruder needs priming
-    bool needs_prime = !m_extruder_on;
-    m_extruder_on = true;
+    bool needs_prime = !m_deposition_active;
+    m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
-    // First segment of the path is signified by extruder being off and the modifier isn't one of five ending modifiers
+    // First segment of the path is signified by inactive deposition and the modifier isn't one of five ending modifiers
     if (needs_prime && path_modifiers != PathModifiers::kSlowDown && path_modifiers != PathModifiers::kForwardTipWipe &&
         path_modifiers != PathModifiers::kReverseTipWipe && path_modifiers != PathModifiers::kCoasting &&
         path_modifiers != PathModifiers::kSpiralLift) {

--- a/src/gcode/writers/marlin_writer.cpp
+++ b/src/gcode/writers/marlin_writer.cpp
@@ -23,7 +23,7 @@ QString MarlinWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
                                         int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_filament_location = 0.0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_print = true;
     m_first_travel = true;
     m_layer_start = true;
@@ -235,7 +235,7 @@ QString MarlinWriter::writeTravel(Point start_location, Point target_location, T
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
     Point new_start_location;
 
-    m_extruder_on = false;
+    m_deposition_active = false;
 
     // Update Acceleration
     if (m_sb->setting<bool>(PRS::Acceleration::kEnableDynamic)) {
@@ -309,11 +309,11 @@ QString MarlinWriter::writeLine(const Point& start_point, const Point& target_po
     QString rv;
 
     // check if extruder needs priming
-    bool needs_prime = !m_extruder_on;
-    m_extruder_on = true;
+    bool needs_prime = !m_deposition_active;
+    m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
-    // First segment of the path is signified by extruder being off and the modifier isn't one of five ending modifiers
+    // First segment of the path is signified by inactive deposition and the modifier isn't one of five ending modifiers
     if (needs_prime && path_modifiers != PathModifiers::kSlowDown && path_modifiers != PathModifiers::kForwardTipWipe &&
         path_modifiers != PathModifiers::kReverseTipWipe && path_modifiers != PathModifiers::kCoasting &&
         path_modifiers != PathModifiers::kSpiralLift) {
@@ -448,11 +448,11 @@ QString MarlinWriter::writeArc(const Point& start_point, const Point& end_point,
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // check if extruder needs priming
-    bool needs_prime = !m_extruder_on;
-    m_extruder_on = true;
+    bool needs_prime = !m_deposition_active;
+    m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
-    // First segment of the path is signified by extruder being off and the modifier isn't one of five ending modifiers
+    // First segment of the path is signified by inactive deposition and the modifier isn't one of five ending modifiers
     if (needs_prime && path_modifiers != PathModifiers::kSlowDown && path_modifiers != PathModifiers::kForwardTipWipe &&
         path_modifiers != PathModifiers::kReverseTipWipe && path_modifiers != PathModifiers::kCoasting &&
         path_modifiers != PathModifiers::kSpiralLift) {

--- a/src/gcode/writers/mazak_writer.cpp
+++ b/src/gcode/writers/mazak_writer.cpp
@@ -22,7 +22,7 @@ QString MazakWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -204,7 +204,7 @@ QString MazakWriter::writeLine(const Point& start_point, const Point& target_poi
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         m_current_rpm = rpm;
         rv += writeExtruderOn(region_type, rpm);
     }
@@ -258,7 +258,7 @@ QString MazakWriter::writeArc(const Point& start_point, const Point& end_point, 
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm);
     }
 
@@ -378,14 +378,14 @@ QString MazakWriter::writeDwell(Time time) {
 
 QString MazakWriter::writeExtruderOn(RegionType type, int rpm) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     rv += "G441" % commentSpaceLine("TURN LASER ON");
     return rv;
 }
 
 QString MazakWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/meld_writer.cpp
+++ b/src/gcode/writers/meld_writer.cpp
@@ -22,7 +22,7 @@ QString MeldWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -188,11 +188,11 @@ QString MeldWriter::writeLine(const Point& start_point, const Point& target_poin
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
-    if (rpm == 0 && m_extruder_on == true) {
+    if (rpm == 0 && m_deposition_active == true) {
         rv += writeExtruderOff();
     }
 
@@ -229,7 +229,7 @@ QString MeldWriter::writeArc(const Point& start_point, const Point& end_point, c
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -352,7 +352,7 @@ QString MeldWriter::writeDwell(Time time) {
 
 QString MeldWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
     output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
@@ -409,7 +409,7 @@ QString MeldWriter::writeExtruderOff() {
     QString rv;
     if (m_sb->setting<int>(ES::FileOutput::kMeldDiscrete)) {
         rv += "M25" % commentSpaceLine("TURN ACTUATOR OFF");
-        m_extruder_on = false;
+        m_deposition_active = false;
     }
     return rv;
 }

--- a/src/gcode/writers/meltio_writer.cpp
+++ b/src/gcode/writers/meltio_writer.cpp
@@ -30,7 +30,7 @@ QString MeltioWriter::writeSettingsHeader(GcodeSyntax syntax) {
 QString MeltioWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                         int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -204,7 +204,7 @@ QString MeltioWriter::writeLine(const Point& start_point, const Point& target_po
 
     QString rv;
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0);
         setFeedrate(0);
     }
@@ -248,7 +248,7 @@ QString MeltioWriter::writeArc(const Point& start_point, const Point& end_point,
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0);
     }
 
@@ -363,7 +363,7 @@ QString MeltioWriter::writeDwell(Time time) {
 
 QString MeltioWriter::writeExtruderOn(RegionType type, int rpm, int extruder_number) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     rv += "M64 P8" % commentSpaceLine("LASER ON");
     rv += "M66 P1 L3 Q10" % commentSpaceLine("WAIT FOR CONFIRMATION");
     rv += "M65 P8" % commentSpaceLine("TURN RELAY OFF");
@@ -372,7 +372,7 @@ QString MeltioWriter::writeExtruderOn(RegionType type, int rpm, int extruder_num
 
 QString MeltioWriter::writeExtruderOff(int extruder_number) {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     rv += "M64 P9" % commentSpaceLine("LASER OFF");
     rv += "M66 P1 L3 Q10" % commentSpaceLine("WAIT FOR CONFIRMATION");
     rv += "M65 P9" % commentSpaceLine("TURN RELAY OFF");

--- a/src/gcode/writers/mvp_writer.cpp
+++ b/src/gcode/writers/mvp_writer.cpp
@@ -23,7 +23,7 @@ QString MVPWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Dis
                                      int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -183,7 +183,7 @@ QString MVPWriter::writeLine(const Point& start_point, const Point& target_point
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -299,7 +299,7 @@ QString MVPWriter::writeDwell(Time time) {
 
 QString MVPWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -344,7 +344,7 @@ QString MVPWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointe
 
 QString MVPWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/okuma_writer.cpp
+++ b/src/gcode/writers/okuma_writer.cpp
@@ -22,7 +22,7 @@ QString OkumaWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -205,7 +205,7 @@ QString OkumaWriter::writeLine(const Point& start_point, const Point& target_poi
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm);
     }
 
@@ -250,7 +250,7 @@ QString OkumaWriter::writeArc(const Point& start_point, const Point& end_point, 
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm);
     }
 
@@ -375,7 +375,7 @@ QString OkumaWriter::writeDwell(Time time) {
 
 QString OkumaWriter::writeExtruderOn(RegionType type, int rpm) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     rv += "( -------------------- laser_on.txt --- )" % m_newline;
     rv += "/LPW=LPWW        (LASER POWER)" % m_newline;
     rv += "( -------------------- )" % m_newline;
@@ -384,7 +384,7 @@ QString OkumaWriter::writeExtruderOn(RegionType type, int rpm) {
 
 QString OkumaWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     rv += "( -------------------- laser_off.txt --- )" % m_newline;
     rv += "/LPW=0               (LASER POWER)" % m_newline;
     rv += "(/)" % m_newline;

--- a/src/gcode/writers/ornl_writer.cpp
+++ b/src/gcode/writers/ornl_writer.cpp
@@ -33,7 +33,7 @@ QString ORNLWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
     m_current_rpm = 0;
     m_current_robot = 1;
     m_machine_type = m_sb->setting<MachineType>(PRS::MachineSetup::kMachineType);
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -239,7 +239,7 @@ QString ORNLWriter::writeLine(const Point& start_point, const Point& target_poin
 
     QString rv;
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0, params);
         setFeedrate(0);
     }
@@ -297,7 +297,7 @@ QString ORNLWriter::writeArc(const Point& start_point, const Point& end_point, c
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
     Distance z_offset = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0, params);
     }
 
@@ -418,7 +418,7 @@ QString ORNLWriter::writeDwell(Time time) {
 QString ORNLWriter::writeExtruderOn(RegionType region_type, int rpm, int extruder_number,
                                     const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
 
     if (m_machine_type == MachineType::kWire_Arc) {
@@ -498,7 +498,7 @@ QString ORNLWriter::writeExtruderOn(RegionType region_type, int rpm, int extrude
 
 QString ORNLWriter::writeExtruderOff(int extruder_number) {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
 
     // Retrieve relevant settings
     Time off_delay = m_sb->setting<Time>(MS::Extruder::kOffDelay);

--- a/src/gcode/writers/reprap_writer.cpp
+++ b/src/gcode/writers/reprap_writer.cpp
@@ -24,7 +24,7 @@ QString RepRapWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
                                         int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_filament_location = 0.0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_print = true;
     m_first_travel = true;
     m_layer_start = true;
@@ -170,7 +170,7 @@ QString RepRapWriter::writeTravel(Point start_location, Point target_location, T
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
 
     Point new_start_location;
-    m_extruder_on = false;
+    m_deposition_active = false;
 
     // Update Acceleration
     if (m_sb->setting<bool>(PRS::Acceleration::kEnableDynamic)) {
@@ -243,11 +243,11 @@ QString RepRapWriter::writeLine(const Point& start_point, const Point& target_po
     QString rv;
 
     // check if extruder needs priming
-    bool needs_prime = !m_extruder_on;
-    m_extruder_on = true;
+    bool needs_prime = !m_deposition_active;
+    m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
-    // First segment of the path is signified by extruder being off and the modifier isn't one of five ending modifiers
+    // First segment of the path is signified by inactive deposition and the modifier isn't one of five ending modifiers
     if (needs_prime && path_modifiers != PathModifiers::kSlowDown && path_modifiers != PathModifiers::kForwardTipWipe &&
         path_modifiers != PathModifiers::kReverseTipWipe && path_modifiers != PathModifiers::kCoasting &&
         path_modifiers != PathModifiers::kSpiralLift) {

--- a/src/gcode/writers/romi_fanuc_writer.cpp
+++ b/src/gcode/writers/romi_fanuc_writer.cpp
@@ -22,7 +22,7 @@ QString RomiFanucWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -181,7 +181,7 @@ QString RomiFanucWriter::writeLine(const Point& start_point, const Point& target
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_extruder_on == false && rpm > 0) {
+    if (m_deposition_active == false && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -234,7 +234,7 @@ QString RomiFanucWriter::writeArc(const Point& start_point, const Point& end_poi
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -354,7 +354,7 @@ QString RomiFanucWriter::writeDwell(Time time) {
 
 QString RomiFanucWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -407,7 +407,7 @@ QString RomiFanucWriter::writeExtruderOn(RegionType type, int rpm, const QShared
 
 QString RomiFanucWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/sandia_writer.cpp
+++ b/src/gcode/writers/sandia_writer.cpp
@@ -31,7 +31,7 @@ QString SandiaWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
                                         int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -190,7 +190,7 @@ QString SandiaWriter::writeLine(const Point& start_point, const Point& target_po
 
     QString rv;
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0, params);
         setFeedrate(0);
     }
@@ -243,7 +243,7 @@ QString SandiaWriter::writeArc(const Point& start_point, const Point& end_point,
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0, params);
     }
 
@@ -387,7 +387,7 @@ QString SandiaWriter::writeTamperOff() {
 QString SandiaWriter::writeExtruderOn(RegionType type, int rpm, int extruder_number,
                                       const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -445,7 +445,7 @@ QString SandiaWriter::writeExtruderOff(int extruder_number) {
     // update to use extruder number
 
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/siemens_writer.cpp
+++ b/src/gcode/writers/siemens_writer.cpp
@@ -24,7 +24,7 @@ QString SiemensWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y,
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_print = true;
     m_first_travel = true;
     m_layer_start = true;
@@ -95,11 +95,11 @@ QString SiemensWriter::writeTravel(Point start_location, Point target_location, 
                                    QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    // If extruder is left on because of no end of path modifier, turn it off using Perimeter end of path G-Code
-    // This syntax doesn't currently issue extruder on/off commands because they are manually input to the
+    // If deposition is left active because of no end of path modifier, turn it off using Perimeter end of path G-Code
+    // This syntax doesn't currently issue deposition on/off commands because they are manually input to the
     // start/end G-Code of the settings
-    if (m_extruder_on) {
-        m_extruder_on = false;
+    if (m_deposition_active) {
+        m_deposition_active = false;
         if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty())
             rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
     }
@@ -162,14 +162,14 @@ QString SiemensWriter::writeLine(const Point& start_point, const Point& target_p
 
     QString rv;
 
-    // This syntax doesn't currently issue extruder on/off commands because they are manually input to the
+    // This syntax doesn't currently issue deposition on/off commands because they are manually input to the
     // start/end G-Code of the setting
     // Write out the region starting G-Code if this is the first segment of the path
-    // First segment of the path is signified by extruder being off and the modifier isn't one of five ending modifiers
-    if (m_extruder_on == false && path_modifiers != PathModifiers::kSlowDown &&
+    // First segment of the path is signified by inactive deposition and the modifier isn't one of five ending modifiers
+    if (m_deposition_active == false && path_modifiers != PathModifiers::kSlowDown &&
         path_modifiers != PathModifiers::kForwardTipWipe && path_modifiers != PathModifiers::kReverseTipWipe &&
         path_modifiers != PathModifiers::kCoasting && path_modifiers != PathModifiers::kSpiralLift) {
-        m_extruder_on = true;
+        m_deposition_active = true;
         if (region_type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterStart).isEmpty())
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterStart) % m_newline;
@@ -197,11 +197,11 @@ QString SiemensWriter::writeLine(const Point& start_point, const Point& target_p
     }
     // Write out the region ending G-Code if this is the first segment of the ending path modifiers
     // First segment is signified by extruder being on and the modifier is one of five ending modifiers
-    else if (m_extruder_on == true &&
+    else if (m_deposition_active == true &&
              (path_modifiers == PathModifiers::kSlowDown || path_modifiers == PathModifiers::kForwardTipWipe ||
               path_modifiers == PathModifiers::kReverseTipWipe || path_modifiers == PathModifiers::kCoasting ||
               path_modifiers == PathModifiers::kSpiralLift)) {
-        m_extruder_on = false;
+        m_deposition_active = false;
         if (region_type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty())
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -261,7 +261,7 @@ QString SiemensWriter::writeArc(const Point& start_point, const Point& end_point
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm);
     }
 

--- a/src/gcode/writers/thermwood_writer.cpp
+++ b/src/gcode/writers/thermwood_writer.cpp
@@ -21,7 +21,7 @@ QString ThermwoodWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
                                            Distance maximum_y, int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -197,7 +197,7 @@ QString ThermwoodWriter::writeLine(const Point& start_point, const Point& target
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -250,7 +250,7 @@ QString ThermwoodWriter::writeArc(const Point& start_point, const Point& end_poi
     float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, params);
     }
 
@@ -370,7 +370,7 @@ QString ThermwoodWriter::writeDwell(Time time) {
 
 QString ThermwoodWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
 
@@ -423,7 +423,7 @@ QString ThermwoodWriter::writeExtruderOn(RegionType type, int rpm, const QShared
 
 QString ThermwoodWriter::writeExtruderOff() {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/tormach_writer.cpp
+++ b/src/gcode/writers/tormach_writer.cpp
@@ -31,7 +31,7 @@ QString TormachWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y,
                                          int num_layers) {
     m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_current_rpm = 0;
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -225,7 +225,7 @@ QString TormachWriter::writeLine(const Point& start_point, const Point& target_p
 
     QString rv;
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0);
         setFeedrate(0);
     }
@@ -351,7 +351,7 @@ QString TormachWriter::writeDwell(Time time) {
 
 QString TormachWriter::writeExtruderOn(RegionType type, int rpm, int extruder_number) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
 
     if (type == RegionType::kInset) {
         if (m_sb->setting<Time>(MS::Extruder::kOnDelayInset) > 0) {
@@ -387,7 +387,7 @@ QString TormachWriter::writeExtruderOn(RegionType type, int rpm, int extruder_nu
 
 QString TormachWriter::writeExtruderOff(int extruder_number) {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
     if (m_sb->setting<Time>(MS::Extruder::kOffDelay) > 0) {
         rv += writeDwell(m_sb->setting<Time>(MS::Extruder::kOffDelay));
     }

--- a/src/gcode/writers/wolf_writer.cpp
+++ b/src/gcode/writers/wolf_writer.cpp
@@ -32,7 +32,7 @@ QString WolfWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
     m_current_rpm = 0;
     m_current_robot = 1;
     m_machine_type = m_sb->setting<MachineType>(PRS::MachineSetup::kMachineType);
-    m_extruder_on = false;
+    m_deposition_active = false;
     m_first_travel = true;
     m_first_print = true;
     m_layer_start = true;
@@ -201,7 +201,7 @@ QString WolfWriter::writeLine(const Point& start_point, const Point& target_poin
         rv += "M6" % commentSpaceLine("TIP WIPE START");
     }
 
-    if (!m_extruder_on && rpm > 0) {
+    if (!m_deposition_active && rpm > 0) {
         rv += writeExtruderOn(region_type, rpm, 0);
         setFeedrate(0);
     }
@@ -321,7 +321,7 @@ QString WolfWriter::writeDwell(Time time) {
 
 QString WolfWriter::writeExtruderOn(RegionType region_type, int rpm, int extruder_number) {
     QString rv;
-    m_extruder_on = true;
+    m_deposition_active = true;
 
     rv += "M101" % commentSpaceLine("TURN PUMP ON");
 
@@ -357,7 +357,7 @@ QString WolfWriter::writeExtruderOn(RegionType region_type, int rpm, int extrude
 
 QString WolfWriter::writeExtruderOff(int extruder_number) {
     QString rv;
-    m_extruder_on = false;
+    m_deposition_active = false;
 
     // Retrieve relevant settings
     Time off_delay = m_sb->setting<Time>(MS::Extruder::kOffDelay);

--- a/src/gcode/writers/writer_base.cpp
+++ b/src/gcode/writers/writer_base.cpp
@@ -51,7 +51,7 @@ WriterBase::WriterBase(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb) :
     m_build_maximum_z = Distance(0.0);
     m_has_build_maximum_z = false;
 
-    m_extruder_on = false;
+    m_deposition_active = false;
 }
 
 QString WriterBase::comment(const QString& text) {

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -391,13 +391,13 @@ void GCodeLoader::run() {
                     if (m_selected_meta.hasTravels) {
                         generated_segments = generateVisualSegment(
                             command.getLineNumber() + 1, current_layer, line_color, command.getCommandID(),
-                            command.getParameters(), command.getExtruderOn(), command.getExtruderSpeed(), true,
+                            command.getParameters(), command.getDepositionActive(), command.getExtruderSpeed(), true,
                             command.getComment());
                     }
                     else {
                         generated_segments = generateVisualSegment(
                             command.getLineNumber() + 1, current_layer, line_color, command.getCommandID(),
-                            command.getParameters(), command.getExtruderOn(), command.getExtruderSpeed(), false,
+                            command.getParameters(), command.getDepositionActive(), command.getExtruderSpeed(), false,
                             command.getComment(), command.getOptionalParameters());
                     }
                     layer.append(generated_segments);
@@ -819,7 +819,7 @@ void GCodeLoader::setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, Se
 }
 
 void GCodeLoader::setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const QString& comment,
-                                     QVector3D& info_end_pos, const bool& extruder_on, const bool& info_speed_set,
+                                     QVector3D& info_end_pos, const bool& deposition_active, const bool& info_speed_set,
                                      const double& extruder_speed) {
     // Set the type info of the segment
     segment->m_segment_info_meta.type = comment;
@@ -828,16 +828,16 @@ void GCodeLoader::setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const
     segment->m_segment_info_meta.start = m_info_start_pos;
     segment->m_segment_info_meta.end = info_end_pos;
 
-    // If the extruder is on, set the speed info
-    if (!extruder_on && !info_speed_set) {
+    // If deposition is active, retain the current speed metadata for the segment.
+    if (!deposition_active && !info_speed_set) {
         segment->m_segment_info_meta.speed = "";
     }
     else {
         segment->m_segment_info_meta.speed = m_info_speed;
     }
 
-    // If the extruder is on, set the extruder speed info
-    if (extruder_on) {
+    // If deposition is active, set the material feed speed metadata.
+    if (deposition_active) {
         if (m_info_extruder_speed.isEmpty()) {
             segment->m_segment_info_meta.extruderSpeed = QString().asprintf("%0.4f", extruder_speed) % " rpm";
         }
@@ -859,8 +859,8 @@ void GCodeLoader::setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const
 
 QVector<QSharedPointer<SegmentBase>>
 GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& color, int command_id,
-                                   const QMap<char, double>& parameters, bool extruder_on, double extruder_speed,
-                                   bool include_non_extruding_moves, QString comment,
+                                   const QMap<char, double>& parameters, bool deposition_active, double extruder_speed,
+                                   bool include_non_deposition_moves, QString comment,
                                    const QMap<char, double>& optional_parameters) {
     // Parameters for drawing and placing each segment in the world correctly
     QVector3D end_pos = m_start_pos;
@@ -937,7 +937,7 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
 
     QVector<QSharedPointer<SegmentBase>> generated_segments;
 
-    if (extruder_on || include_non_extruding_moves) {
+    if (deposition_active || include_non_deposition_moves) {
         QSharedPointer<SegmentBase> segment;
 
         // Builds and draws segments according to their type (Line, Arc, Spline)
@@ -1011,7 +1011,7 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
                               line_num, layer_num);
 
         // Set the segment's meta info
-        setSegmentMetaInfo(segment, comment, info_end_pos, extruder_on, info_speed_set, extruder_speed);
+        setSegmentMetaInfo(segment, comment, info_end_pos, deposition_active, info_speed_set, extruder_speed);
 
         // Add the segment to the list of generated segments
         generated_segments.append(segment);

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -319,6 +319,8 @@ const QString Constants::PrinterSettings::GCode::kEnableWaitForUser = "enable_wa
 const QString Constants::PrinterSettings::GCode::kEnableBoundingBox = "enable_bounding_box";
 const QString Constants::PrinterSettings::GCode::kEnableSettingsFooter = "enable_settings_footer";
 const QString Constants::PrinterSettings::GCode::kLayerTimeComments = "enable_layer_time_comments";
+const QString Constants::PrinterSettings::GCode::kArcSpecialtiesG2G3OptionalStop =
+    "arc_specialties_g2_g3_optional_stop";
 const QString Constants::PrinterSettings::GCode::kStartCode = "start_code";
 const QString Constants::PrinterSettings::GCode::kLayerCodeChange = "layer_change_code";
 const QString Constants::PrinterSettings::GCode::kEndCode = "end_code";


### PR DESCRIPTION
## Summary

This updates the Arc Specialties G-code path to use the current welder command flow and terminology.

- Generalizes shared parser/writer state from `extruder_on` to `deposition_active` so metal deposition commands are not modeled as polymer extrusion.
- Renames the Arc Specialties writer helpers from extruder control to welder control.
- Updates Arc Specialties welder on/off output from `M150`/`M151` to `G82`/`G83`, including validated G83 mode handling.
- Re-enables the travel-lower optional stop routine as `G81`, removes the disabled `M160` wire clip output, and refreshes the Arc Specialties docs/comments around currently disabled `M06` behavior.

## Why

The Arc Specialties controller command set and the writer's metal-deposition semantics have moved away from the older extruder-oriented naming and M-code assumptions. Keeping the old names and commands made the output harder to reason about and risked generating controller instructions that no longer match the current Arc Specialties workflow.

## Impact

Generated Arc Specialties G-code now uses `G82` to start welding and `G83` to stop welding, while the shared G-code parsing and motion-estimation state describes deposition activity more generally. Existing polymer-oriented writers keep their emitted behavior, with call sites updated to the new shared naming.

## Validation

- `git diff develop..HEAD --check`
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer_gcode_settings_importer_tests`
- `nix develop --command ctest --test-dir build/generic-llvm-ninja -C Debug -R gcode_settings_importer_tests --output-on-failure`