### PR TITLE
Add object measuring tools

### DIFF
--- a/include/graphics/base_view.h
+++ b/include/graphics/base_view.h
@@ -188,6 +188,8 @@ class BaseView : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core {
     virtual void handleWheelForward(QPointF mouse_ndc_pos, float delta);
     //! \brief Respond to a mouse wheel backward movement
     virtual void handleWheelBackward(QPointF mouse_ndc_pos, float delta);
+    //! \brief Gives derived views first chance at non-camera key presses.
+    virtual bool handleKeyPress(QKeyEvent* e);
     //! \brief Applies a pan request from mouse or keyboard navigation.
     //! \param v World-space translation vector to apply.
     //! \param absolute If true, set the camera pan target to \p v; otherwise apply \p v as a relative pan.

--- a/include/graphics/view/part_view.h
+++ b/include/graphics/view/part_view.h
@@ -359,13 +359,13 @@ class PartView : public BaseView {
     void updateMeasurementPreview(QPointF mouse_ndc_pos);
 
     //! \brief Clears the live measurement preview.
-    void clearMeasurementPreview();
+    bool clearMeasurementPreview();
 
     //! \brief Picks a point on any part for measurement.
     bool pickMeasurementPoint(const QPointF& mouse_ndc_pos, QVector3D& point);
 
     //! \brief Removes one measurement annotation object from the render set.
-    void removeMeasurementObject(QSharedPointer<GraphicsObject>& object);
+    bool removeMeasurementObject(QSharedPointer<GraphicsObject>& object);
 
     //! \brief Creates a marker at a picked measurement point.
     QSharedPointer<GraphicsObject> createMeasurementMarker(const QVector3D& point);

--- a/include/graphics/view/part_view.h
+++ b/include/graphics/view/part_view.h
@@ -79,6 +79,12 @@ class PartView : public BaseView {
     //! \param plane: Plane normal to align to.
     void setupAlignment(QVector3D plane);
 
+    //! \brief Enables or disables point-to-point measurement mode.
+    void setMeasurementMode(bool enabled);
+
+    //! \brief Removes the visible measurement annotation.
+    void clearMeasurement();
+
     //! \brief Centers a part in the build volume by name.
     //! \param name: Name of part to drop.
     //! \todo This should be done using the selected parts instead.
@@ -124,6 +130,12 @@ class PartView : public BaseView {
     //! \brief Notification that a draggable optimization point setting edit has finished.
     void optimizationPointDragFinished(QString x_setting, double x, QString y_setting, double y);
 
+    //! \brief Emitted when a measurement readout should update or clear.
+    void measurementReadoutChanged(QString readout);
+
+    //! \brief Emitted when a measurement is committed by choosing the second point.
+    void measurementCompleted(QString readout);
+
   protected:
     //! \brief Initalizes the view with the printer and the associated objects.
     void initView() override;
@@ -163,6 +175,9 @@ class PartView : public BaseView {
 
     //! \brief Handles the following: Overhang enable
     void handleMidRelease(QPointF mouse_ndc_pos) override;
+
+    //! \brief Handles measurement keyboard commands.
+    bool handleKeyPress(QKeyEvent* e) override;
 
     //! \brief centers a graphics part in the printer volume
     //! \param gop the graphics part object
@@ -248,6 +263,33 @@ class PartView : public BaseView {
         //! \brief If the view is aligning or not.
         bool aligning = false;
 
+        //! \brief If point-to-point measurement mode is active.
+        bool measuring = false;
+
+        //! \brief If the first point of the active measurement has been selected.
+        bool has_measurement_start = false;
+
+        //! \brief World-space first point of the active measurement.
+        QVector3D measurement_start;
+
+        //! \brief Rendered marker for the first measurement point.
+        QSharedPointer<GraphicsObject> measurement_start_marker;
+
+        //! \brief Rendered marker for the second measurement point.
+        QSharedPointer<GraphicsObject> measurement_end_marker;
+
+        //! \brief Rendered line between measurement points.
+        QSharedPointer<GraphicsObject> measurement_line;
+
+        //! \brief Rendered measurement label.
+        QSharedPointer<GraphicsObject> measurement_label;
+
+        //! \brief Rendered live-preview measurement line.
+        QSharedPointer<GraphicsObject> measurement_preview_line;
+
+        //! \brief Rendered live-preview measurement label.
+        QSharedPointer<GraphicsObject> measurement_preview_label;
+
         //! \brief If overhangs are shown.
         bool overhangs_shown = false;
 
@@ -309,6 +351,33 @@ class PartView : public BaseView {
 
     //! \brief Finds an object based on its part pointer.
     QSharedPointer<PartObject> findObject(QSharedPointer<Part> part);
+
+    //! \brief Handles one click while in measurement mode.
+    bool handleMeasurementClick(QPointF mouse_ndc_pos);
+
+    //! \brief Updates the live measurement preview while a start point is active.
+    void updateMeasurementPreview(QPointF mouse_ndc_pos);
+
+    //! \brief Clears the live measurement preview.
+    void clearMeasurementPreview();
+
+    //! \brief Picks a point on any part for measurement.
+    bool pickMeasurementPoint(const QPointF& mouse_ndc_pos, QVector3D& point);
+
+    //! \brief Removes one measurement annotation object from the render set.
+    void removeMeasurementObject(QSharedPointer<GraphicsObject>& object);
+
+    //! \brief Creates a marker at a picked measurement point.
+    QSharedPointer<GraphicsObject> createMeasurementMarker(const QVector3D& point);
+
+    //! \brief Creates a rendered line between measurement points.
+    QSharedPointer<GraphicsObject> createMeasurementLine(const QVector3D& start, const QVector3D& end);
+
+    //! \brief Creates a billboarded label for the completed measurement.
+    QSharedPointer<GraphicsObject> createMeasurementLabel(const QVector3D& start, const QVector3D& end);
+
+    //! \brief Formats a measurement distance for display using user-preferred distance units.
+    QString formatMeasurementDistance(double microns, bool ascii_units) const;
 
     //! \brief Updates the selected layer settings range plane visibility and placement.
     void updateLayerSettingsRangePlane();

--- a/include/widgets/part_widget/part_toolbar.h
+++ b/include/widgets/part_widget/part_toolbar.h
@@ -47,6 +47,9 @@ class PartToolbar : public QToolBar {
     //! \param plane the plane the align in on
     void setupAlignment(QVector3D plane);
 
+    //! \brief toggles point-to-point measurement mode
+    void measureModeChanged(bool enabled);
+
   public slots:
     //! \brief sets the style of the widget according to current theme
     void setupStyle();
@@ -84,6 +87,9 @@ class PartToolbar : public QToolBar {
     //! \brief sets up align button and controls
     void setupAlign();
 
+    //! \brief sets up measure button
+    void setupMeasurement();
+
     //! \brief sets up center button
     void setupCenter();
 
@@ -118,6 +124,9 @@ class PartToolbar : public QToolBar {
     // Align
     QToolButton* m_align_btn;
     ToolbarAlignInput* m_align_controls;
+
+    // Measure
+    QToolButton* m_measure_btn = nullptr;
 
     // Center
     QToolButton* m_center_btn;

--- a/include/widgets/part_widget/part_widget.h
+++ b/include/widgets/part_widget/part_widget.h
@@ -171,7 +171,13 @@ class PartWidget : public QWidget {
     void setStatusSelection(QString name);
     void setStatusIssue(QString issue);
 
+    //! \brief Updates the measurement readout overlay.
+    void setMeasurementReadout(QString readout);
+
   private:
+    //! \brief Repositions the measurement readout beside the part toolbar.
+    void positionMeasurementReadout();
+
     //! \brief called when the widget is resized
     //! \param event: the event
     void resizeEvent(QResizeEvent* event);
@@ -208,6 +214,8 @@ class PartWidget : public QWidget {
 
     //! \brief Labels
     QLabel* m_selection_label;
+    QLabel* m_measurement_label;
+    QToolButton* m_measurement_clear_btn;
 
     //! \brief Color of emphasized text
     QString m_accentColor;

--- a/include/widgets/part_widget/right_click_menu.h
+++ b/include/widgets/part_widget/right_click_menu.h
@@ -40,7 +40,11 @@ class RightClickMenu : public QMenu {
     //! \brief disables actions/ buttons in the menu depending on nullability and mesh type
     void disableActions();
 
+    //! \brief shows object information for the selected part
+    void showInfoDialog();
+
     //! \brief actions to display
+    QAction* m_info_action;
     QAction* m_switch_to_clipper_action;
     QAction* m_switch_to_build_action;
     QAction* m_switch_to_setting_action;

--- a/src/geometry/mesh/open_mesh.cpp
+++ b/src/geometry/mesh/open_mesh.cpp
@@ -73,6 +73,7 @@ OpenMesh::OpenMesh(MeshTypes::SurfaceMesh poly, QString name, QString file) : Me
     m_faces_original = m_faces = m_faces_aligned = vertices_and_faces.second;
     m_original_representation = m_representation;
     updateDims();
+    m_original_dimensions = m_dimensions;
 }
 
 OpenMesh::OpenMesh(QSharedPointer<OpenMesh> mesh) : MeshBase(mesh) {

--- a/src/graphics/base_view.cpp
+++ b/src/graphics/base_view.cpp
@@ -183,6 +183,11 @@ void BaseView::wheelEvent(QWheelEvent* e) {
 }
 
 void BaseView::keyPressEvent(QKeyEvent* e) {
+    if (handleKeyPress(e)) {
+        e->accept();
+        return;
+    }
+
     if (!isArrowKey(e->key())) {
         QOpenGLWidget::keyPressEvent(e);
         return;
@@ -352,6 +357,11 @@ void BaseView::handleWheelBackward(QPointF mouse_ndc_pos, float delta) {
     float focus_scale = m_camera->getZoom() / m_camera->getDefaultZoom();
     m_focus->scaleAbsolute(QVector3D(focus_scale, focus_scale, focus_scale));
     this->update();
+}
+
+bool BaseView::handleKeyPress(QKeyEvent* e) {
+    Q_UNUSED(e);
+    return false;
 }
 
 void BaseView::translateCamera(QVector3D v, bool absolute) {

--- a/src/graphics/view/part_view.cpp
+++ b/src/graphics/view/part_view.cpp
@@ -5,12 +5,14 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <vector>
 
 #include <QMessageBox>
 #include <QStack>
 #include <QToolTip>
 #include <qcolor.h>
 #include <qcursor.h>
+#include <qevent.h>
 #include <qhashfunctions.h>
 #include <qlist.h>
 #include <qmath.h>
@@ -35,6 +37,7 @@
 #include "graphics/objects/printer/cartesian_printer_object.h"
 #include "graphics/objects/printer/cylindrical_printer_object.h"
 #include "graphics/objects/printer/printer_object.h"
+#include "graphics/objects/sphere_object.h"
 #include "graphics/objects/sphere/seam_object.h"
 #include "graphics/objects/text_object.h"
 #include "graphics/support/part_picker.h"
@@ -53,6 +56,20 @@ namespace ORNL {
 namespace {
 constexpr float kMinimumLayerSettingsRangeThickness = 0.01f;
 constexpr float kMinimumSlicingCylinderHeight = 0.01f;
+constexpr float kMeasurementMarkerRadius = 0.025f;
+constexpr float kMeasurementLabelLift = 0.08f;
+constexpr float kMeasurementLabelScale = 0.08f;
+
+QString asciiDistanceUnitText(QString unit_text) {
+    unit_text.replace(Constants::Units::kMicron, "um");
+    unit_text.replace(QString(QChar(0x00b5)), "u");
+    unit_text.replace(QString(QChar(0x03bc)), "u");
+    return unit_text;
+}
+
+bool isFinitePoint(const QVector3D& point) {
+    return std::isfinite(point.x()) && std::isfinite(point.y()) && std::isfinite(point.z());
+}
 } // namespace
 
 PartView::PartView(QSharedPointer<SettingsBase> sb) {
@@ -153,6 +170,23 @@ void PartView::setupAlignment(QVector3D plane) {
     this->setCursor(Qt::PointingHandCursor);
 
     m_state.aligning = true;
+}
+
+void PartView::setMeasurementMode(bool enabled) {
+    m_state.measuring = enabled;
+    m_state.aligning = false;
+    m_state.has_measurement_start = false;
+
+    if (enabled) {
+        this->setCursor(QCursor(Qt::CrossCursor));
+        emit measurementReadoutChanged("Click first measurement point");
+    }
+    else {
+        this->clearMeasurement();
+        this->setCursor(QCursor(Qt::ArrowCursor));
+    }
+
+    this->update();
 }
 
 void PartView::centerPart(QString name) {
@@ -495,6 +529,10 @@ void PartView::initView() {
 }
 
 void PartView::handleLeftClick(QPointF mouse_ndc_pos) {
+    if (m_state.measuring && handleMeasurementClick(mouse_ndc_pos)) {
+        return;
+    }
+
     if (beginOptimizationPointDrag(mouse_ndc_pos)) {
         return;
     }
@@ -809,6 +847,18 @@ void PartView::handleRightRelease(QPointF mouse_ndc_pos, QPointF global_pos) {
 }
 
 void PartView::handleMouseMove(QPointF mouse_ndc_pos) {
+    if (m_state.measuring) {
+        if (!m_state.highlighted_part.isNull()) {
+            m_state.highlighted_part->unhighlight();
+            m_state.highlighted_part.reset();
+            this->update();
+        }
+
+        updateMeasurementPreview(mouse_ndc_pos);
+        this->setCursor(QCursor(Qt::CrossCursor));
+        return;
+    }
+
     auto picked_seam = m_printer->pickOptimizationPoint(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos);
     if (picked_seam.isValid()) {
         if (!m_state.highlighted_part.isNull()) {
@@ -866,6 +916,16 @@ void PartView::handleWheelBackward(QPointF mouse_ndc_pos, float delta) {
 void PartView::handleMidClick(QPointF mouse_ndc_pos) { this->BaseView::handleMidClick(mouse_ndc_pos); }
 
 void PartView::handleMidRelease(QPointF mouse_ndc_pos) { this->BaseView::handleMidRelease(mouse_ndc_pos); }
+
+bool PartView::handleKeyPress(QKeyEvent* e) {
+    if (!m_state.measuring || e->key() != Qt::Key_Escape)
+        return false;
+
+    clearMeasurement();
+    emit measurementReadoutChanged("Measurement cleared");
+    this->update();
+    return true;
+}
 
 void PartView::resetCamera() {
     // Reset rotation and zoom
@@ -970,6 +1030,8 @@ void PartView::modelReloadUpdate(QSharedPointer<PartMetaItem> pm) {
 
 void PartView::modelRemovalUpdate(QSharedPointer<PartMetaItem> pm) {
     QSharedPointer<PartObject> gop = pm->graphicsPart();
+
+    clearMeasurement();
 
     m_part_objects.remove(gop);
     m_selected_objects.remove(gop);
@@ -1209,6 +1271,163 @@ QSharedPointer<PartObject> PartView::findObject(QSharedPointer<Part> part) {
     }
 
     return nullptr;
+}
+
+bool PartView::handleMeasurementClick(QPointF mouse_ndc_pos) {
+    QVector3D picked_point;
+    if (!pickMeasurementPoint(mouse_ndc_pos, picked_point)) {
+        QToolTip::showText(QCursor::pos(), "Click an object surface to measure.", nullptr, QRect(), 3000);
+        return true;
+    }
+
+    if (!m_state.has_measurement_start) {
+        clearMeasurement();
+
+        m_state.measurement_start = picked_point;
+        m_state.has_measurement_start = true;
+        m_state.measurement_start_marker = createMeasurementMarker(picked_point);
+        addObject(m_state.measurement_start_marker);
+
+        emit measurementReadoutChanged("Select second measurement point");
+        this->update();
+        return true;
+    }
+
+    clearMeasurementPreview();
+
+    m_state.measurement_end_marker = createMeasurementMarker(picked_point);
+    m_state.measurement_line = createMeasurementLine(m_state.measurement_start, picked_point);
+    m_state.measurement_label = createMeasurementLabel(m_state.measurement_start, picked_point);
+
+    addObject(m_state.measurement_line);
+    addObject(m_state.measurement_end_marker);
+    addObject(m_state.measurement_label);
+
+    const double distance_microns =
+        m_state.measurement_start.distanceToPoint(picked_point) * Constants::OpenGL::kViewToObject;
+    const QString readout = formatMeasurementDistance(distance_microns, false);
+    emit measurementReadoutChanged(readout);
+    emit measurementCompleted(QString("Measurement: %1").arg(readout));
+
+    m_state.has_measurement_start = false;
+    this->update();
+    return true;
+}
+
+void PartView::updateMeasurementPreview(QPointF mouse_ndc_pos) {
+    if (!m_state.has_measurement_start) {
+        clearMeasurementPreview();
+        return;
+    }
+
+    QVector3D picked_point;
+    if (!pickMeasurementPoint(mouse_ndc_pos, picked_point)) {
+        clearMeasurementPreview();
+        emit measurementReadoutChanged("Select second measurement point");
+        return;
+    }
+
+    clearMeasurementPreview();
+
+    m_state.measurement_preview_line = createMeasurementLine(m_state.measurement_start, picked_point);
+    m_state.measurement_preview_label = createMeasurementLabel(m_state.measurement_start, picked_point);
+    addObject(m_state.measurement_preview_line);
+    addObject(m_state.measurement_preview_label);
+
+    const double distance_microns =
+        m_state.measurement_start.distanceToPoint(picked_point) * Constants::OpenGL::kViewToObject;
+    emit measurementReadoutChanged(formatMeasurementDistance(distance_microns, false));
+    this->update();
+}
+
+void PartView::clearMeasurementPreview() {
+    removeMeasurementObject(m_state.measurement_preview_line);
+    removeMeasurementObject(m_state.measurement_preview_label);
+}
+
+bool PartView::pickMeasurementPoint(const QPointF& mouse_ndc_pos, QVector3D& point) {
+    float min_dist = std::numeric_limits<float>::infinity();
+    QVector3D closest_point;
+
+    for (auto& gop : m_part_objects) {
+        auto pick = PartPicker::pickDistanceTriangleAndIntersection(this->projectionMatrix(), this->viewMatrix(),
+                                                                    mouse_ndc_pos, gop->triangles());
+        const float dist = std::get<0>(pick);
+        const QVector3D intersect = std::get<2>(pick);
+        if (!std::isfinite(dist) || !isFinitePoint(intersect))
+            continue;
+
+        if (dist < min_dist) {
+            min_dist = dist;
+            closest_point = intersect;
+        }
+    }
+
+    if (!std::isfinite(min_dist))
+        return false;
+
+    point = closest_point;
+    return true;
+}
+
+void PartView::clearMeasurement() {
+    clearMeasurementPreview();
+    removeMeasurementObject(m_state.measurement_start_marker);
+    removeMeasurementObject(m_state.measurement_end_marker);
+    removeMeasurementObject(m_state.measurement_line);
+    removeMeasurementObject(m_state.measurement_label);
+
+    m_state.has_measurement_start = false;
+    m_state.measurement_start = QVector3D();
+    emit measurementReadoutChanged(QString());
+}
+
+void PartView::removeMeasurementObject(QSharedPointer<GraphicsObject>& object) {
+    if (object.isNull())
+        return;
+
+    removeObject(object);
+    object.reset();
+}
+
+QSharedPointer<GraphicsObject> PartView::createMeasurementMarker(const QVector3D& point) {
+    auto marker = QSharedPointer<SphereObject>::create(this, kMeasurementMarkerRadius, Constants::Colors::kYellow);
+    marker->translateAbsolute(point);
+    marker->setOnTop(true);
+    return marker;
+}
+
+QSharedPointer<GraphicsObject> PartView::createMeasurementLine(const QVector3D& start, const QVector3D& end) {
+    std::vector<float> vertices = {start.x(), start.y(), start.z(), end.x(), end.y(), end.z()};
+    std::vector<float> normals = {0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f};
+
+    QColor color = Constants::Colors::kYellow;
+    std::vector<float> colors = {color.redF(), color.greenF(), color.blueF(), color.alphaF(),
+                                 color.redF(), color.greenF(), color.blueF(), color.alphaF()};
+
+    auto line = QSharedPointer<GraphicsObject>::create(this, vertices, normals, colors, GL_LINES);
+    line->setOnTop(true);
+    return line;
+}
+
+QSharedPointer<GraphicsObject> PartView::createMeasurementLabel(const QVector3D& start, const QVector3D& end) {
+    const QVector3D midpoint = (start + end) / 2.0f + QVector3D(0.0f, 0.0f, kMeasurementLabelLift);
+    const double distance_microns = start.distanceToPoint(end) * Constants::OpenGL::kViewToObject;
+
+    auto label = QSharedPointer<TextObject>::create(this, formatMeasurementDistance(distance_microns, true),
+                                                    kMeasurementLabelScale, true);
+    label->translateAbsolute(midpoint);
+    label->setOnTop(true);
+    return label;
+}
+
+QString PartView::formatMeasurementDistance(double microns, bool ascii_units) const {
+    const Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
+    QString unit_text = PreferencesManager::getInstance()->getDistanceUnitText();
+    if (ascii_units)
+        unit_text = asciiDistanceUnitText(unit_text);
+
+    return QString("%1 %2").arg(QString::number(Distance(microns).to(unit), 'f', 3), unit_text);
 }
 
 QQuaternion PartView::slicingPlaneRotation() const {

--- a/src/graphics/view/part_view.cpp
+++ b/src/graphics/view/part_view.cpp
@@ -1316,13 +1316,15 @@ bool PartView::handleMeasurementClick(QPointF mouse_ndc_pos) {
 
 void PartView::updateMeasurementPreview(QPointF mouse_ndc_pos) {
     if (!m_state.has_measurement_start) {
-        clearMeasurementPreview();
+        if (clearMeasurementPreview())
+            this->update();
         return;
     }
 
     QVector3D picked_point;
     if (!pickMeasurementPoint(mouse_ndc_pos, picked_point)) {
-        clearMeasurementPreview();
+        if (clearMeasurementPreview())
+            this->update();
         emit measurementReadoutChanged("Select second measurement point");
         return;
     }
@@ -1340,9 +1342,10 @@ void PartView::updateMeasurementPreview(QPointF mouse_ndc_pos) {
     this->update();
 }
 
-void PartView::clearMeasurementPreview() {
-    removeMeasurementObject(m_state.measurement_preview_line);
-    removeMeasurementObject(m_state.measurement_preview_label);
+bool PartView::clearMeasurementPreview() {
+    bool removed = removeMeasurementObject(m_state.measurement_preview_line);
+    removed = removeMeasurementObject(m_state.measurement_preview_label) || removed;
+    return removed;
 }
 
 bool PartView::pickMeasurementPoint(const QPointF& mouse_ndc_pos, QVector3D& point) {
@@ -1371,23 +1374,27 @@ bool PartView::pickMeasurementPoint(const QPointF& mouse_ndc_pos, QVector3D& poi
 }
 
 void PartView::clearMeasurement() {
-    clearMeasurementPreview();
-    removeMeasurementObject(m_state.measurement_start_marker);
-    removeMeasurementObject(m_state.measurement_end_marker);
-    removeMeasurementObject(m_state.measurement_line);
-    removeMeasurementObject(m_state.measurement_label);
+    bool removed = clearMeasurementPreview();
+    removed = removeMeasurementObject(m_state.measurement_start_marker) || removed;
+    removed = removeMeasurementObject(m_state.measurement_end_marker) || removed;
+    removed = removeMeasurementObject(m_state.measurement_line) || removed;
+    removed = removeMeasurementObject(m_state.measurement_label) || removed;
 
     m_state.has_measurement_start = false;
     m_state.measurement_start = QVector3D();
     emit measurementReadoutChanged(QString());
+
+    if (removed)
+        this->update();
 }
 
-void PartView::removeMeasurementObject(QSharedPointer<GraphicsObject>& object) {
+bool PartView::removeMeasurementObject(QSharedPointer<GraphicsObject>& object) {
     if (object.isNull())
-        return;
+        return false;
 
     removeObject(object);
     object.reset();
+    return true;
 }
 
 QSharedPointer<GraphicsObject> PartView::createMeasurementMarker(const QVector3D& point) {

--- a/src/widgets/part_widget/part_toolbar.cpp
+++ b/src/widgets/part_widget/part_toolbar.cpp
@@ -6,10 +6,14 @@
 #include <QInputDialog>
 #include <QLayout>
 #include <QMenu>
+#include <QPainter>
+#include <QPixmap>
 #include <qcontainerfwd.h>
 #include <qevent.h>
 #include <qicon.h>
 #include <qnamespace.h>
+#include <qpen.h>
+#include <qpoint.h>
 #include <qsharedpointer.h>
 #include <qsizepolicy.h>
 #include <qtmetamacros.h>
@@ -26,6 +30,25 @@
 #include "widgets/part_widget/input/tool_bar_input.h"
 
 namespace ORNL {
+namespace {
+QIcon measurementIcon() {
+    QPixmap pixmap(32, 32);
+    pixmap.fill(Qt::transparent);
+
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setPen(QPen(Qt::black, 2.4, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+
+    painter.drawLine(QPointF(9, 23), QPointF(23, 9));
+    painter.drawLine(QPointF(18, 8), QPointF(24, 8));
+    painter.drawLine(QPointF(24, 8), QPointF(24, 14));
+    painter.drawLine(QPointF(8, 18), QPointF(8, 24));
+    painter.drawLine(QPointF(8, 24), QPointF(14, 24));
+
+    return QIcon(pixmap);
+}
+} // namespace
+
 PartToolbar::PartToolbar(QSharedPointer<PartMetaModel> model, QWidget* parent)
     : m_model(model), m_parent(parent), QToolBar(parent) {
     m_translation_controls = new ToolbarInput(m_parent, false);
@@ -140,6 +163,8 @@ void PartToolbar::setEnabled(bool status) {
     m_scale_btn->setEnabled(status);
     // Align works even if a part is not selected. It should always be enabled.
     // m_align_btn->setEnabled(status);
+    // Measurement works on any visible part and does not require an active selection.
+    m_measure_btn->setEnabled(true);
     m_center_btn->setEnabled(status);
     m_drop_to_floor_btn->setEnabled(status);
 }
@@ -179,6 +204,11 @@ void PartToolbar::setupSubWidgets() {
     this->makeSpace();
 
     setupAlign();
+    this->makeSpace();
+    this->addSeparator();
+    this->makeSpace();
+
+    setupMeasurement();
     this->makeSpace();
     this->addSeparator();
     this->makeSpace();
@@ -287,7 +317,18 @@ void PartToolbar::setupAlign() {
     m_align_controls = new ToolbarAlignInput(m_parent);
     connect(m_align_btn, &QToolButton::pressed, m_align_controls, &ToolbarAlignInput::toggleInput);
     connect(m_align_controls, &ToolbarAlignInput::setAlignment, this,
-            [this](QVector3D dir) { emit setupAlignment(dir); });
+            [this](QVector3D dir) {
+                if (m_measure_btn != nullptr)
+                    m_measure_btn->setChecked(false);
+                emit setupAlignment(dir);
+            });
+}
+
+void PartToolbar::setupMeasurement() {
+    m_measure_btn = buildIconButton(QString(), "Measure Object Distances", true);
+    m_measure_btn->setIcon(measurementIcon());
+    this->addWidget(m_measure_btn);
+    connect(m_measure_btn, &QToolButton::toggled, this, [this](bool checked) { emit measureModeChanged(checked); });
 }
 
 void PartToolbar::setupCenter() {

--- a/src/widgets/part_widget/part_widget.cpp
+++ b/src/widgets/part_widget/part_widget.cpp
@@ -12,6 +12,7 @@
 #include <qquaternion.h>
 #include <qset.h>
 #include <qsharedpointer.h>
+#include <qstyle.h>
 #include <qsurfaceformat.h>
 #include <qtmetamacros.h>
 #include <qvectornd.h>
@@ -315,6 +316,32 @@ void PartWidget::setStatusSelection(QString name) {
 
 void PartWidget::setStatusIssue(QString issue) { m_status_state.issues = issue; }
 
+void PartWidget::setMeasurementReadout(QString readout) {
+    if (readout.isEmpty()) {
+        m_measurement_label->hide();
+        m_measurement_clear_btn->hide();
+        return;
+    }
+
+    m_measurement_label->setText(readout);
+    m_measurement_label->adjustSize();
+    m_measurement_label->show();
+    m_measurement_label->raise();
+    m_measurement_clear_btn->show();
+    m_measurement_clear_btn->raise();
+    positionMeasurementReadout();
+}
+
+void PartWidget::positionMeasurementReadout() {
+    double toolbar_y = (this->height() / 3.0) - (Constants::UI::PartToolbar::kHeight / 2.0);
+    if (toolbar_y <= Constants::UI::PartToolbar::kMinTopOffset)
+        toolbar_y = Constants::UI::PartToolbar::kMinTopOffset;
+
+    const int readout_x = Constants::UI::PartToolbar::kLeftOffset + Constants::UI::PartToolbar::kWidth + 8;
+    m_measurement_label->move(readout_x, toolbar_y);
+    m_measurement_clear_btn->move(readout_x + m_measurement_label->width() + 3, toolbar_y);
+}
+
 void PartWidget::resizeEvent(QResizeEvent* event) {
     QPoint new_size = QPoint(event->size().width(), event->size().height());
 
@@ -324,6 +351,7 @@ void PartWidget::resizeEvent(QResizeEvent* event) {
     m_selection_label->move(Constants::UI::PartControl::kLeftOffset + 10,
                             event->size().height() -
                                 (Constants::UI::PartControl::kSize.height() + 10 + m_selection_label->height()));
+    positionMeasurementReadout();
 
     emit resized(event->size());
 }
@@ -366,6 +394,16 @@ void PartWidget::setupSubWidgets() {
     this->setStatusSelection("None");
     m_selection_label->show();
 
+    // Measurement readout
+    m_measurement_label = new QLabel(this);
+    m_measurement_label->hide();
+    m_measurement_clear_btn = new QToolButton(this);
+    m_measurement_clear_btn->setAutoRaise(true);
+    m_measurement_clear_btn->setFixedSize(22, 22);
+    m_measurement_clear_btn->setIcon(this->style()->standardIcon(QStyle::SP_DialogCloseButton));
+    m_measurement_clear_btn->setToolTip("Clear Measurement");
+    m_measurement_clear_btn->hide();
+
     // Part Control
     m_part_control = new PartControl(this);
     m_part_control->resize(Constants::UI::PartControl::kSize);
@@ -382,6 +420,12 @@ void PartWidget::setupStyle() {
     QString status = "Currently Manipulating: <font color=\"" % m_accentColor % "\">%1</font>";
     status = status.arg(m_status_state.selected_part);
     m_selection_label->setText(status);
+
+    m_measurement_label->setStyleSheet(QString("QLabel { background: rgba(245, 245, 245, 220); color: %1; "
+                                               "border: 1px solid rgba(0, 0, 0, 80); padding: 4px 7px; }")
+                                           .arg(m_accentColor));
+    m_measurement_clear_btn->setStyleSheet("QToolButton { background: rgba(245, 245, 245, 220); "
+                                           "border: 1px solid rgba(0, 0, 0, 80); padding: 1px; }");
 }
 
 void PartWidget::setupLayouts() {
@@ -393,6 +437,7 @@ void PartWidget::setupPosition() {
     // Status
     m_selection_label->move(300, this->height() -
                                      (Constants::UI::PartControl::kSize.height() + 15 + m_selection_label->height()));
+    positionMeasurementReadout();
 
     // Projection Buttons
     QPoint new_size = QPoint(this->width(), this->height());
@@ -427,6 +472,9 @@ void PartWidget::setupEvents() {
     connect(m_toolbar, &PartToolbar::centerParts, m_part_view, &PartView::centerSelectedParts);
     connect(m_toolbar, &PartToolbar::dropPartsToFloor, m_part_view, &PartView::dropSelectedParts);
     connect(m_toolbar, &PartToolbar::setupAlignment, m_part_view, &PartView::setupAlignment);
+    connect(m_toolbar, &PartToolbar::measureModeChanged, m_part_view, &PartView::setMeasurementMode);
+    connect(m_part_view, &PartView::measurementReadoutChanged, this, &PartWidget::setMeasurementReadout);
+    connect(m_measurement_clear_btn, &QToolButton::pressed, m_part_view, &PartView::clearMeasurement);
 
     connect(this, &PartWidget::resized, m_toolbar, &PartToolbar::resize);
     connect(this, &PartWidget::resized, m_view_controls, &ViewControlsToolbar::resize);

--- a/src/widgets/part_widget/right_click_menu.cpp
+++ b/src/widgets/part_widget/right_click_menu.cpp
@@ -1,8 +1,15 @@
 #include "widgets/part_widget/right_click_menu.h"
 
+#include <algorithm>
+#include <cmath>
+
+#include <QDir>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QInputDialog>
 #include <QLabel>
+#include <QLocale>
+#include <QMessageBox>
 #include <QWidgetAction>
 #include <qaction.h>
 #include <qicon.h>
@@ -15,17 +22,123 @@
 #include <qslider.h>
 #include <qwidget.h>
 
+#include "managers/preferences_manager.h"
 #include "managers/session_manager.h"
+#include "utilities/constants.h"
 #include "utilities/enums.h"
 #include "widgets/part_widget/model/part_meta_item.h"
 
 namespace ORNL {
+namespace {
+QString meshTypeText(MeshType type) {
+    switch (type) {
+        case MeshType::kBuild:
+            return "Build";
+        case MeshType::kClipping:
+            return "Clipper";
+        case MeshType::kSettings:
+            return "Setting";
+        case MeshType::kSupport:
+            return "Support";
+    }
+
+    return "Unknown";
+}
+
+QString sourceFilePath(QSharedPointer<Part> part) {
+    if (part.isNull())
+        return QString();
+
+    if (!part->sourceFilePath().isEmpty())
+        return part->sourceFilePath();
+
+    if (!part->rootMesh().isNull())
+        return part->rootMesh()->path();
+
+    return QString();
+}
+
+QString fileTypeText(const QString& path) {
+    if (path.isEmpty())
+        return "Generated";
+
+    const QString suffix = QFileInfo(path).suffix().toUpper();
+    return suffix.isEmpty() ? "Unknown" : suffix;
+}
+
+int triangleCount(QSharedPointer<Part> part) {
+    if (part.isNull())
+        return 0;
+
+    int count = 0;
+    for (auto mesh : part->meshes()) {
+        if (mesh.isNull())
+            continue;
+
+        count += mesh->originalFaces().size();
+    }
+
+    return count;
+}
+
+bool originalMeshDimensions(QSharedPointer<Part> part, Distance3D& dimensions) {
+    if (part.isNull())
+        return false;
+
+    bool found_vertex = false;
+    QVector3D minimum;
+    QVector3D maximum;
+
+    for (auto mesh : part->meshes()) {
+        if (mesh.isNull())
+            continue;
+
+        const QVector<MeshVertex> vertices = mesh->originalVertices();
+        for (const MeshVertex& vertex : vertices) {
+            if (!found_vertex) {
+                minimum = vertex.location;
+                maximum = vertex.location;
+                found_vertex = true;
+                continue;
+            }
+
+            minimum.setX(std::min(minimum.x(), vertex.location.x()));
+            minimum.setY(std::min(minimum.y(), vertex.location.y()));
+            minimum.setZ(std::min(minimum.z(), vertex.location.z()));
+            maximum.setX(std::max(maximum.x(), vertex.location.x()));
+            maximum.setY(std::max(maximum.y(), vertex.location.y()));
+            maximum.setZ(std::max(maximum.z(), vertex.location.z()));
+        }
+    }
+
+    if (!found_vertex)
+        return false;
+
+    dimensions = Distance3D(Distance(maximum.x() - minimum.x()), Distance(maximum.y() - minimum.y()),
+                            Distance(maximum.z() - minimum.z()));
+    return true;
+}
+
+QString formatDistance(double microns) {
+    const Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
+    return QString("%1 %2")
+        .arg(QString::number(Distance(microns).to(unit), 'f', 3),
+             PreferencesManager::getInstance()->getDistanceUnitText());
+}
+
+QString dimensionsText(double x_microns, double y_microns, double z_microns) {
+    return QString("X %1, Y %2, Z %3")
+        .arg(formatDistance(x_microns), formatDistance(y_microns), formatDistance(z_microns));
+}
+} // namespace
+
 RightClickMenu::RightClickMenu(QWidget* parent) : QMenu(("Context menu"), parent) {
     this->setupActions();
     this->setupEvents();
 }
 
 void RightClickMenu::setupActions() {
+    m_info_action = new QAction("Info", this);
     m_switch_to_build_action = new QAction("Switch to Build", this);
     m_switch_to_clipper_action = new QAction("Switch to Clipper", this);
     m_switch_to_setting_action = new QAction("Switch to Setting", this);
@@ -36,6 +149,7 @@ void RightClickMenu::setupActions() {
     m_lock_part_action = new QAction("Toggle Part Lock(s)", this);
     m_set_instances_action = new QAction("Set Number of Instances", this);
 
+    m_info_action->setIcon(QIcon(":/icons/info.png"));
     m_switch_to_clipper_action->setIcon(QIcon(":/icons/clip.png"));
     m_switch_to_build_action->setIcon(QIcon(":/icons/print_head.png"));
     m_switch_to_setting_action->setIcon(QIcon(":/icons/settings_black.png"));
@@ -46,6 +160,8 @@ void RightClickMenu::setupActions() {
     m_lock_part_action->setIcon(QIcon(":/icons/lock.png"));
     m_set_instances_action->setIcon(QIcon(":/icons/copy_black.png"));
 
+    this->addAction(m_info_action);
+    this->addSeparator();
     this->addAction(m_switch_to_build_action);
     this->addAction(m_switch_to_clipper_action);
     this->addAction(m_switch_to_setting_action);
@@ -87,6 +203,8 @@ void RightClickMenu::setupActions() {
 }
 
 void RightClickMenu::setupEvents() {
+    connect(m_info_action, &QAction::triggered, this, &RightClickMenu::showInfoDialog);
+
     connect(m_switch_to_clipper_action, &QAction::triggered, this, [this]() {
         m_switch_to_build_action->setDisabled(false);
         m_switch_to_setting_action->setDisabled(false);
@@ -190,6 +308,40 @@ void RightClickMenu::setupEvents() {
     });
 }
 
+void RightClickMenu::showInfoDialog() {
+    if (m_selected_items.size() != 1)
+        return;
+
+    QSharedPointer<PartMetaItem> item = m_selected_items.first();
+    if (item.isNull() || item->part().isNull() || item->graphicsPart().isNull())
+        return;
+
+    QSharedPointer<Part> part = item->part();
+    QSharedPointer<PartObject> graphics_part = item->graphicsPart();
+    const QString source_path = sourceFilePath(part);
+
+    const QVector3D current_dimensions = graphics_part->maximum() - graphics_part->minimum();
+    QStringList lines;
+    lines << QString("Name: %1").arg(part->name());
+    lines << QString("File type: %1").arg(fileTypeText(source_path));
+    lines << QString("Mesh role: %1").arg(meshTypeText(item->meshType()));
+    lines << QString("Triangles: %1").arg(QLocale().toString(triangleCount(part)));
+    lines << QString("Current dimensions: %1")
+                 .arg(dimensionsText(std::fabs(current_dimensions.x()) * Constants::OpenGL::kViewToObject,
+                                     std::fabs(current_dimensions.y()) * Constants::OpenGL::kViewToObject,
+                                     std::fabs(current_dimensions.z()) * Constants::OpenGL::kViewToObject));
+
+    Distance3D original_dimensions;
+    if (originalMeshDimensions(part, original_dimensions)) {
+        lines << QString("Original mesh dimensions: %1")
+                     .arg(dimensionsText(original_dimensions.x(), original_dimensions.y(), original_dimensions.z()));
+    }
+
+    lines << QString("Source: %1").arg(source_path.isEmpty() ? "Generated part" : QDir::toNativeSeparators(source_path));
+
+    QMessageBox::information(this, "Object Info", lines.join("\n"));
+}
+
 void RightClickMenu::show(const QPointF& pos, QList<QSharedPointer<PartMetaItem>> items) {
     m_selected_items = items;
     this->disableActions();
@@ -248,6 +400,7 @@ void RightClickMenu::disableActions() {
         m_transparency_menu->setDisabled(false);
         m_wireframe_action->setDisabled(false);
         m_solidwireframe_action->setDisabled(false);
+        m_info_action->setDisabled(m_selected_items.size() != 1);
 
         if (m_selected_items.size() == 1) {
             m_replace_part_action->setDisabled(false);
@@ -268,6 +421,7 @@ void RightClickMenu::disableActions() {
         m_reload_part_action->setDisabled(true);
         m_delete_part_action->setDisabled(true);
         m_set_instances_action->setDisabled(true);
+        m_info_action->setDisabled(true);
         m_transparency_menu->setDisabled(true);
         m_wireframe_action->setDisabled(true);
         m_solidwireframe_action->setDisabled(true);

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -914,6 +914,7 @@ void MainWindow::setupEvents() {
 
     // Connect slice button
     connect(m_part_widget, &PartWidget::slice, this, &MainWindow::doSlice);
+    connect(m_part_widget->view(), &PartView::measurementCompleted, this, &MainWindow::updateStatus);
     // connect(m_part_widget->m_slice_btn, &QToolButton::clicked, this, &MainWindow::doSlice);
 
     // Session connections.


### PR DESCRIPTION
## Summary

Adds object measurement support to the object view and fills out the object info workflow requested in issue #237.

## What changed

- Added a toolbar measurement mode with a monochrome icon that matches the existing part toolbar style.
- Added click-to-measure behavior in the 3D object view: first click starts, mouse movement previews, second click commits a persistent annotation.
- Added explicit clear paths for measurements: Esc, disabling measurement mode, starting a new measurement, or the clear button beside the readout.
- Added a compact measurement readout beside the toolbar and logs completed measurements to the bottom-right Status console.
- Added right-click object Info with file type, mesh role, triangle count, current dimensions, original mesh dimensions, and source path.
- Fixed original mesh dimension reporting for open meshes/imported meshes so Info does not show 0 x 0 x 0 when original vertices have valid bounds.

## Why

Issue #237 requested object dimensions/measurements, including an Info window and a way to measure two picked locations on an object. The follow-up UX changes make the measurement result persistent instead of disappearing as the mouse moves.

## Impact

Users can inspect object metadata from the right-click menu and measure surface-to-surface distances directly in Object View using their configured distance units.

## Validation

- `cmake --build build/generic-llvm-ninja --config Debug -j2`
- `ctest --test-dir build/generic-llvm-ninja -C Debug --output-on-failure`

All 6 tests passed.